### PR TITLE
[project-template] add coding style checker

### DIFF
--- a/cmake/check-coding-style.sh
+++ b/cmake/check-coding-style.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+ERRFILE=`mktemp`
+export ERRFILE
+echo 0 > "${ERRFILE}"
+
+# check clang-format formatting
+if which clang-format-14 > /dev/null; then
+  find \( -name *.cc -o -name *.cpp -o -name *.h \) -exec clang-format-14 --output-replacements-xml \{\} \; | grep "^<replacement " > /dev/null
+  if [ $? -ne 1 ]; then
+    echo 1 > "${ERRFILE}"
+    echo "Code formatting incorrect!"
+  fi
+else
+  echo "WARNING: clang-format-14 not found, code formatting not checked!"
+fi
+
+# check copyright/licence file header comment
+checkCopyrightComment() {
+  SPDX_OK=1
+  if [[ "`head -n1 $1`" != '// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK'* ]]; then
+    SPDX_OK=0
+  fi
+  if [[ "`head -n2 $1 | tail -n1`" != '// SPDX-License-Identifier: '* ]]; then
+    SPDX_OK=0
+  fi
+  if [ $SPDX_OK -eq 0 ]; then
+    echo 1 > "${ERRFILE}"
+    echo "File $1 has no or an incorrect SPDX comment."
+  fi
+}
+export -f checkCopyrightComment
+find \( -name *.cc -o -name *.cpp -o -name *.h \) -exec bash -c 'checkCopyrightComment {}' \;
+
+# check all header files for "#pragma once" in 3rd line
+checkPramgaOnce() {
+  if [ "`head -n3 $1 | tail -n1`" != '#pragma once' ]; then
+    echo 1 > "${ERRFILE}"
+    echo "Header $1 has no pragma once in 3rd line!"
+  fi
+}
+export -f checkPramgaOnce
+find -name *.h -exec bash -c 'checkPramgaOnce {}' \;
+
+ERROR=`cat "${ERRFILE}"`
+rm -f "${ERRFILE}"
+
+exit ${ERROR}
+

--- a/cmake/enable_code_style_check.cmake
+++ b/cmake/enable_code_style_check.cmake
@@ -1,0 +1,22 @@
+#######################################################################################################################
+# enable_code_style_check.cmake
+#
+# Enable automatic check of coding style as part of the tests.
+#
+#######################################################################################################################
+
+#######################################################################################################################
+#
+# IMPORTANT NOTE:
+#
+# DO NOT MODIFY THIS FILE inside a project. Instead update the project-template repository and pull the change from
+# there. Make sure to keep the file generic, since it will be used by other projects, too.
+#
+# If you have modified this file inside a project despite this warning, make sure to cherry-pick all your changes
+# into the project-template repository immediately.
+#
+#######################################################################################################################
+
+enable_testing()
+add_test(NAME coding_style COMMAND ${CMAKE_SOURCE_DIR}/cmake/check-coding-style.sh
+                           WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Enable by adding
  include(cmake/enable_code_style_check.cmake)
to the project's CMakeLists.txt
