### PR TITLE
fix: VersionInfoProvider de-registration at destruct

### DIFF
--- a/Modules/include/VersionInfoProvider.h
+++ b/Modules/include/VersionInfoProvider.h
@@ -24,6 +24,8 @@ namespace ChimeraTK {
    public:
     explicit VersionInfoProvider(Application* owner);
 
+    ~VersionInfoProvider() override { dynamic_cast<Application*>(getOwner())->setVersionInfoProvider(nullptr); };
+
    private:
     int configPatch{appConfig().get<int>("Application/configPatchVersion")};
 

--- a/Modules/src/StatusWithMessage.cc
+++ b/Modules/src/StatusWithMessage.cc
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
 #include "StatusWithMessage.h"
 
 namespace ChimeraTK {

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -455,13 +455,17 @@ namespace ChimeraTK::Model {
           assert(ownershipDeleted);
 
           // remove pv access edge
+#ifndef NDEBUG
           bool pvAccessDeleted{false};
+#endif
           if(node.getDirection().dir == VariableDirection::consuming) {
             for(const auto& edge :
                 boost::make_iterator_range(boost::edge_range(_d->vertex, amm._d->vertex, _d->impl->_graph))) {
               if(_d->impl->_graph[edge].type == EdgeProperties::Type::pvAccess) {
                 boost::remove_edge(edge, _d->impl->_graph);
+#ifndef NDEBUG
                 pvAccessDeleted = true;
+#endif
                 break;
               }
             }
@@ -472,7 +476,9 @@ namespace ChimeraTK::Model {
                 boost::make_iterator_range(boost::edge_range(amm._d->vertex, _d->vertex, _d->impl->_graph))) {
               if(_d->impl->_graph[edge].type == EdgeProperties::Type::pvAccess) {
                 boost::remove_edge(edge, _d->impl->_graph);
+#ifndef NDEBUG
                 pvAccessDeleted = true;
+#endif
                 break;
               }
             }


### PR DESCRIPTION
The VersionInfoProvider registers with the Application, so we can find the (singleton-like) instance in the Application. If it is destroyed for whatever reason, this instance pointer must be de-registered to prevent use-after-free as well as allow the subsequent creation of another VersionInfoProvider.