### PR TITLE
Wip improve logging

### DIFF
--- a/Modules/include/Logging.h
+++ b/Modules/include/Logging.h
@@ -122,8 +122,9 @@ namespace ctk = ChimeraTK;
 
 namespace logging {
 
-  /** Define available logging levels. */
-  enum LogLevel { DEBUG, INFO, WARNING, ERROR, SILENT };
+  /** Define available logging levels. INTERNAL is used to
+   * indicate an already published message  */
+  enum LogLevel { DEBUG, INFO, WARNING, ERROR, SILENT, INTERNAL };
 
   /** Define stream operator to use the LogLevel in streams, e.g. std::cout */
   std::ostream& operator<<(std::ostream& os, const logging::LogLevel& level);
@@ -164,12 +165,15 @@ namespace logging {
      *
      * \param module The owning module that is using the Logger. It will appear as
      * sender in the LoggingModule, which is receiving messages from the Logger.
+     * \param name Name used to initialise the VariableGroup.
+     * \param description Description used to initialise the VariableGroup.
      * \param tag A tag that is used to identify the Logger by the LoggingModule.
      */
-    Logger(ctk::Module* module, const std::string& tag = "Logging");
+    Logger(ctk::Module* module, const std::string &name = "Logging",
+        const std::string &description = "VariableGroup added by the Logger",
+        const std::string& tag = "Logging");
     /** Message to be send to the logging module */
     ctk::ScalarOutput<std::string> message;
-    ctk::ScalarOutput<std::string> alias;
 
     /**
      * \brief Send a message, which means to update the message and messageLevel
@@ -177,12 +181,6 @@ namespace logging {
      *
      */
     void sendMessage(const std::string& msg, const logging::LogLevel& level);
-
-    /**
-     * \brief If an alias is set it will be used in messages instaed of the register
-     * path of the owning module.
-     */
-    void setAlias(const std::string& alias);
 
     void prepare() override;
   };

--- a/Modules/include/Logging.h
+++ b/Modules/include/Logging.h
@@ -110,10 +110,13 @@
 #ifndef MODULES_LOGGING_H_
 #define MODULES_LOGGING_H_
 
-#include "ApplicationCore.h"
 #include <fstream>
 #include <map>
 #include <queue>
+
+#include <ChimeraTK/RegisterPath.h>
+
+#include "ApplicationCore.h"
 
 namespace ctk = ChimeraTK;
 
@@ -201,13 +204,13 @@ namespace logging {
    */
   class LoggingModule : public ctk::ApplicationModule {
    private:
-    ctk::VariableNetworkNode getAccessorPair(const std::string& sender);
+    ctk::VariableNetworkNode getAccessorPair(const std::string& sender, const std::string& name);
 
     struct MessageSource {
       ctk::ScalarPushInput<std::string> msg;
       std::string sendingModule;
-      MessageSource(const std::string& moduleName, Module* module)
-      : msg{module, moduleName + "Msg", "", ""}, sendingModule(moduleName) {}
+      MessageSource(const ChimeraTK::RegisterPath& path, Module* module, const size_t& id)
+      : msg{module, "message_" + std::to_string(id), "", "", {"***logging_internal***"}}, sendingModule(path) {}
     };
     /** List of senders. */
     std::vector<MessageSource> sources;

--- a/Modules/include/Logging.h
+++ b/Modules/include/Logging.h
@@ -110,13 +110,13 @@
 #ifndef MODULES_LOGGING_H_
 #define MODULES_LOGGING_H_
 
-#include <fstream>
-#include <map>
-#include <queue>
+#include "ApplicationCore.h"
 
 #include <ChimeraTK/RegisterPath.h>
 
-#include "ApplicationCore.h"
+#include <fstream>
+#include <map>
+#include <queue>
 
 namespace ctk = ChimeraTK;
 
@@ -169,9 +169,8 @@ namespace logging {
      * \param description Description used to initialise the VariableGroup.
      * \param tag A tag that is used to identify the Logger by the LoggingModule.
      */
-    Logger(ctk::Module* module, const std::string &name = "Logging",
-        const std::string &description = "VariableGroup added by the Logger",
-        const std::string& tag = "Logging");
+    Logger(ctk::Module* module, const std::string& name = "Logging",
+        const std::string& description = "VariableGroup added by the Logger", const std::string& tag = "Logging");
     /** Message to be send to the logging module */
     ctk::ScalarOutput<std::string> message;
 

--- a/Modules/include/Logging.h
+++ b/Modules/include/Logging.h
@@ -252,6 +252,8 @@ namespace logging {
 
     std::unique_ptr<std::ofstream> file; ///< Log file where to write log messages
 
+    size_t getNumberOfModules() { return sources.size(); }
+
     void prepare() override;
 
     /**

--- a/Modules/src/Logging.cc
+++ b/Modules/src/Logging.cc
@@ -5,14 +5,15 @@
  *      Author: zenker
  */
 
+#include "Logging.h"
+
+#include "boost/date_time/posix_time/posix_time.hpp"
+
 #include <fstream>
 #include <ostream>
 #include <sstream>
 #include <string>
 #include <vector>
-
-#include "Logging.h"
-#include "boost/date_time/posix_time/posix_time.hpp"
 
 using namespace logging;
 
@@ -43,11 +44,12 @@ std::string logging::getTime() {
   return str;
 }
 
-Logger::Logger(ctk::Module* module, const std::string &name, const std::string &description, const std::string& tag)
+Logger::Logger(ctk::Module* module, const std::string& name, const std::string& description, const std::string& tag)
 : VariableGroup(module, name, description),
-  message(this, "message", "", "Message of the module to the logging System. The leading number indicates the log level "
+  message(this, "message", "",
+      "Message of the module to the logging System. The leading number indicates the log level "
       "(0: DEBUG, 1: INFO, 2: WARNING, 3: ERROR, 4;SILENT). A leading 5 is used internally for old messages.",
-      {tag, module->getName(), "***logging_internal***"}){}
+      {tag, module->getName(), "***logging_internal***"}) {}
 
 void Logger::sendMessage(const std::string& msg, const logging::LogLevel& level) {
   if(message.isInitialised()) {
@@ -184,7 +186,7 @@ void LoggingModule::mainLoop() {
   LogLevel level;
 
   while(1) {
-    //we skip the initial value since it is empty anyway and set in Logger::prepare
+    // we skip the initial value since it is empty anyway and set in Logger::prepare
     auto id = group.readAny();
     if(id_list.count(id) == 0) {
       throw ChimeraTK::logic_error("Cannot find  element id"
@@ -206,7 +208,7 @@ void LoggingModule::mainLoop() {
                                    "when updating logging variables.");
     }
     // if log level is INTERANEL someone called writeAll() in a module containing the Logger -> ignore
-    if(level == LogLevel::INTERNAL){
+    if(level == LogLevel::INTERNAL) {
       continue;
     }
     if(targetStream == 4) continue;

--- a/Modules/src/Logging.cc
+++ b/Modules/src/Logging.cc
@@ -79,9 +79,15 @@ LoggingModule::LoggingModule(ctk::EntityOwner* owner, const std::string& name, c
     for(auto it = list.begin(); it != list.end(); ++it) {
       // do not add the module itself
       if(it->getOwningModule() == this) continue;
-      std::cout << "Registered module " << it->getOwningModule()->getName() << " for logging." << std::endl;
-      auto acc = getAccessorPair(it->getOwningModule()->getName());
-      (*it) >> acc;
+      try {
+        auto acc = getAccessorPair(it->getOwningModule()->getName());
+        (*it) >> acc;
+        std::cout << "Registered module " << it->getOwningModule()->getName() << " for logging." << std::endl;
+      }
+      catch(ChimeraTK::logic_error& e) {
+        std::cerr << "Failed to add logging module: " << it->getOwningModule()->getName() << " Error: " << e.what()
+                  << std::endl;
+      }
     }
   }
   if(sources.empty()) std::cerr << "LoggingModule did not find any module that uses a Logger." << std::endl;

--- a/Modules/src/Logging.cc
+++ b/Modules/src/Logging.cc
@@ -45,9 +45,9 @@ std::string logging::getTime() {
 
 Logger::Logger(ctk::Module* module, const std::string& tag)
 : VariableGroup(module, "Logging", "VariableGroup added by the Logger"),
-  message(module, "message", "", "Message of the module to the logging System",
+  message(this, "message", "", "Message of the module to the logging System",
       {tag, module->getName(), "***logging_internal***"}),
-  alias(module, "alias", "", "Alias used to identify messages. If not empty the owning module register path is used.",
+  alias(this, "alias", "", "Alias used to identify messages. If not empty the owning module register path is used.",
       {module->getName(), "***logging_internal***"}) {}
 
 void Logger::sendMessage(const std::string& msg, const logging::LogLevel& level) {

--- a/tests/executables_src/testLogging.cc
+++ b/tests/executables_src/testLogging.cc
@@ -134,7 +134,10 @@ BOOST_AUTO_TEST_CASE(testAlias) {
   tf.stepApplication();
   std::string ss = tf.readScalar<std::string>("/LoggingModule/logTail");
   BOOST_CHECK_EQUAL(ss.substr(ss.find("LoggingModule:") + 14, 6), std::string("/Dummy"));
-  app.dummy.logger->setAlias("NewName");
+//  app.dummy.logger->setAlias("NewName");
+  auto alias = tf.getScalar<std::string>("/Dummy/Logging/alias");
+  alias = "NewName";
+  alias.write();
   app.dummy.logger->sendMessage("TestMessage", LogLevel::DEBUG);
   tf.stepApplication();
   ss = tf.readScalar<std::string>("/LoggingModule/logTail");


### PR DESCRIPTION
The changes allow to add Loggers in Modules having the same name, which was not possible before. Now the hierarchy is build in the LoggingModule to avoid clashes. 
Connecting the PVs from the LoggingModule to the PVs added by the Logger does not work automatically. 
This needs to be fixed once the tools are available in ChimeraTK. 
A version that implements the automatic connecting version is prepared can be found in the branch wip_improve_logging. 

For now PVs from the LoggingModule are not added to the CS by an findTagAndAppendToModule overload. This is not needed once they are moved to the PVs added by the Logger in the Hierarchy.
