### PR TITLE
fix: use after free

### DIFF
--- a/include/Model.h
+++ b/include/Model.h
@@ -400,7 +400,7 @@ namespace ChimeraTK::Model {
     void addTag(const std::string& tag);
 
     /// Remove VariableNetworkNode from the list of nodes. Note: Will invalidate return value of getNodes()!
-    void removeNode(const VariableNetworkNode& node);
+    void removeNode(VariableNetworkNode node);
 
     friend class ChimeraTK::VariableNetworkNode;
     friend class ChimeraTK::DeviceModule;

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -396,7 +396,7 @@ namespace ChimeraTK::Model {
 
   /********************************************************************************************************************/
 
-  void ProcessVariableProxy::removeNode(const VariableNetworkNode& node) {
+  void ProcessVariableProxy::removeNode(VariableNetworkNode node) {
     assert(node.getType() == NodeType::Application || node.getType() == NodeType::Device);
     assert(node.getModel().isValid());
     assert(isValid());


### PR DESCRIPTION
ProcessVariableProxy::removeNode() was effectively taking a reference to
a shared pointer as an argument and is removing the same (effective)
shared pointer from a list. This poses a problem if the reference passed
points to the list directly and is the last shared pointer to this
object so it gets freed, because removeNode() is accessing the object
after removing it from the list.