### PR TITLE
Logger: Fix missing initial value; add automatic registration with the LoggingModule.

### DIFF
--- a/Modules/include/Logging.h
+++ b/Modules/include/Logging.h
@@ -49,14 +49,19 @@
  *  The foreseen way of using the Logger is to add a Logger to a module that
  should send log messages.
  *
- *  The LoggingModule will take care of finding all Loggers used in the Application.
+ *  The LoggingModule will take care of finding all Loggers.
  *  Therefore, the LoggingModule needs to be constructed last - after all ApplicationModules
- *  using a Logger are constructed.
+ *  using a Logger are constructed. It will look in its owner for all accessors with tags that match the
+ *  tags given to the LoggingModule. Like that one can use tags in the Logger to assign senders for the LoggingModule
+ *  and in addition the LoggingModule can be placed inside a ModuleGroup to consider only accessors in that
+ *  group when setting up the connections.
+ *
  *  The following example shows how to integrate the Logging module and the
  Logging into an application (myApp) and one module sending
  *  messages (TestModule).
  *  \code
  *  sruct TestModule: public ChimeraTK::ApplicationModule{
+ *  // use default tag of the Logger -> "Logging"
  *  boost::shared_ptr<Logger> logger{new Logger(this)};
  *  ...
  *  };
@@ -68,6 +73,7 @@
  *  TestModule { this, "test", "" };
  *
  *  // needs to be added after all modules that use a Logger!
+ *  // Default tag of the LoggingModule is used -> "Logging"
  *  LoggingModule log { this, "LoggingModule", "LoggingModule test" };
  *  ...
  *  };
@@ -155,8 +161,9 @@ namespace logging {
      *
      * \param module The owning module that is using the Logger. It will appear as
      * sender in the LoggingModule, which is receiving messages from the Logger.
+     * \param tag A tag that is used to identify the Logger by the LoggingModule.
      */
-    Logger(ctk::Module* module);
+    Logger(ctk::Module* module, const std::string &tag = "Logging");
     /** Message to be send to the logging module */
     ctk::ScalarOutput<std::string> message;
 
@@ -175,7 +182,7 @@ namespace logging {
    *
    * A ChimeraTK module is producing messages, that are send to the LoggingModule
    * via the \c message variable. The message is then put into the logfile ring
-   * buffer and published in the \c LogFileTail. In addidtion the message can be
+   * buffer and published in the \c LogFileTail. In addition the message can be
    * put to an ostream. Available streams are:
    * - file stream
    * - cout/cerr
@@ -220,7 +227,7 @@ namespace logging {
    public:
     LoggingModule(ctk::EntityOwner* owner, const std::string& name, const std::string& description,
           ctk::HierarchyModifier hierarchyModifier = ctk::HierarchyModifier::none,
-          const std::unordered_set<std::string>& tags = {});
+          const std::unordered_set<std::string>& tags = {"Logging"});
 
     LoggingModule(){}
 

--- a/Modules/src/Logging.cc
+++ b/Modules/src/Logging.cc
@@ -44,7 +44,7 @@ std::string logging::getTime() {
 }
 
 Logger::Logger(ctk::Module* module)
-: message(module, "message", "", "Message of the module to the logging System", {"Logging", module->getName()}) {}
+: VariableGroup(module,"Logging" , "VariableGroup added by the Logger"), message(module, "message", "", "Message of the module to the logging System", {"Logging", module->getName()}) {}
 
 void Logger::sendMessage(const std::string& msg, const logging::LogLevel& level) {
   if(message.isInitialised()) {
@@ -61,6 +61,24 @@ void Logger::sendMessage(const std::string& msg, const logging::LogLevel& level)
   else {
     // only use the buffer until ctk initialized the process variables
     msg_buffer.push(std::to_string(level) + msg + "\n");
+  }
+}
+
+void Logger::prepare(){
+  // write initial value in order to bring LoggingModule to mainLoop()
+  message.write();
+}
+
+LoggingModule::LoggingModule(ctk::EntityOwner* owner, const std::string& name, const std::string& description,
+      ctk::HierarchyModifier hierarchyModifier,
+      const std::unordered_set<std::string>& tags):
+        ApplicationModule(owner, name, description, hierarchyModifier, tags){
+  auto virtualLogging = getOwner()->findTag("Logging");
+  auto list = virtualLogging.getAccessorListRecursive();
+  for (auto it = list.begin(); it != list.end(); ++it){
+    std::cout << "Registered module " << it->getOwningModule()->getName() << " for logging." << std::endl;
+    auto acc = getAccessorPair(it->getOwningModule()->getName());
+    (*it) >> acc;
   }
 }
 
@@ -121,6 +139,7 @@ void LoggingModule::mainLoop() {
   LogLevel level;
 
   while(1) {
+    //we skip the initial value since it is empty anyway and set in Logger::prepare
     auto id = group.readAny();
     if(id_list.count(id) == 0) {
       throw ChimeraTK::logic_error("Cannot find  element id"

--- a/Modules/src/Logging.cc
+++ b/Modules/src/Logging.cc
@@ -75,6 +75,7 @@ LoggingModule::LoggingModule(ctk::EntityOwner* owner, const std::string& name, c
         ApplicationModule(owner, name, description, hierarchyModifier, tags){
   auto virtualLogging = getOwner()->findTag("Logging");
   auto list = virtualLogging.getAccessorListRecursive();
+  if(list.empty()) std::cerr << "LoggingModule did not find any module that uses a Logger." << std::endl;
   for (auto it = list.begin(); it != list.end(); ++it){
     std::cout << "Registered module " << it->getOwningModule()->getName() << " for logging." << std::endl;
     auto acc = getAccessorPair(it->getOwningModule()->getName());

--- a/Modules/src/Logging.cc
+++ b/Modules/src/Logging.cc
@@ -197,11 +197,6 @@ void LoggingModule::mainLoop() {
   }
 }
 
-void LoggingModule::addSource(boost::shared_ptr<Logger> logger) {
-  auto acc = getAccessorPair(logger->message.getOwner()->getName());
-  logger->message >> acc;
-}
-
 ctk::VariableNetworkNode LoggingModule::getAccessorPair(const std::string& sender) {
   auto it = std::find_if(sources.begin(), sources.end(), boost::bind(&MessageSource::sendingModule, _1) == sender);
   if(it == sources.end()) {


### PR DESCRIPTION
Now the Logger is a VariableGroup and in the prepare() method an empty
msg is written once. This makes sure the LoggingModule is not waiting
for initial values of Loggers and messages by other Loggers get lost.