### PR TITLE
optimization for StatusAggregator

### DIFF
--- a/Modules/include/StatusAggregator.h
+++ b/Modules/include/StatusAggregator.h
@@ -114,7 +114,7 @@ namespace ChimeraTK {
     /// Convert Status value into a priority (high integer value = high priority), depending on chosen PriorityMode
     /// Return value of -1 has the special meaning that the input Status's must be all equal, otherwise it must result
     /// in a warning Status.
-    int getPriority(StatusOutput::Status status);
+    int getPriority(StatusOutput::Status status) const;
   };
 
   /********************************************************************************************************************/

--- a/Modules/src/StatusAggregator.cc
+++ b/Modules/src/StatusAggregator.cc
@@ -116,7 +116,8 @@ namespace ChimeraTK {
   int StatusAggregator::getPriority(StatusOutput::Status status) {
     using Status = StatusOutput::Status;
 
-    const std::map<PriorityMode, std::map<Status, int32_t>> map_priorities{
+    // static helps against initializing over and over again
+    static const std::map<PriorityMode, std::map<Status, int32_t>> map_priorities{
         {PriorityMode::fwko, {{Status::OK, 1}, {Status::FAULT, 3}, {Status::OFF, 0}, {Status::WARNING, 2}}},
         {PriorityMode::fwok, {{Status::OK, 0}, {Status::FAULT, 3}, {Status::OFF, 1}, {Status::WARNING, 2}}},
         {PriorityMode::ofwk, {{Status::OK, 0}, {Status::FAULT, 2}, {Status::OFF, 3}, {Status::WARNING, 1}}},
@@ -134,14 +135,16 @@ namespace ChimeraTK {
       // find highest priority status of all inputs
       StatusOutput::Status status;
       bool statusSet = false; // flag whether status has been set from an input already
+      int statusPrio;         // stores getPriority(status)
       for(auto& input : _inputs) {
         auto prio = getPriority(input);
-        if(!statusSet || prio > getPriority(status)) {
+        if(!statusSet || prio > statusPrio) {
           status = input;
+          statusPrio = prio;
           statusSet = true;
         }
         else if(prio == -1) { //  -1 means, we need to warn about mixed values
-          if(getPriority(status) == -1 && input != status) {
+          if(statusPrio == -1 && input != status) {
             status = StatusOutput::Status::WARNING;
           }
         }

--- a/Modules/src/StatusAggregator.cc
+++ b/Modules/src/StatusAggregator.cc
@@ -113,7 +113,7 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
-  int StatusAggregator::getPriority(StatusOutput::Status status) {
+  int StatusAggregator::getPriority(StatusOutput::Status status) const {
     using Status = StatusOutput::Status;
 
     // static helps against initializing over and over again
@@ -135,7 +135,7 @@ namespace ChimeraTK {
       // find highest priority status of all inputs
       StatusOutput::Status status;
       bool statusSet = false; // flag whether status has been set from an input already
-      int statusPrio;         // stores getPriority(status)
+      int statusPrio = 0;     // stores getPriority(status)
       for(auto& input : _inputs) {
         auto prio = getPriority(input);
         if(!statusSet || prio > statusPrio) {

--- a/Modules/src/StatusAggregator.cc
+++ b/Modules/src/StatusAggregator.cc
@@ -134,8 +134,12 @@ namespace ChimeraTK {
     while(true) {
       // find highest priority status of all inputs
       StatusOutput::Status status;
-      bool statusSet = false; // flag whether status has been set from an input already
-      int statusPrio = 0;     // stores getPriority(status)
+      // flag whether status has been set from an input already
+      bool statusSet = false;
+      // this stores getPriority(status) if statusSet=true
+      // Intent is to reduce evaluation frequency of getPriority
+      // the initial value provided here is only to prevent compiler warnings
+      int statusPrio = 0;
       for(auto& input : _inputs) {
         auto prio = getPriority(input);
         if(!statusSet || prio > statusPrio) {
@@ -146,6 +150,7 @@ namespace ChimeraTK {
         else if(prio == -1) { //  -1 means, we need to warn about mixed values
           if(statusPrio == -1 && input != status) {
             status = StatusOutput::Status::WARNING;
+            statusPrio = getPriority(status);
           }
         }
       }


### PR DESCRIPTION
make getPriority faster by making prio map static and reduce evaluation frequency

with dcm_ctrl_server, Debug mode, CPU load caused by StatusAggregator was about 600 % and is reduced  to about 120% by this small optimization.