### PR TITLE
Fix logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(${PROJECT_NAME}_MINOR_VERSION 09)
 set(${PROJECT_NAME}_PATCH_VERSION 00)
 include(cmake/set_version_numbers.cmake)
 
+option(BUILD_TESTS "Build also tests." ON)
+
 # Find the ControlSystemAdapter
 add_dependency(ChimeraTK-ControlSystemAdapter 01.05 REQUIRED)
 
@@ -29,13 +31,15 @@ include_directories(SYSTEM ${glib_INCLUDE_DIRS} ${LibXML++_INCLUDE_DIRS})
 
 # optional dependency: BOOST unit test framework needed for tests
 FIND_PACKAGE(Boost COMPONENTS unit_test_framework)
-IF(Boost_UNIT_TEST_FRAMEWORK_FOUND)
-  set(TESTING_IS_ENABLED "true")
-  ENABLE_TESTING()
-ELSE()
-  message(" The following packages were not found, so testing will be disabled:")
-  message("  * BOOST unit_test_framework")
-ENDIF()
+IF(BUILD_TESTS)
+  IF(Boost_UNIT_TEST_FRAMEWORK_FOUND)
+    set(TESTING_IS_ENABLED "true")
+    ENABLE_TESTING()
+  ELSE()
+    message(" The following packages were not found, so testing will be disabled:")
+    message("  * BOOST unit_test_framework")
+  ENDIF()
+ENDIF(BUILD_TESTS)
 
 # Find BOOST filesystem
 # Note: we need to search this after looking for the unit_test_framework, since we must not link against the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,12 +50,14 @@ FIND_PACKAGE(Boost COMPONENTS filesystem date_time chrono system thread REQUIRED
 # requierd dependency: HDF5 library needed for the MicroDAQ system (TODO make optional!)
 option(BUILD_MICRODAQ "Build the MicroDAQ module, which depends on HDF5 (libhdf5-dev)." ON)
 if(BUILD_MICRODAQ)
-  FIND_PACKAGE(HDF5 COMPONENTS CXX REQUIRED)
-  include_directories(SYSTEM ${HDF5_INCLUDE_DIRS})
-  link_directories(${HDF5_LIBRARY_DIRS})
-  # add flag to be used in user code to test weather MicroDAQ is included
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_MICRO_DAQ")
-  IF(HDF5-NOTFOUND)
+  FIND_PACKAGE(HDF5 COMPONENTS CXX)
+  IF(HDF5_FOUND)
+    include_directories(SYSTEM ${HDF5_INCLUDE_DIRS})
+    link_directories(${HDF5_LIBRARY_DIRS})
+    # add flag to be used in user code to test weather MicroDAQ is included
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_MICRO_DAQ")
+  ELSE()
+    set(HDF5_LIBRARIES "")
     message(" HDF5 was not found, so the MicroDAQ system will not be built.")
   ENDIF()
 endif(BUILD_MICRODAQ)
@@ -74,10 +76,10 @@ aux_source_directory(${CMAKE_SOURCE_DIR}/src library_sources)
 include_directories(${CMAKE_SOURCE_DIR}/Modules/include)
 aux_source_directory(${CMAKE_SOURCE_DIR}/Modules/src library_sources)
 
-if((NOT BUILD_MICRODAQ) OR (HDF5-NOTFOUND))
+if((NOT BUILD_MICRODAQ) OR (NOT HDF5_FOUND))
   LIST(REMOVE_ITEM library_sources ${CMAKE_SOURCE_DIR}/Modules/include/MicroDAQ.h)
   LIST(REMOVE_ITEM library_sources ${CMAKE_SOURCE_DIR}/Modules/src/MicroDAQ.cc)
-endif((NOT BUILD_MICRODAQ) OR (HDF5-NOTFOUND))
+endif((NOT BUILD_MICRODAQ) OR (NOT HDF5_FOUND))
 
 MACRO( COPY_MAPPING_FILES )
   foreach( FILE_TO_COPY test.xlmap test.dmap )
@@ -137,7 +139,7 @@ install( TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin LIBRARY DESTINATION lib
 # all include files go into include/PROJECT_NAME
 # The exclusion of ${PROJECT_NAME} prevents the recursive installation of the files just being installed.
 # The original headers are in include/*.h, the installed ones in include/PROJECT_NAME/*.h.
-if((NOT BUILD_MICRODAQ) OR (HDF5-NOTFOUND))
+if((NOT BUILD_MICRODAQ) OR (NOT HDF5_FOUND))
   install(DIRECTORY ${${PROJECT_NAME}_INCLUDE_DIRS} DESTINATION include/ChimeraTK/ApplicationCore
                                                     FILES_MATCHING PATTERN "*.h"
                                                                    PATTERN ".svn" EXCLUDE
@@ -149,7 +151,7 @@ else()
                                                     FILES_MATCHING PATTERN "*.h"
                                                                    PATTERN ".svn" EXCLUDE
                                                                    PATTERN "${PROJECT_NAME}" EXCLUDE)
-endif((NOT BUILD_MICRODAQ) OR (HDF5-NOTFOUND))
+endif((NOT BUILD_MICRODAQ) OR (NOT HDF5_FOUND))
 
 set(${PROJECT_NAME}_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
 set(${PROJECT_NAME}_LIBRARIES "${ChimeraTK-ControlSystemAdapter_LIBRARIES} ${HDF5_LIBRARIES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ set(${PROJECT_NAME}_MINOR_VERSION 09)
 set(${PROJECT_NAME}_PATCH_VERSION 00)
 include(cmake/set_version_numbers.cmake)
 
-option(BUILD_TESTS "Build also tests." ON)
+option(BUILD_TESTS "Build tests." ON)
+option(BUILD_MICRODAQ "Build MicroDAQ module, which depends on HDF5 (libhdf5-dev)." ON)
 
 # Find the ControlSystemAdapter
 add_dependency(ChimeraTK-ControlSystemAdapter 01.05 REQUIRED)
@@ -47,15 +48,17 @@ ENDIF(BUILD_TESTS)
 FIND_PACKAGE(Boost COMPONENTS filesystem date_time chrono system thread REQUIRED)
 
 # requierd dependency: HDF5 library needed for the MicroDAQ system (TODO make optional!)
-FIND_PACKAGE(HDF5 COMPONENTS CXX REQUIRED)
-include_directories(SYSTEM ${HDF5_INCLUDE_DIRS})
-link_directories(${HDF5_LIBRARY_DIRS})
-IF(HDF5_FOUND)
+option(BUILD_MICRODAQ "Build the MicroDAQ module, which depends on HDF5 (libhdf5-dev)." ON)
+if(BUILD_MICRODAQ)
+  FIND_PACKAGE(HDF5 COMPONENTS CXX REQUIRED)
+  include_directories(SYSTEM ${HDF5_INCLUDE_DIRS})
+  link_directories(${HDF5_LIBRARY_DIRS})
+  # add flag to be used in user code to test weather MicroDAQ is included
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_MICRO_DAQ")
-ELSE()
-  message(" HDF5 was not found, so the MicroDAQ system will not be built.")
-  set(HDF5_LIBRARIES "")
-ENDIF()
+  IF(HDF5-NOTFOUND)
+    message(" HDF5 was not found, so the MicroDAQ system will not be built.")
+  ENDIF()
+endif(BUILD_MICRODAQ)
 
 include(cmake/set_default_build_to_release.cmake)
 include(cmake/set_default_flags.cmake)
@@ -70,6 +73,11 @@ aux_source_directory(${CMAKE_SOURCE_DIR}/src library_sources)
 # add generic modules
 include_directories(${CMAKE_SOURCE_DIR}/Modules/include)
 aux_source_directory(${CMAKE_SOURCE_DIR}/Modules/src library_sources)
+
+if((NOT BUILD_MICRODAQ) OR (HDF5-NOTFOUND))
+  LIST(REMOVE_ITEM library_sources ${CMAKE_SOURCE_DIR}/Modules/include/MicroDAQ.h)
+  LIST(REMOVE_ITEM library_sources ${CMAKE_SOURCE_DIR}/Modules/src/MicroDAQ.cc)
+endif((NOT BUILD_MICRODAQ) OR (HDF5-NOTFOUND))
 
 MACRO( COPY_MAPPING_FILES )
   foreach( FILE_TO_COPY test.xlmap test.dmap )
@@ -129,10 +137,19 @@ install( TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin LIBRARY DESTINATION lib
 # all include files go into include/PROJECT_NAME
 # The exclusion of ${PROJECT_NAME} prevents the recursive installation of the files just being installed.
 # The original headers are in include/*.h, the installed ones in include/PROJECT_NAME/*.h.
-install(DIRECTORY ${${PROJECT_NAME}_INCLUDE_DIRS} DESTINATION include/ChimeraTK/ApplicationCore
-                                                  FILES_MATCHING PATTERN "*.h"
-                                                                 PATTERN ".svn"
-                                                  EXCLUDE PATTERN "${PROJECT_NAME}" EXCLUDE)
+if((NOT BUILD_MICRODAQ) OR (HDF5-NOTFOUND))
+  install(DIRECTORY ${${PROJECT_NAME}_INCLUDE_DIRS} DESTINATION include/ChimeraTK/ApplicationCore
+                                                    FILES_MATCHING PATTERN "*.h"
+                                                                   PATTERN ".svn" EXCLUDE
+                                                                   PATTERN "${PROJECT_NAME}" EXCLUDE
+                                                                   PATTERN "*MicroDAQ.h" EXCLUDE
+                                                    )
+else()
+  install(DIRECTORY ${${PROJECT_NAME}_INCLUDE_DIRS} DESTINATION include/ChimeraTK/ApplicationCore
+                                                    FILES_MATCHING PATTERN "*.h"
+                                                                   PATTERN ".svn" EXCLUDE
+                                                                   PATTERN "${PROJECT_NAME}" EXCLUDE)
+endif((NOT BUILD_MICRODAQ) OR (HDF5-NOTFOUND))
 
 set(${PROJECT_NAME}_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
 set(${PROJECT_NAME}_LIBRARIES "${ChimeraTK-ControlSystemAdapter_LIBRARIES} ${HDF5_LIBRARIES}")

--- a/Modules/include/Logging.h
+++ b/Modules/include/Logging.h
@@ -139,7 +139,7 @@ namespace logging {
    */
   class Logger {
    private:
-    std::queue<std::pair<std::string, logging::LogLevel>> msg_buffer;
+    std::queue<std::string> msg_buffer;
 
    public:
     /**
@@ -161,9 +161,6 @@ namespace logging {
     Logger(ctk::Module* module);
     /** Message to be send to the logging module */
     ctk::ScalarOutput<std::string> message;
-
-    /** Message to be send to the logging module */
-    ctk::ScalarOutput<uint> messageLevel;
 
     /**
      * \brief Send a message, which means to update the message and messageLevel
@@ -193,14 +190,14 @@ namespace logging {
    */
   class LoggingModule : public ctk::ApplicationModule {
    private:
-    std::pair<ctk::VariableNetworkNode, ctk::VariableNetworkNode> getAccessorPair(const std::string& sender);
+    ctk::VariableNetworkNode getAccessorPair(const std::string& sender);
 
     /** Map key is the feeding module */
-    std::map<std::string, Message> msg_list;
+    std::map<std::string, ctk::ScalarPushInput<std::string> > msg_list;
 
     /** Find the Message that was updated.
      */
-    std::map<std::string, Message>::iterator FindSender(const ChimeraTK::TransferElementID& id);
+    std::map<std::string, ctk::ScalarPushInput<std::string> >::iterator FindSender(const ChimeraTK::TransferElementID& id);
 
     /** Number of messages stored in the tail */
     size_t messageCounter;

--- a/Modules/include/Logging.h
+++ b/Modules/include/Logging.h
@@ -216,12 +216,12 @@ namespace logging {
       "(cout/cerr), 3 (none)",
       {"CS", getName()}};
 
-    ctk::ScalarPollInput<std::string> logFile{this, "Logfile", "",
+    ctk::ScalarPollInput<std::string> logFile{this, "logFile", "",
       "Name of the external logfile. If empty messages are pushed to "
       "cout/cerr",
       {"CS", getName()}};
 
-    ctk::ScalarPollInput<uint> tailLength{this, "maxLength", "",
+    ctk::ScalarPollInput<uint> tailLength{this, "maxTailLength", "",
       "Maximum number of messages to be shown in the logging stream tail.",
       {"CS", getName()}};
 
@@ -229,7 +229,7 @@ namespace logging {
       "Current log level used for messages.",
       {"CS", getName()}};
 
-    ctk::ScalarOutput<std::string> logTail{this, "LogTail", "",
+    ctk::ScalarOutput<std::string> logTail{this, "logTail", "",
       "Tail of the logging stream.",
       {"CS", "PROCESS", getName()}};
 

--- a/Modules/include/Logging.h
+++ b/Modules/include/Logging.h
@@ -206,7 +206,7 @@ namespace logging {
      * \param msg The mesage
      * \param isError If true cerr is used. Else cout is used.
      */
-    void broadcastMessage(std::string msg, bool isError = false);
+    void broadcastMessage(std::string msg, const bool &isError = false);
 
    public:
     using ctk::ApplicationModule::ApplicationModule;
@@ -236,7 +236,7 @@ namespace logging {
     std::unique_ptr<std::ofstream> file; ///< Log file where to write log messages
 
     /** Add a Module as a source to this DAQ. */
-    void addSource(Logger* logger);
+    void addSource(boost::shared_ptr<Logger> logger);
 
     /**
      * Application core main loop.

--- a/Modules/include/Logging.h
+++ b/Modules/include/Logging.h
@@ -23,7 +23,7 @@
  *   level. The Logging module compares both levels and decides if a message is
  dropped (e.g. message level is
  *   DEBUG and Module level is ERROR) or broadcasted.
- * - tailLength: The number of messages published by the Logging module (see
+ * - maxTailLength: The number of messages published by the Logging module (see
  logTail), i.e. to the control system.
  *   This length has no influence on the targetStreams, that receive all
  messages (depending on the logLevel). The
@@ -72,10 +72,7 @@
  *
  *
  *  void myAPP::defineConnctions(){
- *  cs["Logging"]("targetStream") >> log.targetStream;
- *  cs["Logging"]("logLevel") >> log.logLevel;
- *  cs["Logging"]("logFile") >> log.logFile;
- *  cs["Logging"]("tailLength") >> log.tailLength;
+ *  log.findTag("CS").connectTo(cs);
  *  log.addSource(&TestModule.logger)
  *  ...
  *  }
@@ -88,7 +85,7 @@
  *
  *  A message always looks like this:
  *  LogLevel::LoggingModuleName/SendingModuleName TimeString -> message\n
- *  In the example given above the meassge could look like:
+ *  In the example given above the message could look like:
  *  \code
  *  DEBUG::LogggingModule/test 2018-Apr-12 14:03:07.947949 -> Test
  *  \endcode

--- a/Modules/src/Logging.cc
+++ b/Modules/src/Logging.cc
@@ -62,7 +62,7 @@ void Logger::sendMessage(const std::string& msg, const logging::LogLevel& level)
   }
 }
 
-void LoggingModule::broadcastMessage(std::string msg, bool isError) {
+void LoggingModule::broadcastMessage(std::string msg, const bool &isError) {
   if(msg.back() != '\n') {
     msg.append("\n");
   }
@@ -144,7 +144,7 @@ void LoggingModule::mainLoop() {
   }
 }
 
-void LoggingModule::addSource(Logger* logger) {
+void LoggingModule::addSource(boost::shared_ptr<Logger> logger) {
   auto acc = getAccessorPair(logger->message.getOwner()->getName());
   logger->message >> acc;
 }


### PR DESCRIPTION
Fix:
- problem in the logging module, which lead to a wrong message level being assigned to a message 

Feature:
- add option to disable building tests to CMake
- add option to disable building MicroDAQ to CMake (see #62)