### PR TITLE
make testable mode deadlock detection more robust

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -1328,10 +1328,17 @@ void Application::testableModeLock(const std::string& name) {
   if(getInstance().testableMode_repeatingMutexOwner > 0) usleep(10000);
 
   // obtain the lock
-  auto success = getTestableModeLockObject().try_lock_for(std::chrono::seconds(10));
+  auto lastSeen_lastOwner = getInstance().testableMode_lastMutexOwner;
+repeatTryLock:
+  auto success = getTestableModeLockObject().try_lock_for(std::chrono::seconds(30));
   if(!success) {
+    auto currentLastOwner = getInstance().testableMode_lastMutexOwner;
+    if(currentLastOwner != lastSeen_lastOwner) {
+      lastSeen_lastOwner = currentLastOwner;
+      goto repeatTryLock;
+    }
     std::cout << "Application::testableModeLock(): Thread " << threadName()                       // LCOV_EXCL_LINE
-              << " could not obtain lock for 10 seconds, presumably because "                     // LCOV_EXCL_LINE
+              << " could not obtain lock for 30 seconds, presumably because "                     // LCOV_EXCL_LINE
               << threadName(getInstance().testableMode_lastMutexOwner) << " does not release it." // LCOV_EXCL_LINE
               << std::endl;                                                                       // LCOV_EXCL_LINE
 


### PR DESCRIPTION
Sometimes several long running modules in a row might have caused false alarms. So seen in tests of the llrfctrl server with multiple devices (which require some time to open and initialise).