### PR TITLE
do not recover registers with old VersionNumber (cf. #9961)

### DIFF
--- a/src/DeviceModule.cc
+++ b/src/DeviceModule.cc
@@ -357,7 +357,7 @@ namespace ChimeraTK {
         });
         for(auto& recoveryHelper : recoveryHelpers) {
           if(recoveryHelper->versionNumber != VersionNumber{nullptr}) {
-            recoveryHelper->accessor->write(recoveryHelper->versionNumber);
+            recoveryHelper->accessor->write();
             recoveryHelper->wasWritten = true;
           }
         }


### PR DESCRIPTION
This fixes together with another change in DeviceAccess the LNM
MathPlugin with push-type variables as parameters.