### PR TITLE
fix DeviceModule throws when using CDD containing slashes

### DIFF
--- a/src/DeviceModule.cc
+++ b/src/DeviceModule.cc
@@ -118,7 +118,10 @@ namespace ChimeraTK {
   VirtualModule& DeviceModule::virtualiseFromCatalog() const {
     if(virtualisedModuleFromCatalog_isValid) return virtualisedModuleFromCatalog;
 
-    virtualisedModuleFromCatalog = VirtualModule(deviceAliasOrURI, "Device module", ModuleType::Device);
+    auto moduleName = deviceAliasOrURI;
+    std::replace(moduleName.begin(), moduleName.end(), '/', '_'); // replace slashes with underscores
+
+    virtualisedModuleFromCatalog = VirtualModule(moduleName, "Device module", ModuleType::Device);
 
     if(!deviceIsInitialized) {
       device = Device(deviceAliasOrURI);


### PR DESCRIPTION
Slashes are not allowed in module names, but the DeviceModule crates a status module using the CDD (or alias) as a name. The slashes are now replaced by underscores.