### PR TITLE
CircularDependencyDetector: Avoid deadlock in registerDependencyWait

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -1328,6 +1328,12 @@ void Application::CircularDependencyDetector::registerDependencyWait(VariableNet
 
       throw ChimeraTK::logic_error("Cirular dependency of ApplicationModules while waiting for initial values");
     }
+    else{
+      // Give other threads a chance to add to the wait map
+      lock.unlock();
+      usleep(10000);
+      lock.lock();
+    }
   }
 }
 


### PR DESCRIPTION
If a circular dependency was checked and the dependent module was not
yet in the waitMap, the lock was never released.