### PR TITLE
fix: Escape device name in initialisation handler

### DIFF
--- a/Modules/include/ScriptedInitialisationHandler.h
+++ b/Modules/include/ScriptedInitialisationHandler.h
@@ -60,7 +60,7 @@ namespace ChimeraTK {
     unsigned int _errorGracePeriod; // additional sleep time before a retry after an error
     //_scriptOutput must be in this file after _outputName so the latter can be used as constructor parameter
     ScalarOutput<std::string> _scriptOutput{
-        this, RegisterPath("/Devices") / _deviceAlias / _outputName, "", "stdout+stderr of init script"};
+        this, RegisterPath("/Devices") / Utilities::escapeName(_deviceAlias, false) / _outputName, "", "stdout+stderr of init script"};
   };
 
 } // namespace ChimeraTK


### PR DESCRIPTION
If a device was only defined by CDD and the CDD contained some sort of hierarchy separator, the unescaped CDD was causing an invalid variable name.