### PR TITLE
StatusAggregator debugging option

### DIFF
--- a/Modules/include/StatusAggregator.h
+++ b/Modules/include/StatusAggregator.h
@@ -115,6 +115,10 @@ namespace ChimeraTK {
     /// Return value of -1 has the special meaning that the input Status's must be all equal, otherwise it must result
     /// in a warning Status.
     int getPriority(StatusOutput::Status status) const;
+
+    /// Allow runtime debugging (FIXME: use Void instead!)
+    ModifyHierarchy<ScalarPushInput<int>> debug{
+        this, "/Debug/statusAggregators", "", "Print debug info for all status aggregators once."};
   };
 
   /********************************************************************************************************************/

--- a/Modules/src/StatusAggregator.cc
+++ b/Modules/src/StatusAggregator.cc
@@ -1,5 +1,6 @@
 #include "StatusAggregator.h"
 #include "ControlSystemModule.h"
+#include "ConfigReader.h"
 
 #include <list>
 #include <regex>
@@ -165,7 +166,21 @@ namespace ChimeraTK {
       }
 
       // wait for changed inputs
-      rag.readAny();
+    waitForChange:
+      auto change = rag.readAny();
+
+      // handle request for debug info
+      if(change == debug.value.getId()) {
+        static std::mutex debugMutex; // all aggregators trigger at the same time => lock for clean output
+        std::unique_lock<std::mutex> lk(debugMutex);
+
+        std::cout << "StatusAggregtor " << getQualifiedName() << " debug info:" << std::endl;
+        for(auto& input : _inputs) {
+          std::cout << input.getName() << " = " << input << std::endl;
+        }
+        std::cout << "debug info finished." << std::endl;
+        goto waitForChange;
+      }
     }
   }
 


### PR DESCRIPTION
This helps to understand why the aggregated status is how it is, e.g. when not all inputs are accessible through the control system, or when it is unclear which inputs the aggregator has.