### PR TITLE
chore/doc: move all tests to namespace to help Doxygen

### DIFF
--- a/tests/executables_src/testApplication.cc
+++ b/tests/executables_src/testApplication.cc
@@ -20,343 +20,347 @@
 using namespace boost::unit_test_framework;
 namespace ctk = ChimeraTK;
 
-/*********************************************************************************************************************/
-/* Application without name */
+namespace Tests::testApplication {
 
-struct TestApp : public ctk::Application {
-  explicit TestApp(const std::string& name) : ctk::Application(name) {}
-  ~TestApp() override { shutdown(); }
+  /*********************************************************************************************************************/
+  /* Application without name */
 
-  ctk::ConstMultiplier<double> multiplierD{this, "multiplierD", "Some module", 42};
-  ctk::ScalarPipe<std::string> pipe{this, "pipeIn", "pipeOut", "unit", "Some pipe module"};
-  ctk::ConstMultiplier<uint16_t, uint16_t, 120> multiplierU16{this, "multiplierU16", "Some other module", 42};
+  struct TestApp : public ctk::Application {
+    explicit TestApp(const std::string& name) : ctk::Application(name) {}
+    ~TestApp() override { shutdown(); }
 
-  ctk::DeviceModule device{this, "(logicalNameMap?map=empty.xlmap)", "/trigger"};
-};
+    ctk::ConstMultiplier<double> multiplierD{this, "multiplierD", "Some module", 42};
+    ctk::ScalarPipe<std::string> pipe{this, "pipeIn", "pipeOut", "unit", "Some pipe module"};
+    ctk::ConstMultiplier<uint16_t, uint16_t, 120> multiplierU16{this, "multiplierU16", "Some other module", 42};
 
-/*********************************************************************************************************************/
-/* test trigger by app variable when connecting a polled device register to an
- * app variable */
+    ctk::DeviceModule device{this, "(logicalNameMap?map=empty.xlmap)", "/trigger"};
+  };
 
-BOOST_AUTO_TEST_CASE(testApplicationExceptions) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testApplicationExceptions" << std::endl;
+  /*********************************************************************************************************************/
+  /* test trigger by app variable when connecting a polled device register to an
+   * app variable */
 
-  // zero length name forbidden
-  try {
-    TestApp app("");
-    BOOST_FAIL("Exception expected.");
-  }
-  catch(ChimeraTK::logic_error&) {
-  }
+  BOOST_AUTO_TEST_CASE(testApplicationExceptions) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testApplicationExceptions" << std::endl;
 
-  // names with spaces and special characters are forbidden
-  try {
-    TestApp app("With space");
-    BOOST_FAIL("Exception expected.");
-  }
-  catch(ChimeraTK::logic_error&) {
-  }
-  try {
-    TestApp app("WithExclamationMark!");
-    BOOST_FAIL("Exception expected.");
-  }
-  catch(ChimeraTK::logic_error&) {
-  }
-
-  // all allowed characters in the name
-  { TestApp app("AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz_1234567890"); }
-
-  // repeated characters are allowed
-  { TestApp app("AAAAAAA"); }
-
-  // Two apps at the same time are not allowed
-  TestApp app1("FirstInstance");
-  try {
-    TestApp app2("SecondInstance");
-    BOOST_FAIL("Exception expected.");
-  }
-  catch(ChimeraTK::logic_error&) {
-  }
-}
-
-/*********************************************************************************************************************/
-// Helper function for testXmlGeneration:
-// Obtain a value from an XML node
-std::string getValueFromNode(const xmlpp::Node* node, const std::string& subnodeName) {
-  xmlpp::Node* theChild = nullptr;
-  for(const auto& child : node->get_children()) {
-    if(child->get_name() == subnodeName) {
-      theChild = child;
+    // zero length name forbidden
+    try {
+      TestApp app("");
+      BOOST_FAIL("Exception expected.");
     }
-  }
-  BOOST_REQUIRE(theChild != nullptr); // requested child tag is there
-  auto subChildList = theChild->get_children();
-  if(subChildList.empty()) { // special case: no text in the tag -> return empty string
-    return "";
-  }
-  BOOST_REQUIRE_EQUAL(subChildList.size(),
-      1); // child tag contains only text (no further sub-tags)
-  const xmlpp::TextNode* textNode = dynamic_cast<xmlpp::TextNode*>(subChildList.front());
-  BOOST_REQUIRE(textNode != nullptr);
-  return textNode->get_content();
-}
-
-/*********************************************************************************************************************/
-/* test creation of XML file describing the variable tree */
-
-BOOST_AUTO_TEST_CASE(testXmlGeneration) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testXmlGeneration" << std::endl;
-
-  // delete XML file if already existing
-  boost::filesystem::remove("TestAppInstance.xml");
-
-  // create app which exports some properties and generate its XML file
-  TestApp app("TestAppInstance");
-  app.generateXML();
-
-  // validate the XML file
-  xmlpp::XsdValidator validator("application.xsd");
-  validator.validate("TestAppInstance.xml");
-
-  // parse XML file
-  xmlpp::DomParser parser;
-  try {
-    parser.parse_file("TestAppInstance.xml");
-  }
-  catch(xmlpp::exception& e) {
-    throw std::runtime_error(std::string("ConfigReader: Error opening the config file "
-                                         "'TestAppInstance.xml': ") +
-        e.what());
-  }
-
-  // get root element
-  auto* const root = parser.get_document()->get_root_node();
-  BOOST_CHECK_EQUAL(root->get_name(), "application");
-
-  // parsing loop
-  bool found_pipeIn{false};
-  bool found_multiplierDIn{false};
-  bool found_multiplierDOut{false};
-  bool found_multiplierU16In{false};
-  bool found_multiplierU16Out{false};
-  bool found_pipeOut{false};
-  bool foundTrigger{false};
-
-  bool foundDeviceStatus{false};
-  bool foundDeviceMessage{false};
-  bool foundBecameFunctional{false};
-
-  for(const auto& child : root->get_children()) {
-    // cast into element, ignore if not an element (e.g. comment)
-    const auto* element = dynamic_cast<const xmlpp::Element*>(child);
-    if(!element) {
-      continue;
+    catch(ChimeraTK::logic_error&) {
     }
 
-    if(element->get_name() == "variable") {
-      // obtain attributes from the element
-      auto* xname = element->get_attribute("name");
-      BOOST_REQUIRE(xname != nullptr);
-      std::string name(xname->get_value());
+    // names with spaces and special characters are forbidden
+    try {
+      TestApp app("With space");
+      BOOST_FAIL("Exception expected.");
+    }
+    catch(ChimeraTK::logic_error&) {
+    }
+    try {
+      TestApp app("WithExclamationMark!");
+      BOOST_FAIL("Exception expected.");
+    }
+    catch(ChimeraTK::logic_error&) {
+    }
 
-      // obtain values from sub-elements
-      std::string value_type = getValueFromNode(element, "value_type");
-      std::string direction = getValueFromNode(element, "direction");
-      std::string unit = getValueFromNode(element, "unit");
-      std::string description = getValueFromNode(element, "description");
-      std::string numberOfElements = getValueFromNode(element, "numberOfElements");
+    // all allowed characters in the name
+    { TestApp app("AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz_1234567890"); }
 
-      // check if variables are described correctly
-      if(name == "pipeOut") {
-        found_pipeIn = true;
-        BOOST_TEST(value_type == "string");
-        BOOST_TEST(direction == "application_to_control_system");
-        BOOST_TEST(unit == "unit");
-        BOOST_TEST(description == "Some pipe module");
-        BOOST_TEST(numberOfElements == "1");
-      }
-      else if(name == "pipeIn") {
-        found_pipeOut = true;
-        BOOST_TEST(value_type == "string");
-        BOOST_CHECK_EQUAL(direction, "control_system_to_application");
-        BOOST_TEST(unit == "unit");
-        BOOST_TEST(description == "Some pipe module");
-        BOOST_TEST(numberOfElements == "1");
-      }
-      else if(name == "trigger") {
-        foundTrigger = true;
-        BOOST_TEST(value_type == "Void");
-        BOOST_CHECK_EQUAL(direction, "control_system_to_application");
-        BOOST_TEST(unit == "n./a.");
-        BOOST_TEST(description == "");
-        BOOST_TEST(numberOfElements == "0");
-      }
-      else {
-        BOOST_ERROR("Wrong variable name found.");
+    // repeated characters are allowed
+    { TestApp app("AAAAAAA"); }
+
+    // Two apps at the same time are not allowed
+    TestApp app1("FirstInstance");
+    try {
+      TestApp app2("SecondInstance");
+      BOOST_FAIL("Exception expected.");
+    }
+    catch(ChimeraTK::logic_error&) {
+    }
+  }
+
+  /*********************************************************************************************************************/
+  // Helper function for testXmlGeneration:
+  // Obtain a value from an XML node
+  std::string getValueFromNode(const xmlpp::Node* node, const std::string& subnodeName) {
+    xmlpp::Node* theChild = nullptr;
+    for(const auto& child : node->get_children()) {
+      if(child->get_name() == subnodeName) {
+        theChild = child;
       }
     }
-    else if(element->get_name() == "directory") {
-      auto* xname = element->get_attribute("name");
-      BOOST_REQUIRE(xname != nullptr);
-      std::string name(xname->get_value());
+    BOOST_REQUIRE(theChild != nullptr); // requested child tag is there
+    auto subChildList = theChild->get_children();
+    if(subChildList.empty()) { // special case: no text in the tag -> return empty string
+      return "";
+    }
+    BOOST_REQUIRE_EQUAL(subChildList.size(),
+        1); // child tag contains only text (no further sub-tags)
+    const xmlpp::TextNode* textNode = dynamic_cast<xmlpp::TextNode*>(subChildList.front());
+    BOOST_REQUIRE(textNode != nullptr);
+    return textNode->get_content();
+  }
 
-      for(const auto& subchild : child->get_children()) {
-        const auto* element2 = dynamic_cast<const xmlpp::Element*>(subchild);
-        if(!element2) {
-          continue;
+  /*********************************************************************************************************************/
+  /* test creation of XML file describing the variable tree */
+
+  BOOST_AUTO_TEST_CASE(testXmlGeneration) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testXmlGeneration" << std::endl;
+
+    // delete XML file if already existing
+    boost::filesystem::remove("TestAppInstance.xml");
+
+    // create app which exports some properties and generate its XML file
+    TestApp app("TestAppInstance");
+    app.generateXML();
+
+    // validate the XML file
+    xmlpp::XsdValidator validator("application.xsd");
+    validator.validate("TestAppInstance.xml");
+
+    // parse XML file
+    xmlpp::DomParser parser;
+    try {
+      parser.parse_file("TestAppInstance.xml");
+    }
+    catch(xmlpp::exception& e) {
+      throw std::runtime_error(std::string("ConfigReader: Error opening the config file "
+                                           "'TestAppInstance.xml': ") +
+          e.what());
+    }
+
+    // get root element
+    auto* const root = parser.get_document()->get_root_node();
+    BOOST_CHECK_EQUAL(root->get_name(), "application");
+
+    // parsing loop
+    bool found_pipeIn{false};
+    bool found_multiplierDIn{false};
+    bool found_multiplierDOut{false};
+    bool found_multiplierU16In{false};
+    bool found_multiplierU16Out{false};
+    bool found_pipeOut{false};
+    bool foundTrigger{false};
+
+    bool foundDeviceStatus{false};
+    bool foundDeviceMessage{false};
+    bool foundBecameFunctional{false};
+
+    for(const auto& child : root->get_children()) {
+      // cast into element, ignore if not an element (e.g. comment)
+      const auto* element = dynamic_cast<const xmlpp::Element*>(child);
+      if(!element) {
+        continue;
+      }
+
+      if(element->get_name() == "variable") {
+        // obtain attributes from the element
+        auto* xname = element->get_attribute("name");
+        BOOST_REQUIRE(xname != nullptr);
+        std::string name(xname->get_value());
+
+        // obtain values from sub-elements
+        std::string value_type = getValueFromNode(element, "value_type");
+        std::string direction = getValueFromNode(element, "direction");
+        std::string unit = getValueFromNode(element, "unit");
+        std::string description = getValueFromNode(element, "description");
+        std::string numberOfElements = getValueFromNode(element, "numberOfElements");
+
+        // check if variables are described correctly
+        if(name == "pipeOut") {
+          found_pipeIn = true;
+          BOOST_TEST(value_type == "string");
+          BOOST_TEST(direction == "application_to_control_system");
+          BOOST_TEST(unit == "unit");
+          BOOST_TEST(description == "Some pipe module");
+          BOOST_TEST(numberOfElements == "1");
         }
+        else if(name == "pipeIn") {
+          found_pipeOut = true;
+          BOOST_TEST(value_type == "string");
+          BOOST_CHECK_EQUAL(direction, "control_system_to_application");
+          BOOST_TEST(unit == "unit");
+          BOOST_TEST(description == "Some pipe module");
+          BOOST_TEST(numberOfElements == "1");
+        }
+        else if(name == "trigger") {
+          foundTrigger = true;
+          BOOST_TEST(value_type == "Void");
+          BOOST_CHECK_EQUAL(direction, "control_system_to_application");
+          BOOST_TEST(unit == "n./a.");
+          BOOST_TEST(description == "");
+          BOOST_TEST(numberOfElements == "0");
+        }
+        else {
+          BOOST_ERROR("Wrong variable name found.");
+        }
+      }
+      else if(element->get_name() == "directory") {
+        auto* xname = element->get_attribute("name");
+        BOOST_REQUIRE(xname != nullptr);
+        std::string name(xname->get_value());
 
-        if(element2->get_name() == "directory") {
-          auto* xname2 = element2->get_attribute("name");
-          BOOST_REQUIRE(xname2 != nullptr);
-          std::string name2(xname2->get_value());
-          BOOST_REQUIRE(name2 == ctk::Utilities::escapeName(app.device.getDeviceAliasOrURI(), false));
+        for(const auto& subchild : child->get_children()) {
+          const auto* element2 = dynamic_cast<const xmlpp::Element*>(subchild);
+          if(!element2) {
+            continue;
+          }
 
-          for(const auto& devicechild : element2->get_children()) {
-            const auto* deviceChildElement = dynamic_cast<const xmlpp::Element*>(devicechild);
-            if(!deviceChildElement) {
-              continue;
-            }
-            if(deviceChildElement->get_name() == "variable") {
-              // obtain attributes from the element
-              auto* xname3 = deviceChildElement->get_attribute("name");
-              BOOST_REQUIRE(xname3 != nullptr);
-              std::string name3(xname3->get_value());
+          if(element2->get_name() == "directory") {
+            auto* xname2 = element2->get_attribute("name");
+            BOOST_REQUIRE(xname2 != nullptr);
+            std::string name2(xname2->get_value());
+            BOOST_REQUIRE(name2 == ctk::Utilities::escapeName(app.device.getDeviceAliasOrURI(), false));
 
-              // obtain values from sub-elements
-              std::string value_type = getValueFromNode(deviceChildElement, "value_type");
-              std::string direction = getValueFromNode(deviceChildElement, "direction");
-              std::string unit = getValueFromNode(deviceChildElement, "unit");
-              std::string description = getValueFromNode(deviceChildElement, "description");
-              std::string numberOfElements = getValueFromNode(deviceChildElement, "numberOfElements");
-              if(name3 == "status") {
-                foundDeviceStatus = true;
-                BOOST_CHECK_EQUAL(value_type, "int32");
-                BOOST_CHECK_EQUAL(description, "Error status of the device - Error status of the device");
-                BOOST_CHECK_EQUAL(numberOfElements, "1");
-                BOOST_CHECK_EQUAL(direction, "application_to_control_system");
-                BOOST_CHECK_EQUAL(unit, "");
+            for(const auto& devicechild : element2->get_children()) {
+              const auto* deviceChildElement = dynamic_cast<const xmlpp::Element*>(devicechild);
+              if(!deviceChildElement) {
+                continue;
               }
-              else if(name3 == "status_message") {
-                foundDeviceMessage = true;
-                BOOST_CHECK_EQUAL(value_type, "string");
-                BOOST_CHECK_EQUAL(description, "Error status of the device - status message");
-                BOOST_CHECK_EQUAL(numberOfElements, "1");
-                BOOST_CHECK_EQUAL(direction, "application_to_control_system");
-                BOOST_CHECK_EQUAL(unit, "");
-              }
-              else if(name3 == "deviceBecameFunctional") {
-                foundBecameFunctional = true;
-                BOOST_CHECK_EQUAL(value_type, "Void");
-                BOOST_CHECK_EQUAL(description, "");
-                BOOST_CHECK_EQUAL(numberOfElements, "1");
-                BOOST_CHECK_EQUAL(direction, "application_to_control_system");
-                BOOST_CHECK_EQUAL(unit, "");
+              if(deviceChildElement->get_name() == "variable") {
+                // obtain attributes from the element
+                auto* xname3 = deviceChildElement->get_attribute("name");
+                BOOST_REQUIRE(xname3 != nullptr);
+                std::string name3(xname3->get_value());
+
+                // obtain values from sub-elements
+                std::string value_type = getValueFromNode(deviceChildElement, "value_type");
+                std::string direction = getValueFromNode(deviceChildElement, "direction");
+                std::string unit = getValueFromNode(deviceChildElement, "unit");
+                std::string description = getValueFromNode(deviceChildElement, "description");
+                std::string numberOfElements = getValueFromNode(deviceChildElement, "numberOfElements");
+                if(name3 == "status") {
+                  foundDeviceStatus = true;
+                  BOOST_CHECK_EQUAL(value_type, "int32");
+                  BOOST_CHECK_EQUAL(description, "Error status of the device - Error status of the device");
+                  BOOST_CHECK_EQUAL(numberOfElements, "1");
+                  BOOST_CHECK_EQUAL(direction, "application_to_control_system");
+                  BOOST_CHECK_EQUAL(unit, "");
+                }
+                else if(name3 == "status_message") {
+                  foundDeviceMessage = true;
+                  BOOST_CHECK_EQUAL(value_type, "string");
+                  BOOST_CHECK_EQUAL(description, "Error status of the device - status message");
+                  BOOST_CHECK_EQUAL(numberOfElements, "1");
+                  BOOST_CHECK_EQUAL(direction, "application_to_control_system");
+                  BOOST_CHECK_EQUAL(unit, "");
+                }
+                else if(name3 == "deviceBecameFunctional") {
+                  foundBecameFunctional = true;
+                  BOOST_CHECK_EQUAL(value_type, "Void");
+                  BOOST_CHECK_EQUAL(description, "");
+                  BOOST_CHECK_EQUAL(numberOfElements, "1");
+                  BOOST_CHECK_EQUAL(direction, "application_to_control_system");
+                  BOOST_CHECK_EQUAL(unit, "");
+                }
+                else {
+                  BOOST_ERROR("Unexpected variable " + name2);
+                }
               }
               else {
-                BOOST_ERROR("Unexpected variable " + name2);
+                BOOST_ERROR("Wrong tag " + element2->get_name() + " found");
               }
             }
-            else {
-              BOOST_ERROR("Wrong tag " + element2->get_name() + " found");
-            }
           }
-        }
-        else if(element2->get_name() == "variable") {
-          // obtain attributes from the element
-          auto* xname2 = element2->get_attribute("name");
-          BOOST_REQUIRE(xname2 != nullptr);
-          std::string name2(xname2->get_value());
+          else if(element2->get_name() == "variable") {
+            // obtain attributes from the element
+            auto* xname2 = element2->get_attribute("name");
+            BOOST_REQUIRE(xname2 != nullptr);
+            std::string name2(xname2->get_value());
 
-          // obtain values from sub-elements
-          std::string value_type = getValueFromNode(element2, "value_type");
-          std::string direction = getValueFromNode(element2, "direction");
-          std::string unit = getValueFromNode(element2, "unit");
-          std::string description = getValueFromNode(element2, "description");
-          std::string numberOfElements = getValueFromNode(element2, "numberOfElements");
+            // obtain values from sub-elements
+            std::string value_type = getValueFromNode(element2, "value_type");
+            std::string direction = getValueFromNode(element2, "direction");
+            std::string unit = getValueFromNode(element2, "unit");
+            std::string description = getValueFromNode(element2, "description");
+            std::string numberOfElements = getValueFromNode(element2, "numberOfElements");
 
-          if(name2 == "input") {
-            if(name == "multiplierD") {
-              found_multiplierDIn = true;
-              BOOST_CHECK_EQUAL(value_type, "double");
-              BOOST_CHECK_EQUAL(description, "Some module");
-              BOOST_CHECK_EQUAL(numberOfElements, "1");
+            if(name2 == "input") {
+              if(name == "multiplierD") {
+                found_multiplierDIn = true;
+                BOOST_CHECK_EQUAL(value_type, "double");
+                BOOST_CHECK_EQUAL(description, "Some module");
+                BOOST_CHECK_EQUAL(numberOfElements, "1");
+              }
+              else if(name == "multiplierU16") {
+                found_multiplierU16In = true;
+                BOOST_CHECK_EQUAL(value_type, "uint16");
+                BOOST_CHECK_EQUAL(description, "Some other module");
+                BOOST_CHECK_EQUAL(numberOfElements, "120");
+              }
+              else {
+                BOOST_ERROR("Wrong Directory name found");
+              }
+              BOOST_CHECK_EQUAL(direction, "control_system_to_application");
+              BOOST_CHECK_EQUAL(unit, "");
             }
-            else if(name == "multiplierU16") {
-              found_multiplierU16In = true;
-              BOOST_CHECK_EQUAL(value_type, "uint16");
-              BOOST_CHECK_EQUAL(description, "Some other module");
-              BOOST_CHECK_EQUAL(numberOfElements, "120");
+            else if(name2 == "output") {
+              if(name == "multiplierD") {
+                found_multiplierDOut = true;
+                BOOST_CHECK_EQUAL(value_type, "double");
+                BOOST_CHECK_EQUAL(description, "Some module");
+                BOOST_CHECK_EQUAL(numberOfElements, "1");
+              }
+              else if(name == "multiplierU16") {
+                found_multiplierU16Out = true;
+                BOOST_CHECK_EQUAL(value_type, "uint16");
+                BOOST_CHECK_EQUAL(description, "Some other module");
+                BOOST_CHECK_EQUAL(numberOfElements, "120");
+              }
+              else {
+                BOOST_ERROR("Wrong Directory name found");
+              }
+              BOOST_CHECK_EQUAL(direction, "application_to_control_system");
+              BOOST_CHECK_EQUAL(unit, "");
             }
             else {
-              BOOST_ERROR("Wrong Directory name found");
+              BOOST_ERROR("Wrong variable name found.");
             }
-            BOOST_CHECK_EQUAL(direction, "control_system_to_application");
-            BOOST_CHECK_EQUAL(unit, "");
-          }
-          else if(name2 == "output") {
-            if(name == "multiplierD") {
-              found_multiplierDOut = true;
-              BOOST_CHECK_EQUAL(value_type, "double");
-              BOOST_CHECK_EQUAL(description, "Some module");
-              BOOST_CHECK_EQUAL(numberOfElements, "1");
-            }
-            else if(name == "multiplierU16") {
-              found_multiplierU16Out = true;
-              BOOST_CHECK_EQUAL(value_type, "uint16");
-              BOOST_CHECK_EQUAL(description, "Some other module");
-              BOOST_CHECK_EQUAL(numberOfElements, "120");
-            }
-            else {
-              BOOST_ERROR("Wrong Directory name found");
-            }
-            BOOST_CHECK_EQUAL(direction, "application_to_control_system");
-            BOOST_CHECK_EQUAL(unit, "");
-          }
-          else {
-            BOOST_ERROR("Wrong variable name found.");
           }
         }
       }
+      else {
+        BOOST_ERROR("Wrong tag found.");
+      }
     }
-    else {
-      BOOST_ERROR("Wrong tag found.");
-    }
+
+    BOOST_CHECK(found_pipeIn);
+    BOOST_CHECK(found_pipeOut);
+    BOOST_CHECK(found_multiplierDIn);
+    BOOST_CHECK(found_multiplierDOut);
+    BOOST_CHECK(found_multiplierU16In);
+    BOOST_CHECK(found_multiplierU16Out);
+    BOOST_CHECK(foundTrigger);
+    BOOST_CHECK(foundDeviceMessage);
+    BOOST_CHECK(foundDeviceStatus);
+    BOOST_CHECK(foundBecameFunctional);
   }
 
-  BOOST_CHECK(found_pipeIn);
-  BOOST_CHECK(found_pipeOut);
-  BOOST_CHECK(found_multiplierDIn);
-  BOOST_CHECK(found_multiplierDOut);
-  BOOST_CHECK(found_multiplierU16In);
-  BOOST_CHECK(found_multiplierU16Out);
-  BOOST_CHECK(foundTrigger);
-  BOOST_CHECK(foundDeviceMessage);
-  BOOST_CHECK(foundDeviceStatus);
-  BOOST_CHECK(foundBecameFunctional);
-}
+  BOOST_AUTO_TEST_CASE(testDOTGeneration) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> tesDOTGeneration" << std::endl;
 
-BOOST_AUTO_TEST_CASE(testDOTGeneration) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> tesDOTGeneration" << std::endl;
+    // delete DOT file if already existing
+    boost::filesystem::remove("TestAppInstance.dot");
 
-  // delete DOT file if already existing
-  boost::filesystem::remove("TestAppInstance.dot");
+    // create app which exports some properties and generate its XML file
+    TestApp app("TestAppInstance");
+    app.generateDOT();
 
-  // create app which exports some properties and generate its XML file
-  TestApp app("TestAppInstance");
-  app.generateDOT();
+    // check existence
+    bool found_dot{boost::filesystem::exists("TestAppInstance.dot")};
 
-  // check existence
-  bool found_dot{boost::filesystem::exists("TestAppInstance.dot")};
+    BOOST_CHECK(found_dot);
+  }
 
-  BOOST_CHECK(found_dot);
-}
+}; // namespace Tests::testApplication

--- a/tests/executables_src/testBidirectionalVariables.cc
+++ b/tests/executables_src/testBidirectionalVariables.cc
@@ -22,626 +22,630 @@
 using namespace boost::unit_test_framework;
 namespace ctk = ChimeraTK;
 
-/*********************************************************************************************************************/
+namespace Tests::testBidirectionalVariables {
 
-/* Module which converts the input data from inches to centimetres - and the
- * other way round for the return channel. In case of the return channel, the
- * data is rounded downwards to integer inches and sent again forward. */
-struct ModuleA : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
+  /*********************************************************************************************************************/
 
-  ctk::ScalarPushInputWB<int> var1{this, "var1", "inches", "A length, for some reason rounded to integer"};
-  ctk::ScalarOutputPushRB<double> var2{this, "var2", "centimetres", "Same length converted to centimetres"};
+  /* Module which converts the input data from inches to centimetres - and the
+   * other way round for the return channel. In case of the return channel, the
+   * data is rounded downwards to integer inches and sent again forward. */
+  struct ModuleA : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  void prepare() override {
-    incrementDataFaultCounter(); // force all outputs  to invalid
-    writeAll();                  // write initial values
-    decrementDataFaultCounter(); // validity according to input validity
-  }
+    ctk::ScalarPushInputWB<int> var1{this, "var1", "inches", "A length, for some reason rounded to integer"};
+    ctk::ScalarOutputPushRB<double> var2{this, "var2", "centimetres", "Same length converted to centimetres"};
 
-  void mainLoop() override {
-    auto group = readAnyGroup();
-    while(true) {
-      auto var = group.readAny();
-      if(var == var2.getId()) {
-        var1 = std::floor(var2 / 2.54);
-        var1.write();
-      }
-      var2 = var1 * 2.54;
-      var2.write();
+    void prepare() override {
+      incrementDataFaultCounter(); // force all outputs  to invalid
+      writeAll();                  // write initial values
+      decrementDataFaultCounter(); // validity according to input validity
     }
-  }
-};
 
-/*********************************************************************************************************************/
-
-/* Module which limits a value to stay below a maximum value. */
-struct ModuleB : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  ctk::ScalarPushInputWB<double> var2{this, "var2", "centimetres", "Some length, confined to a configurable range"};
-  ctk::ScalarPushInput<double> max{this, "max", "centimetres", "Maximum length"};
-  ctk::ScalarOutput<double> var3{this, "var3", "centimetres", "The limited length"};
-
-  void prepare() override {
-    incrementDataFaultCounter(); // force all outputs  to invalid
-    writeAll();                  // write initial values
-    decrementDataFaultCounter(); // validity according to input validity
-  }
-
-  void mainLoop() override {
-    auto group = readAnyGroup();
-    while(true) {
-      auto var = group.readAny();
-      bool write = var == var2.getId();
-      if(var2 > max) {
-        var2 = static_cast<double>(max);
+    void mainLoop() override {
+      auto group = readAnyGroup();
+      while(true) {
+        auto var = group.readAny();
+        if(var == var2.getId()) {
+          var1 = std::floor(var2 / 2.54);
+          var1.write();
+        }
+        var2 = var1 * 2.54;
         var2.write();
-        write = true;
-      }
-      if(write) { // write only if var2 was received or the value was changed
-                  // due to a reduced limit
-        var3 = static_cast<double>(var2);
-        var3.write();
       }
     }
-  }
-};
+  };
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-struct ModuleD : public ctk::ApplicationModule {
-  using ApplicationModule::ApplicationModule;
+  /* Module which limits a value to stay below a maximum value. */
+  struct ModuleB : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  ctk::ScalarPushInput<int> var1{this, "var1", "inches", "A length, for some reason rounded to integer"};
-  ctk::ScalarOutput<int> varOut{this, "var1_out", "inches", "A length, for some reason rounded to integer"};
+    ctk::ScalarPushInputWB<double> var2{this, "var2", "centimetres", "Some length, confined to a configurable range"};
+    ctk::ScalarPushInput<double> max{this, "max", "centimetres", "Maximum length"};
+    ctk::ScalarOutput<double> var3{this, "var3", "centimetres", "The limited length"};
 
-  void mainLoop() override {
-    // Copy everything from in to out - this is done because the test runs in testable mode
-    // And would stall if we do not read var1 in here
-    // By propagating the value to varOut, it is possible to selectively read the values from the CS instead
-    // as before with the double connection "trick".
-    while(true) {
-      var1.read();
-      varOut = static_cast<int>(var1);
-      varOut.write();
+    void prepare() override {
+      incrementDataFaultCounter(); // force all outputs  to invalid
+      writeAll();                  // write initial values
+      decrementDataFaultCounter(); // validity according to input validity
     }
-  }
-};
 
-/*********************************************************************************************************************/
-
-struct ModuleFunnel : public ctk::ApplicationModule {
-  using ApplicationModule::ApplicationModule;
-
-  ctk::ScalarPushInputWB<int> var1{this, "/var1", "", "Input with funneled return channel"};
-  ctk::ScalarOutput<int> var1out{this, "var1out", "", ""};
-  ctk::ScalarPushInput<int> var1in{this, "var1in", "", ""};
-
-  void mainLoop() override {
-    // This module essentially splits up the forward and return channel of the PushInputWB "var1".
-    auto group = readAnyGroup();
-
-    auto change = var1.getId();
-
-    while(true) {
-      if(change == var1.getId()) {
-        var1out.setAndWrite(var1);
-      }
-      else if(change == var1in.getId()) {
-        var1.setAndWrite(var1in);
-      }
-
-      change = group.readAny();
-    }
-  }
-};
-
-/*********************************************************************************************************************/
-
-struct TestApplication : public ctk::Application {
-  TestApplication() : Application("testSuite") {}
-  ~TestApplication() override { shutdown(); }
-
-  ModuleA a;
-  ModuleB b;
-  ModuleD copy;
-};
-
-/*********************************************************************************************************************/
-
-struct FunnelApplication : public ctk::Application {
-  FunnelApplication() : Application("testSuite") {}
-  ~FunnelApplication() override { shutdown(); }
-
-  ModuleFunnel f1{this, "Funnel1", ""};
-  ModuleFunnel f2{this, "Funnel2", ""};
-};
-
-/*********************************************************************************************************************/
-
-struct ModuleC : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  ctk::ScalarPushInputWB<int> var1{this, "var1", "", ""};
-
-  void mainLoop() override {
-    auto group = readAnyGroup();
-
-    var1 = 42;
-    var1.write();
-
-    while(true) {
-      auto var = group.readAny();
-      if(var == var1.getId()) {
-        var1 = var1 + 1;
-        var1.write();
+    void mainLoop() override {
+      auto group = readAnyGroup();
+      while(true) {
+        auto var = group.readAny();
+        bool write = var == var2.getId();
+        if(var2 > max) {
+          var2 = static_cast<double>(max);
+          var2.write();
+          write = true;
+        }
+        if(write) { // write only if var2 was received or the value was changed
+                    // due to a reduced limit
+          var3 = static_cast<double>(var2);
+          var3.write();
+        }
       }
     }
-  }
-};
+  };
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-struct InitTestApplication : public ctk::Application {
-  InitTestApplication() : Application("testSuite") {}
-  ~InitTestApplication() override { shutdown(); }
+  struct ModuleD : public ctk::ApplicationModule {
+    using ApplicationModule::ApplicationModule;
 
-  ModuleC c{this, "ModuleC", ""};
-};
+    ctk::ScalarPushInput<int> var1{this, "var1", "inches", "A length, for some reason rounded to integer"};
+    ctk::ScalarOutput<int> varOut{this, "var1_out", "inches", "A length, for some reason rounded to integer"};
 
-/*********************************************************************************************************************/
+    void mainLoop() override {
+      // Copy everything from in to out - this is done because the test runs in testable mode
+      // And would stall if we do not read var1 in here
+      // By propagating the value to varOut, it is possible to selectively read the values from the CS instead
+      // as before with the double connection "trick".
+      while(true) {
+        var1.read();
+        varOut = static_cast<int>(var1);
+        varOut.write();
+      }
+    }
+  };
 
-BOOST_AUTO_TEST_CASE(testDirectAppToCSConnections) {
-  std::cout << "*** testDirectAppToCSConnections" << std::endl;
+  /*********************************************************************************************************************/
 
-  TestApplication app;
-  app.b = {&app, ".", ""};
+  struct ModuleFunnel : public ctk::ApplicationModule {
+    using ApplicationModule::ApplicationModule;
 
-  ctk::TestFacility test(app);
-  test.runApplication();
-  auto var2 = test.getScalar<double>("var2");
-  auto var3 = test.getScalar<double>("var3");
-  auto max = test.getScalar<double>("max");
+    ctk::ScalarPushInputWB<int> var1{this, "/var1", "", "Input with funneled return channel"};
+    ctk::ScalarOutput<int> var1out{this, "var1out", "", ""};
+    ctk::ScalarPushInput<int> var1in{this, "var1in", "", ""};
 
-  // set maximum in B
-  max = 49.5;
-  max.write();
-  test.stepApplication();
+    void mainLoop() override {
+      // This module essentially splits up the forward and return channel of the PushInputWB "var1".
+      auto group = readAnyGroup();
 
-  // inject value which does not get limited
-  var2 = 49;
-  var2.write();
-  test.stepApplication();
-  var3.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var3), 49, 0.001);
-  BOOST_CHECK(var2.readNonBlocking() == false);
-  BOOST_CHECK(var3.readNonBlocking() == false);
+      auto change = var1.getId();
 
-  // inject value which gets limited
-  var2 = 50;
-  var2.write();
-  test.stepApplication();
-  var2.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var2), 49.5, 0.001);
-  var3.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var3), 49.5, 0.001);
-  BOOST_CHECK(var2.readNonBlocking() == false);
-  BOOST_CHECK(var3.readNonBlocking() == false);
+      while(true) {
+        if(change == var1.getId()) {
+          var1out.setAndWrite(var1);
+        }
+        else if(change == var1in.getId()) {
+          var1.setAndWrite(var1in);
+        }
 
-  // change the limit so the current value gets changed
-  max = 48.5;
-  max.write();
-  test.stepApplication();
-  var2.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var2), 48.5, 0.001);
-  var3.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var3), 48.5, 0.001);
-  BOOST_CHECK(var2.readNonBlocking() == false);
-  BOOST_CHECK(var3.readNonBlocking() == false);
-}
+        change = group.readAny();
+      }
+    }
+  };
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(testRealisticExample) {
-  std::cout << "*** testRealisticExample" << std::endl;
+  struct TestApplication : public ctk::Application {
+    TestApplication() : Application("testSuite") {}
+    ~TestApplication() override { shutdown(); }
 
-  TestApplication app;
-  app.a = {&app, ".", ""};
-  app.b = {&app, ".", ""};
-  app.copy = {&app, ".", ""};
+    ModuleA a;
+    ModuleB b;
+    ModuleD copy;
+  };
 
-  ctk::TestFacility test(app);
-  auto var1 = test.getScalar<int>("var1");
-  auto var1_copied = test.getScalar<int>("var1_out");
-  auto var2 = test.getScalar<double>("var2");
-  auto var3 = test.getScalar<double>("var3");
-  auto max = test.getScalar<double>("max");
-  test.runApplication();
+  /*********************************************************************************************************************/
 
-  // set maximum in B, so that var1=49 is still below maximum but var2=50 is
-  // already above and rounding in ModuleB will change the value again
-  max = 49.5 * 2.54;
-  max.write();
-  test.stepApplication();
+  struct FunnelApplication : public ctk::Application {
+    FunnelApplication() : Application("testSuite") {}
+    ~FunnelApplication() override { shutdown(); }
 
-  // inject value which does not get limited
-  var1 = 49;
-  var1.write();
-  test.stepApplication();
-  var1_copied.read();
-  var2.read();
-  var3.read();
-  BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 49);
-  BOOST_CHECK_CLOSE(static_cast<double>(var2), 49 * 2.54, 0.001);
-  BOOST_CHECK_CLOSE(static_cast<double>(var3), 49 * 2.54, 0.001);
-  BOOST_CHECK(var1.readNonBlocking() == false); // nothing was sent through the return channel
-  BOOST_CHECK(var1_copied.readLatest() == false);
-  BOOST_CHECK(var2.readNonBlocking() == false);
-  BOOST_CHECK(var3.readNonBlocking() == false);
+    ModuleFunnel f1{this, "Funnel1", ""};
+    ModuleFunnel f2{this, "Funnel2", ""};
+  };
 
-  // inject value which gets limited
-  var1 = 50;
-  var1.write();
-  test.stepApplication();
-  var1.read();
-  BOOST_CHECK_EQUAL(static_cast<int>(var1), 49);
-  var1_copied.read();
-  BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 50);
-  var1_copied.read();
-  BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 49);
-  var2.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var2), 50 * 2.54, 0.001);
-  var2.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var2), 49.5 * 2.54, 0.001);
-  var2.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var2), 49 * 2.54, 0.001);
-  var3.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var3), 49.5 * 2.54, 0.001);
-  var3.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var3), 49 * 2.54, 0.001);
-  BOOST_CHECK(var1.readNonBlocking() == false);
-  BOOST_CHECK(var1_copied.readLatest() == false);
-  BOOST_CHECK(var2.readNonBlocking() == false);
-  BOOST_CHECK(var3.readNonBlocking() == false);
+  /*********************************************************************************************************************/
 
-  // change the limit so the current value gets changed
-  max = 48.5 * 2.54;
-  max.write();
-  test.stepApplication();
-  var1.read();
-  BOOST_CHECK_EQUAL(static_cast<int>(var1), 48);
-  var1_copied.read();
-  BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 48);
-  var2.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var2), 48.5 * 2.54, 0.001);
-  var2.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var2), 48 * 2.54, 0.001);
-  var3.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var3), 48.5 * 2.54, 0.001);
-  var3.read();
-  BOOST_CHECK_CLOSE(static_cast<double>(var3), 48 * 2.54, 0.001);
-  BOOST_CHECK(var1.readNonBlocking() == false);
-  BOOST_CHECK(var1_copied.readLatest() == false);
-  BOOST_CHECK(var2.readNonBlocking() == false);
-  BOOST_CHECK(var3.readNonBlocking() == false);
+  struct ModuleC : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  // Run the following tests a couple of times, as they are testing for the
-  // absence of race conditions. This makes it more likely to find failures in a
-  // single run of the test
-  for(size_t i = 0; i < 10; ++i) {
-    // feed in some default values (so the tests can be executed multiple times
-    // in a row)
-    max = 48.5 * 2.54;
+    ctk::ScalarPushInputWB<int> var1{this, "var1", "", ""};
+
+    void mainLoop() override {
+      auto group = readAnyGroup();
+
+      var1 = 42;
+      var1.write();
+
+      while(true) {
+        auto var = group.readAny();
+        if(var == var1.getId()) {
+          var1 = var1 + 1;
+          var1.write();
+        }
+      }
+    }
+  };
+
+  /*********************************************************************************************************************/
+
+  struct InitTestApplication : public ctk::Application {
+    InitTestApplication() : Application("testSuite") {}
+    ~InitTestApplication() override { shutdown(); }
+
+    ModuleC c{this, "ModuleC", ""};
+  };
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDirectAppToCSConnections) {
+    std::cout << "*** testDirectAppToCSConnections" << std::endl;
+
+    TestApplication app;
+    app.b = {&app, ".", ""};
+
+    ctk::TestFacility test(app);
+    test.runApplication();
+    auto var2 = test.getScalar<double>("var2");
+    auto var3 = test.getScalar<double>("var3");
+    auto max = test.getScalar<double>("max");
+
+    // set maximum in B
+    max = 49.5;
     max.write();
     test.stepApplication();
+
+    // inject value which does not get limited
+    var2 = 49;
+    var2.write();
+    test.stepApplication();
+    var3.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var3), 49, 0.001);
+    BOOST_CHECK(var2.readNonBlocking() == false);
+    BOOST_CHECK(var3.readNonBlocking() == false);
+
+    // inject value which gets limited
+    var2 = 50;
+    var2.write();
+    test.stepApplication();
+    var2.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var2), 49.5, 0.001);
+    var3.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var3), 49.5, 0.001);
+    BOOST_CHECK(var2.readNonBlocking() == false);
+    BOOST_CHECK(var3.readNonBlocking() == false);
+
+    // change the limit so the current value gets changed
+    max = 48.5;
+    max.write();
+    test.stepApplication();
+    var2.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var2), 48.5, 0.001);
+    var3.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var3), 48.5, 0.001);
+    BOOST_CHECK(var2.readNonBlocking() == false);
+    BOOST_CHECK(var3.readNonBlocking() == false);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testRealisticExample) {
+    std::cout << "*** testRealisticExample" << std::endl;
+
+    TestApplication app;
+    app.a = {&app, ".", ""};
+    app.b = {&app, ".", ""};
+    app.copy = {&app, ".", ""};
+
+    ctk::TestFacility test(app);
+    auto var1 = test.getScalar<int>("var1");
+    auto var1_copied = test.getScalar<int>("var1_out");
+    auto var2 = test.getScalar<double>("var2");
+    auto var3 = test.getScalar<double>("var3");
+    auto max = test.getScalar<double>("max");
+    test.runApplication();
+
+    // set maximum in B, so that var1=49 is still below maximum but var2=50 is
+    // already above and rounding in ModuleB will change the value again
+    max = 49.5 * 2.54;
+    max.write();
+    test.stepApplication();
+
+    // inject value which does not get limited
+    var1 = 49;
+    var1.write();
+    test.stepApplication();
+    var1_copied.read();
+    var2.read();
+    var3.read();
+    BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 49);
+    BOOST_CHECK_CLOSE(static_cast<double>(var2), 49 * 2.54, 0.001);
+    BOOST_CHECK_CLOSE(static_cast<double>(var3), 49 * 2.54, 0.001);
+    BOOST_CHECK(var1.readNonBlocking() == false); // nothing was sent through the return channel
+    BOOST_CHECK(var1_copied.readLatest() == false);
+    BOOST_CHECK(var2.readNonBlocking() == false);
+    BOOST_CHECK(var3.readNonBlocking() == false);
+
+    // inject value which gets limited
     var1 = 50;
     var1.write();
     test.stepApplication();
-    var1.readLatest(); // empty the queues
-    var1_copied.readLatest();
-    var2.readLatest();
-    var3.readLatest();
+    var1.read();
+    BOOST_CHECK_EQUAL(static_cast<int>(var1), 49);
+    var1_copied.read();
+    BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 50);
+    var1_copied.read();
+    BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 49);
+    var2.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var2), 50 * 2.54, 0.001);
+    var2.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var2), 49.5 * 2.54, 0.001);
+    var2.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var2), 49 * 2.54, 0.001);
+    var3.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var3), 49.5 * 2.54, 0.001);
+    var3.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var3), 49 * 2.54, 0.001);
+    BOOST_CHECK(var1.readNonBlocking() == false);
+    BOOST_CHECK(var1_copied.readLatest() == false);
+    BOOST_CHECK(var2.readNonBlocking() == false);
+    BOOST_CHECK(var3.readNonBlocking() == false);
+
+    // change the limit so the current value gets changed
+    max = 48.5 * 2.54;
+    max.write();
+    test.stepApplication();
+    var1.read();
     BOOST_CHECK_EQUAL(static_cast<int>(var1), 48);
+    var1_copied.read();
     BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 48);
+    var2.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var2), 48.5 * 2.54, 0.001);
+    var2.read();
     BOOST_CHECK_CLOSE(static_cast<double>(var2), 48 * 2.54, 0.001);
+    var3.read();
+    BOOST_CHECK_CLOSE(static_cast<double>(var3), 48.5 * 2.54, 0.001);
+    var3.read();
     BOOST_CHECK_CLOSE(static_cast<double>(var3), 48 * 2.54, 0.001);
     BOOST_CHECK(var1.readNonBlocking() == false);
     BOOST_CHECK(var1_copied.readLatest() == false);
     BOOST_CHECK(var2.readNonBlocking() == false);
     BOOST_CHECK(var3.readNonBlocking() == false);
 
-    // concurrent change of value and limit. Note: The final result must be
-    // deterministic, but which values are seen in between is subject to race
-    // conditions between the two concurrent updates. Thus we are using
-    // readLatest() in some cases here.
-    var1 = 30;
-    max = 25.5 * 2.54;
-    var1.write();
-    max.write();
-    test.stepApplication();
-    var1.read();
-    BOOST_CHECK_EQUAL(static_cast<int>(var1), 25);
-    var1_copied.read();
-    BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 30);
-    BOOST_CHECK(var1_copied.readLatest() == true);
-    BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 25);
-    BOOST_CHECK(var2.readLatest() == true);
-    BOOST_CHECK_CLOSE(static_cast<double>(var2), 25 * 2.54, 0.001);
-    BOOST_CHECK(var3.readLatest() == true);
-    BOOST_CHECK_CLOSE(static_cast<double>(var3), 25 * 2.54, 0.001);
-    BOOST_CHECK(var1.readNonBlocking() == false);
-    BOOST_CHECK(var1_copied.readLatest() == false);
-    BOOST_CHECK(var2.readNonBlocking() == false);
-    BOOST_CHECK(var3.readNonBlocking() == false);
+    // Run the following tests a couple of times, as they are testing for the
+    // absence of race conditions. This makes it more likely to find failures in a
+    // single run of the test
+    for(size_t i = 0; i < 10; ++i) {
+      // feed in some default values (so the tests can be executed multiple times
+      // in a row)
+      max = 48.5 * 2.54;
+      max.write();
+      test.stepApplication();
+      var1 = 50;
+      var1.write();
+      test.stepApplication();
+      var1.readLatest(); // empty the queues
+      var1_copied.readLatest();
+      var2.readLatest();
+      var3.readLatest();
+      BOOST_CHECK_EQUAL(static_cast<int>(var1), 48);
+      BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 48);
+      BOOST_CHECK_CLOSE(static_cast<double>(var2), 48 * 2.54, 0.001);
+      BOOST_CHECK_CLOSE(static_cast<double>(var3), 48 * 2.54, 0.001);
+      BOOST_CHECK(var1.readNonBlocking() == false);
+      BOOST_CHECK(var1_copied.readLatest() == false);
+      BOOST_CHECK(var2.readNonBlocking() == false);
+      BOOST_CHECK(var3.readNonBlocking() == false);
 
-    // concurrent change of value and limit - other order than before
-    var1 = 15;
-    max = 20.5 * 2.54;
-    max.write();
-    var1.write();
-    test.stepApplication();
-    var1_copied.read();
-    BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 15);
-    BOOST_CHECK(var2.readLatest() == true);
-    BOOST_CHECK_CLOSE(static_cast<double>(var2), 15 * 2.54, 0.001);
-    BOOST_CHECK(var3.readLatest() == true);
-    BOOST_CHECK_CLOSE(static_cast<double>(var3), 15 * 2.54, 0.001);
-    BOOST_CHECK(var1.readNonBlocking() == false);
-    BOOST_CHECK(var1_copied.readLatest() == false);
-    BOOST_CHECK(var2.readNonBlocking() == false);
-    BOOST_CHECK(var3.readNonBlocking() == false);
-  }
-}
+      // concurrent change of value and limit. Note: The final result must be
+      // deterministic, but which values are seen in between is subject to race
+      // conditions between the two concurrent updates. Thus we are using
+      // readLatest() in some cases here.
+      var1 = 30;
+      max = 25.5 * 2.54;
+      var1.write();
+      max.write();
+      test.stepApplication();
+      var1.read();
+      BOOST_CHECK_EQUAL(static_cast<int>(var1), 25);
+      var1_copied.read();
+      BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 30);
+      BOOST_CHECK(var1_copied.readLatest() == true);
+      BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 25);
+      BOOST_CHECK(var2.readLatest() == true);
+      BOOST_CHECK_CLOSE(static_cast<double>(var2), 25 * 2.54, 0.001);
+      BOOST_CHECK(var3.readLatest() == true);
+      BOOST_CHECK_CLOSE(static_cast<double>(var3), 25 * 2.54, 0.001);
+      BOOST_CHECK(var1.readNonBlocking() == false);
+      BOOST_CHECK(var1_copied.readLatest() == false);
+      BOOST_CHECK(var2.readNonBlocking() == false);
+      BOOST_CHECK(var3.readNonBlocking() == false);
 
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testFunnel) {
-  std::cout << "*** testFunnel" << std::endl;
-
-  FunnelApplication app;
-
-  ctk::TestFacility test(app);
-
-  auto var1 = test.getScalar<int>("var1");
-  auto funnel1out = test.getScalar<int>("/Funnel1/var1out");
-  auto funnel1in = test.getScalar<int>("/Funnel1/var1in");
-  auto funnel2out = test.getScalar<int>("/Funnel2/var1out");
-  auto funnel2in = test.getScalar<int>("/Funnel2/var1in");
-
-  test.runApplication();
-
-  // discard initial values
-  funnel1out.readLatest();
-  funnel2out.readLatest();
-
-  var1.setAndWrite(42);
-  test.stepApplication();
-  BOOST_TEST(!var1.readNonBlocking());
-  BOOST_TEST(funnel1out.readNonBlocking());
-  BOOST_TEST(funnel1out == 42);
-  BOOST_TEST(funnel2out.readNonBlocking());
-  BOOST_TEST(funnel2out == 42);
-
-  funnel1in.setAndWrite(43);
-  test.stepApplication();
-  BOOST_TEST(!funnel1out.readNonBlocking());
-  BOOST_TEST(var1.readNonBlocking());
-  BOOST_TEST(var1 == 43);
-  BOOST_TEST(funnel2out.readNonBlocking());
-  BOOST_TEST(funnel2out == 43);
-
-  funnel2in.setAndWrite(44);
-  test.stepApplication();
-  BOOST_TEST(!funnel2out.readNonBlocking());
-  BOOST_TEST(var1.readNonBlocking());
-  BOOST_TEST(var1 == 44);
-  BOOST_TEST(funnel1out.readNonBlocking());
-  BOOST_TEST(funnel1out == 44);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testStartup) {
-  std::cout << "*** testStartup" << std::endl;
-
-  InitTestApplication testApp;
-  ChimeraTK::TestFacility testFacility(testApp);
-
-  testFacility.setScalarDefault<int>("/ModuleC/var1", 22);
-
-  testFacility.runApplication();
-
-  // The default value should be overwritten when ModuleC enters its mainLoop
-  BOOST_CHECK_EQUAL(testFacility.readScalar<int>("ModuleC/var1"), 42);
-}
-
-/*********************************************************************************************************************/
-
-struct TestApplication2 : ctk::Application {
-  TestApplication2() : Application("testSuite") {}
-  ~TestApplication2() override { shutdown(); }
-
-  // void defineConnections() override { lower.connectTo(upper); }
-
-  template<typename ACCESSOR>
-  struct Module : public ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
-
-    ACCESSOR var{this, "var", "", ""};
-
-    bool sendInitialValue{ctk::VariableNetworkNode(var).getDirection().dir == ctk::VariableDirection::feeding};
-    void prepare() override {
-      if(sendInitialValue) {
-        var.write();
-      }
+      // concurrent change of value and limit - other order than before
+      var1 = 15;
+      max = 20.5 * 2.54;
+      max.write();
+      var1.write();
+      test.stepApplication();
+      var1_copied.read();
+      BOOST_CHECK_EQUAL(static_cast<int>(var1_copied), 15);
+      BOOST_CHECK(var2.readLatest() == true);
+      BOOST_CHECK_CLOSE(static_cast<double>(var2), 15 * 2.54, 0.001);
+      BOOST_CHECK(var3.readLatest() == true);
+      BOOST_CHECK_CLOSE(static_cast<double>(var3), 15 * 2.54, 0.001);
+      BOOST_CHECK(var1.readNonBlocking() == false);
+      BOOST_CHECK(var1_copied.readLatest() == false);
+      BOOST_CHECK(var2.readNonBlocking() == false);
+      BOOST_CHECK(var3.readNonBlocking() == false);
     }
+  }
 
-    boost::latch mainLoopStarted{1};
-    void mainLoop() override { mainLoopStarted.count_down(); }
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testFunnel) {
+    std::cout << "*** testFunnel" << std::endl;
+
+    FunnelApplication app;
+
+    ctk::TestFacility test(app);
+
+    auto var1 = test.getScalar<int>("var1");
+    auto funnel1out = test.getScalar<int>("/Funnel1/var1out");
+    auto funnel1in = test.getScalar<int>("/Funnel1/var1in");
+    auto funnel2out = test.getScalar<int>("/Funnel2/var1out");
+    auto funnel2in = test.getScalar<int>("/Funnel2/var1in");
+
+    test.runApplication();
+
+    // discard initial values
+    funnel1out.readLatest();
+    funnel2out.readLatest();
+
+    var1.setAndWrite(42);
+    test.stepApplication();
+    BOOST_TEST(!var1.readNonBlocking());
+    BOOST_TEST(funnel1out.readNonBlocking());
+    BOOST_TEST(funnel1out == 42);
+    BOOST_TEST(funnel2out.readNonBlocking());
+    BOOST_TEST(funnel2out == 42);
+
+    funnel1in.setAndWrite(43);
+    test.stepApplication();
+    BOOST_TEST(!funnel1out.readNonBlocking());
+    BOOST_TEST(var1.readNonBlocking());
+    BOOST_TEST(var1 == 43);
+    BOOST_TEST(funnel2out.readNonBlocking());
+    BOOST_TEST(funnel2out == 43);
+
+    funnel2in.setAndWrite(44);
+    test.stepApplication();
+    BOOST_TEST(!funnel2out.readNonBlocking());
+    BOOST_TEST(var1.readNonBlocking());
+    BOOST_TEST(var1 == 44);
+    BOOST_TEST(funnel1out.readNonBlocking());
+    BOOST_TEST(funnel1out == 44);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testStartup) {
+    std::cout << "*** testStartup" << std::endl;
+
+    InitTestApplication testApp;
+    ChimeraTK::TestFacility testFacility(testApp);
+
+    testFacility.setScalarDefault<int>("/ModuleC/var1", 22);
+
+    testFacility.runApplication();
+
+    // The default value should be overwritten when ModuleC enters its mainLoop
+    BOOST_CHECK_EQUAL(testFacility.readScalar<int>("ModuleC/var1"), 42);
+  }
+
+  /*********************************************************************************************************************/
+
+  struct TestApplication2 : ctk::Application {
+    TestApplication2() : Application("testSuite") {}
+    ~TestApplication2() override { shutdown(); }
+
+    // void defineConnections() override { lower.connectTo(upper); }
+
+    template<typename ACCESSOR>
+    struct Module : public ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
+
+      ACCESSOR var{this, "var", "", ""};
+
+      bool sendInitialValue{ctk::VariableNetworkNode(var).getDirection().dir == ctk::VariableDirection::feeding};
+      void prepare() override {
+        if(sendInitialValue) {
+          var.write();
+        }
+      }
+
+      boost::latch mainLoopStarted{1};
+      void mainLoop() override { mainLoopStarted.count_down(); }
+    };
+    Module<ctk::ScalarPushInputWB<int>> lower{this, ".", ""};
+    Module<ctk::ScalarOutputPushRB<int>> upper{this, ".", ""};
   };
-  Module<ctk::ScalarPushInputWB<int>> lower{this, ".", ""};
-  Module<ctk::ScalarOutputPushRB<int>> upper{this, ".", ""};
-};
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(testReadWriteAll) {
-  std::cout << "*** testReadWriteAll" << std::endl;
+  BOOST_AUTO_TEST_CASE(testReadWriteAll) {
+    std::cout << "*** testReadWriteAll" << std::endl;
 
-  TestApplication2 app;
-  ChimeraTK::TestFacility test{app};
-
-  test.runApplication();
-
-  // forward channel writeAll/readAll
-  app.upper.var = 42;
-  app.upper.writeAll();
-  app.lower.readAll();
-  BOOST_CHECK_EQUAL(app.lower.var, 42);
-
-  // return channel writeAll
-  app.lower.var = 43;
-  app.lower.writeAll();
-  BOOST_CHECK(app.upper.var.readNonBlocking() == false);
-
-  // return channel readAll
-  app.lower.var.write();
-  app.upper.readAll();
-  BOOST_CHECK_NE(app.upper.var, 43);
-  BOOST_CHECK(app.upper.var.readNonBlocking() == true);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testDataValidityReturn) {
-  std::cout << "*** testDataValidityReturn" << std::endl;
-
-  // forward channel
-  {
     TestApplication2 app;
     ChimeraTK::TestFacility test{app};
 
     test.runApplication();
-    assert(app.lower.getDataValidity() == ctk::DataValidity::ok);
 
-    app.upper.incrementDataFaultCounter();
+    // forward channel writeAll/readAll
+    app.upper.var = 42;
+    app.upper.writeAll();
+    app.lower.readAll();
+    BOOST_CHECK_EQUAL(app.lower.var, 42);
+
+    // return channel writeAll
+    app.lower.var = 43;
+    app.lower.writeAll();
+    BOOST_CHECK(app.upper.var.readNonBlocking() == false);
+
+    // return channel readAll
+    app.lower.var.write();
+    app.upper.readAll();
+    BOOST_CHECK_NE(app.upper.var, 43);
+    BOOST_CHECK(app.upper.var.readNonBlocking() == true);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDataValidityReturn) {
+    std::cout << "*** testDataValidityReturn" << std::endl;
+
+    // forward channel
+    {
+      TestApplication2 app;
+      ChimeraTK::TestFacility test{app};
+
+      test.runApplication();
+      assert(app.lower.getDataValidity() == ctk::DataValidity::ok);
+
+      app.upper.incrementDataFaultCounter();
+      app.upper.var = 666;
+      app.upper.var.write();
+      app.upper.decrementDataFaultCounter();
+      app.lower.var.read();
+      BOOST_CHECK(app.lower.var.dataValidity() == ctk::DataValidity::faulty);
+      BOOST_CHECK(app.lower.getDataValidity() == ctk::DataValidity::faulty);
+    }
+
+    // return channel
+    {
+      TestApplication2 app;
+      ChimeraTK::TestFacility test{app};
+
+      test.runApplication();
+      assert(app.upper.getDataValidity() == ctk::DataValidity::ok);
+      app.lower.incrementDataFaultCounter();
+      app.lower.var = 120;
+      app.lower.var.write();
+      app.upper.var.read();
+      BOOST_CHECK(app.upper.var.dataValidity() == ctk::DataValidity::ok);
+      BOOST_CHECK(app.upper.getDataValidity() == ctk::DataValidity::ok);
+      app.lower.decrementDataFaultCounter();
+
+      // Manually setting the validity of the return channel
+      app.lower.var = 130;
+      app.lower.var.setDataValidity(ctk::DataValidity::faulty);
+      app.lower.var.write();
+      app.upper.var.read();
+      BOOST_CHECK(app.upper.var.dataValidity() == ctk::DataValidity::faulty);
+      BOOST_CHECK(app.upper.getDataValidity() == ctk::DataValidity::faulty);
+
+      //=====================================================================
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testInitialValues) {
+    std::cout << "*** testInitialValues" << std::endl;
+
+    TestApplication2 app;
+    app.upper.sendInitialValue = false;
+    ChimeraTK::TestFacility test(app, false);
+
+    test.runApplication();
+
+    // return channel: upper must start without lower sending anything through the return channel
+    CHECK_TIMEOUT(app.upper.mainLoopStarted.try_wait(), 10000);
+
+    // forward channel: lower must not start without upper sending the initial value
+    usleep(10000);
+    BOOST_CHECK(!app.lower.mainLoopStarted.try_wait());
     app.upper.var = 666;
     app.upper.var.write();
-    app.upper.decrementDataFaultCounter();
-    app.lower.var.read();
-    BOOST_CHECK(app.lower.var.dataValidity() == ctk::DataValidity::faulty);
-    BOOST_CHECK(app.lower.getDataValidity() == ctk::DataValidity::faulty);
+    CHECK_TIMEOUT(app.lower.mainLoopStarted.try_wait(), 10000);
+    BOOST_CHECK_EQUAL(app.lower.var, 666);
   }
 
-  // return channel
-  {
-    TestApplication2 app;
-    ChimeraTK::TestFacility test{app};
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
+  struct ModuleX : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
+
+    ChimeraTK::ScalarOutputPushRB<int> out{this, "/output", "", ""};
+    ChimeraTK::ScalarPushInput<int> in{this, "/input", "", ""};
+    void mainLoop() override {
+      auto g = readAnyGroup();
+      ChimeraTK::TransferElementID id;
+      while(true) {
+        out.setAndWrite(in);
+        id = g.readAny();
+      }
+    }
+  };
+
+  /*********************************************************************************************************************/
+
+  struct ModuleY : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
+
+    ChimeraTK::ScalarPushInputWB<int> in{this, "/output", "", ""};
+    void mainLoop() override {
+      auto g = readAnyGroup();
+      while(true) {
+        g.readAny();
+      }
+    }
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TestApplicationShutdownIssue : ChimeraTK::Application {
+    using ChimeraTK::Application::Application;
+    ~TestApplicationShutdownIssue() override { shutdown(); }
+
+    ModuleX mod1{this, "Mod1", ""};
+    ModuleY mod2{this, "Mod2", ""};
+  };
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testShutdownWithFeedingFanOut) {
+    // This test checks that the FeedingFanOut does not try to propagate the boost::thread_interrupted exception through
+    // the return channel, which will fail with a logic_error (in this particular case) because the return channel has
+    // not yet been written yet and hence its VersionNumber is still 0.
+
+    TestApplicationShutdownIssue app("TestApplicationShutdownIssue");
+    ChimeraTK::TestFacility test(app, true);
     test.runApplication();
-    assert(app.upper.getDataValidity() == ctk::DataValidity::ok);
-    app.lower.incrementDataFaultCounter();
-    app.lower.var = 120;
-    app.lower.var.write();
-    app.upper.var.read();
-    BOOST_CHECK(app.upper.var.dataValidity() == ctk::DataValidity::ok);
-    BOOST_CHECK(app.upper.getDataValidity() == ctk::DataValidity::ok);
-    app.lower.decrementDataFaultCounter();
 
-    // Manually setting the validity of the return channel
-    app.lower.var = 130;
-    app.lower.var.setDataValidity(ctk::DataValidity::faulty);
-    app.lower.var.write();
-    app.upper.var.read();
-    BOOST_CHECK(app.upper.var.dataValidity() == ctk::DataValidity::faulty);
-    BOOST_CHECK(app.upper.getDataValidity() == ctk::DataValidity::faulty);
+    test.writeScalar("/input", 1);
+    test.stepApplication();
 
-    //=====================================================================
+    std::cout << "Will shutdown now" << std::endl;
   }
-}
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(testInitialValues) {
-  std::cout << "*** testInitialValues" << std::endl;
-
-  TestApplication2 app;
-  app.upper.sendInitialValue = false;
-  ChimeraTK::TestFacility test(app, false);
-
-  test.runApplication();
-
-  // return channel: upper must start without lower sending anything through the return channel
-  CHECK_TIMEOUT(app.upper.mainLoopStarted.try_wait(), 10000);
-
-  // forward channel: lower must not start without upper sending the initial value
-  usleep(10000);
-  BOOST_CHECK(!app.lower.mainLoopStarted.try_wait());
-  app.upper.var = 666;
-  app.upper.var.write();
-  CHECK_TIMEOUT(app.lower.mainLoopStarted.try_wait(), 10000);
-  BOOST_CHECK_EQUAL(app.lower.var, 666);
-}
-
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
-
-struct ModuleX : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
-
-  ChimeraTK::ScalarOutputPushRB<int> out{this, "/output", "", ""};
-  ChimeraTK::ScalarPushInput<int> in{this, "/input", "", ""};
-  void mainLoop() override {
-    auto g = readAnyGroup();
-    ChimeraTK::TransferElementID id;
-    while(true) {
-      out.setAndWrite(in);
-      id = g.readAny();
-    }
-  }
-};
-
-/*********************************************************************************************************************/
-
-struct ModuleY : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
-
-  ChimeraTK::ScalarPushInputWB<int> in{this, "/output", "", ""};
-  void mainLoop() override {
-    auto g = readAnyGroup();
-    while(true) {
-      g.readAny();
-    }
-  }
-};
-
-/*********************************************************************************************************************/
-
-struct TestApplicationShutdownIssue : ChimeraTK::Application {
-  using ChimeraTK::Application::Application;
-  ~TestApplicationShutdownIssue() override { shutdown(); }
-
-  ModuleX mod1{this, "Mod1", ""};
-  ModuleY mod2{this, "Mod2", ""};
-};
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testShutdownWithFeedingFanOut) {
-  // This test checks that the FeedingFanOut does not try to propagate the boost::thread_interrupted exception through
-  // the return channel, which will fail with a logic_error (in this particular case) because the return channel has
-  // not yet been written yet and hence its VersionNumber is still 0.
-
-  TestApplicationShutdownIssue app("TestApplicationShutdownIssue");
-  ChimeraTK::TestFacility test(app, true);
-  test.runApplication();
-
-  test.writeScalar("/input", 1);
-  test.stepApplication();
-
-  std::cout << "Will shutdown now" << std::endl;
-}
-
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
+} // namespace Tests::testBidirectionalVariables

--- a/tests/executables_src/testCircularDependencyFaultyFlags.cc
+++ b/tests/executables_src/testCircularDependencyFaultyFlags.cc
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
 // SPDX-License-Identifier: LGPL-3.0-or-later
-#define BOOST_TEST_MODULE testPropagateDataFaultFlag
+#define BOOST_TEST_MODULE testCircularDependencyFaultyFlags
 
 // Tests never terminate when an exception is caught and BOOST_NO_EXCEPTIONS is set, but the exeption's what() message
 // is printed. Without the define the what() message is not printed, but the test ist not stuck... I leave it commented
 // but in the code so you activate when debugging.
-//#define BOOST_NO_EXCEPTIONS
+// #define BOOST_NO_EXCEPTIONS
 #include <boost/test/included/unit_test.hpp>
-//#undef BOOST_NO_EXCEPTIONS
+// #undef BOOST_NO_EXCEPTIONS
 
 #include "ApplicationModule.h"
 #include "DeviceModule.h"
@@ -16,658 +16,662 @@
 #include "VariableGroup.h"
 namespace ctk = ChimeraTK;
 
-// The basic setup has 4 modules connected in a circle
+namespace Tests::testCircularDependencyFaultyFlags {
 
-//// The base module has the inputs and outputs for the circular dependency
-///
-///  To test variable groups for inputs and outputs:
-///  Output 1 and input 2 are always from another module, while input 1 and output 2 live in this module.
-struct TestModuleBase : ctk::ApplicationModule {
-  struct /*InputGroup*/ : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarPushInput<int> circularInput1{this, "circularOutput1", "", ""};
-  } inputGroup;
+  // The basic setup has 4 modules connected in a circle
 
-  struct /*OutputGroup*/ : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> circularOutput2{this, "circularInput2", "", ""};
-  } outputGroup;
+  //// The base module has the inputs and outputs for the circular dependency
+  ///
+  ///  To test variable groups for inputs and outputs:
+  ///  Output 1 and input 2 are always from another module, while input 1 and output 2 live in this module.
+  struct TestModuleBase : ctk::ApplicationModule {
+    struct /*InputGroup*/ : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarPushInput<int> circularInput1{this, "circularOutput1", "", ""};
+    } inputGroup;
 
-  ctk::ScalarPushInput<int> circularInput2{this, "circularInput2", "", ""};
-  ctk::ScalarOutput<int> circularOutput1{this, "circularOutput1", "", ""};
+    struct /*OutputGroup*/ : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> circularOutput2{this, "circularInput2", "", ""};
+    } outputGroup;
 
-  TestModuleBase(const std::string& inputName, const std::string& outputName, ctk::ModuleGroup* owner,
-      const std::string& name, const std::string& description)
-  : ApplicationModule(owner, name, description), inputGroup(this, "../" + inputName, ""),
-    outputGroup(this, "../" + outputName, "") {}
+    ctk::ScalarPushInput<int> circularInput2{this, "circularInput2", "", ""};
+    ctk::ScalarOutput<int> circularOutput1{this, "circularOutput1", "", ""};
 
-  void mainLoop() override {
-    while(true) {
-      circularOutput1 = static_cast<int>(inputGroup.circularInput1);
-      outputGroup.circularOutput2 = static_cast<int>(circularInput2);
+    TestModuleBase(const std::string& inputName, const std::string& outputName, ctk::ModuleGroup* owner,
+        const std::string& name, const std::string& description)
+    : ApplicationModule(owner, name, description), inputGroup(this, "../" + inputName, ""),
+      outputGroup(this, "../" + outputName, "") {}
 
-      writeAll();
-      readAll();
+    void mainLoop() override {
+      while(true) {
+        circularOutput1 = static_cast<int>(inputGroup.circularInput1);
+        outputGroup.circularOutput2 = static_cast<int>(circularInput2);
+
+        writeAll();
+        readAll();
+      }
     }
-  }
-};
+  };
 
-/// ModuleA has two additional inputs to get invalidity flags. It is reading all inputs with ReadAny
-struct ModuleA : TestModuleBase {
-  using TestModuleBase::TestModuleBase;
+  /// ModuleA has two additional inputs to get invalidity flags. It is reading all inputs with ReadAny
+  struct ModuleA : TestModuleBase {
+    using TestModuleBase::TestModuleBase;
 
-  ctk::ScalarPushInput<int> a{this, "a", "", ""};
-  ctk::ScalarPushInput<int> b{this, "b", "", ""};
-  ctk::ScalarOutput<int> circleResult{this, "circleResult", "", ""};
+    ctk::ScalarPushInput<int> a{this, "a", "", ""};
+    ctk::ScalarPushInput<int> b{this, "b", "", ""};
+    ctk::ScalarOutput<int> circleResult{this, "circleResult", "", ""};
 
-  void prepare() override { writeAll(); }
+    void prepare() override { writeAll(); }
 
-  void mainLoop() override {
-    // The circular inputs always are both coming as a pair, but we only want to write once.
-    // Hence we only put one of them into the ReadAnyGroup and always read the second one manually if the first one
-    // is read by the group.
-    ctk::ReadAnyGroup rag({a, b, inputGroup.circularInput1});
+    void mainLoop() override {
+      // The circular inputs always are both coming as a pair, but we only want to write once.
+      // Hence we only put one of them into the ReadAnyGroup and always read the second one manually if the first one
+      // is read by the group.
+      ctk::ReadAnyGroup rag({a, b, inputGroup.circularInput1});
 
-    while(true) {
-      auto id = rag.readAny();
+      while(true) {
+        auto id = rag.readAny();
 
-      // A module with circular inputs and readAny must always actively break the circle. Otherwise for each external
-      // input and n-1 internal inputs and additional data element is inserted into the circle, which will let queues
-      // run over and re-trigger the circle all the time.
-      // This is a very typical scenario for circular connections: A module gets some input, triggers a helper module
-      // which calculates a value that is read back by the first module, and then the first module continues without
-      // re-triggering the circle.
+        // A module with circular inputs and readAny must always actively break the circle. Otherwise for each external
+        // input and n-1 internal inputs and additional data element is inserted into the circle, which will let queues
+        // run over and re-trigger the circle all the time.
+        // This is a very typical scenario for circular connections: A module gets some input, triggers a helper module
+        // which calculates a value that is read back by the first module, and then the first module continues without
+        // re-triggering the circle.
 
-      assert((id == a.getId() || id == b.getId()) || id == inputGroup.circularInput1.getId() ||
-          id == circularInput2.getId());
+        assert((id == a.getId() || id == b.getId()) || id == inputGroup.circularInput1.getId() ||
+            id == circularInput2.getId());
 
-      if(id == inputGroup.circularInput1.getId()) {
-        // Read the other circular input as well. They always come in pairs.
+        if(id == inputGroup.circularInput1.getId()) {
+          // Read the other circular input as well. They always come in pairs.
+          circularInput2.read();
+        }
+
+        if(id == a.getId() || id == b.getId()) {
+          circularOutput1 = static_cast<int>(inputGroup.circularInput1) + a;
+          outputGroup.circularOutput2 = static_cast<int>(circularInput2) + b;
+
+          circularOutput1.write();
+          outputGroup.circularOutput2.write();
+        }
+        else { // new data is from the circular inputs
+          circleResult = static_cast<int>(inputGroup.circularInput1) + circularInput2;
+          circleResult.write();
+        }
+
+      } // while(true)
+    }   // mainLoop
+  };    // ModuleA
+
+  /// ModuleC has a trigger together with a readAll.; (it's a trigger for the circle because there is always something
+  /// at the circular inputs)
+  struct ModuleC : TestModuleBase {
+    using TestModuleBase::TestModuleBase;
+    ctk::ScalarPushInput<int> trigger{this, "trigger", "", ""};
+
+    // Special loop to guarantee that the internal inputs are read first, so we don't have unread data in the queue and
+    // can use the testable mode
+    void mainLoop() override {
+      while(true) {
+        circularOutput1 = static_cast<int>(inputGroup.circularInput1);
+        outputGroup.circularOutput2 = static_cast<int>(circularInput2);
+        writeAll();
+        // readAll();
+        inputGroup.circularInput1.read();
         circularInput2.read();
-      }
-
-      if(id == a.getId() || id == b.getId()) {
-        circularOutput1 = static_cast<int>(inputGroup.circularInput1) + a;
-        outputGroup.circularOutput2 = static_cast<int>(circularInput2) + b;
-
-        circularOutput1.write();
-        outputGroup.circularOutput2.write();
-      }
-      else { // new data is from the circular inputs
-        circleResult = static_cast<int>(inputGroup.circularInput1) + circularInput2;
-        circleResult.write();
-      }
-
-    } // while(true)
-  }   // mainLoop
-};    // ModuleA
-
-/// ModuleC has a trigger together with a readAll.; (it's a trigger for the circle because there is always something at
-/// the circular inputs)
-struct ModuleC : TestModuleBase {
-  using TestModuleBase::TestModuleBase;
-  ctk::ScalarPushInput<int> trigger{this, "trigger", "", ""};
-
-  // Special loop to guarantee that the internal inputs are read first, so we don't have unread data in the queue and
-  // can use the testable mode
-  void mainLoop() override {
-    while(true) {
-      circularOutput1 = static_cast<int>(inputGroup.circularInput1);
-      outputGroup.circularOutput2 = static_cast<int>(circularInput2);
-      writeAll();
-      // readAll();
-      inputGroup.circularInput1.read();
-      circularInput2.read();
-      trigger.read();
-    }
-  }
-};
-
-/// Involve the DeviceModule. Here are some variables from a test device.
-struct ModuleD : TestModuleBase {
-  using TestModuleBase::TestModuleBase;
-  ctk::ScalarPollInput<int> i1{this, "/m1/i1", "", ""};
-  ctk::ScalarPollInput<int> i3{this, "/m1/i3", "", ""};
-  ctk::ScalarOutput<int> o1{this, "/m1/o1", "", ""};
-};
-
-struct TestApplication1 : ctk::Application {
-  TestApplication1() : Application("testSuite") {}
-  ~TestApplication1() override { shutdown(); }
-
-  ModuleA a{"D", "B", this, "A", ""}; // reads like: This is A, gets input from D and writes to B
-  TestModuleBase b{"A", "C", this, "B", ""};
-  ModuleC c{"B", "D", this, "C", ""};
-  ModuleD d{"C", "A", this, "D", ""};
-
-  ctk::DeviceModule device{this, "(dummy?map=testDataValidity1.map)"};
-};
-
-template<typename APP_TYPE>
-struct CircularAppTestFixcture {
-  APP_TYPE app;
-  ctk::TestFacility test{app};
-
-  ctk::ScalarRegisterAccessor<int> a{test.getScalar<int>("A/a")};
-  ctk::ScalarRegisterAccessor<int> b{test.getScalar<int>("A/b")};
-  ctk::ScalarRegisterAccessor<int> cTrigger{test.getScalar<int>("C/trigger")};
-  ctk::ScalarRegisterAccessor<int> aOut1{test.getScalar<int>("A/circularOutput1")};
-  ctk::ScalarRegisterAccessor<int> bOut1{test.getScalar<int>("B/circularOutput1")};
-  ctk::ScalarRegisterAccessor<int> cOut1{test.getScalar<int>("C/circularOutput1")};
-  ctk::ScalarRegisterAccessor<int> dOut1{test.getScalar<int>("D/circularOutput1")};
-  ctk::ScalarRegisterAccessor<int> aIn2{test.getScalar<int>("A/circularInput2")};
-  ctk::ScalarRegisterAccessor<int> bIn2{test.getScalar<int>("B/circularInput2")};
-  ctk::ScalarRegisterAccessor<int> cIn2{test.getScalar<int>("C/circularInput2")};
-  ctk::ScalarRegisterAccessor<int> dIn2{test.getScalar<int>("D/circularInput2")};
-  ctk::ScalarRegisterAccessor<int> circleResult{test.getScalar<int>("A/circleResult")};
-
-  void readAllLatest() {
-    aOut1.readLatest();
-    bOut1.readLatest();
-    cOut1.readLatest();
-    dOut1.readLatest();
-    aIn2.readLatest();
-    bIn2.readLatest();
-    cIn2.readLatest();
-    dIn2.readLatest();
-    circleResult.readLatest();
-  }
-
-  void checkAllDataValidity(ctk::DataValidity validity) {
-    BOOST_CHECK(aOut1.dataValidity() == validity);
-    BOOST_CHECK(bOut1.dataValidity() == validity);
-    BOOST_CHECK(cOut1.dataValidity() == validity);
-    BOOST_CHECK(dOut1.dataValidity() == validity);
-    BOOST_CHECK(aIn2.dataValidity() == validity);
-    BOOST_CHECK(bIn2.dataValidity() == validity);
-    BOOST_CHECK(cIn2.dataValidity() == validity);
-    BOOST_CHECK(dIn2.dataValidity() == validity);
-    BOOST_CHECK(circleResult.dataValidity() == validity);
-  }
-
-  CircularAppTestFixcture() { test.runApplication(); }
-};
-
-/** \anchor dataValidity_test_TestCircularInputDetection
- * Tests Technical specification: data validity propagation
- *  * \ref dataValidity_4_1_1 "4.1.1"  Inputs which are part of a circular dependency are marked as circular input.
- *  * \ref dataValidity_4_1_1_1 "4.1.1.1"  (partly, DeviceModule and other ApplciationModules not tested) Inputs from CS
- * are external inputs.
- *  * \ref dataValidity_4_1_2 "4.1.2"  All modules which have a circular dependency form a circular network.
- */
-BOOST_AUTO_TEST_CASE(TestCircularInputDetection) {
-  TestApplication1 app;
-  ctk::TestFacility test(app);
-
-  test.runApplication();
-  // app.dumpConnections();
-  // app.dump();
-
-  // just test that the circular inputs have been detected correctly
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.a.inputGroup.circularInput1).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.a.circularInput2).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.a.a).isCircularInput() == false);
-  // Check that the circular outputs are not marked as circular inputs. They are in the circle, but they are not inputs.
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.a.circularOutput1).isCircularInput() == false);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.a.outputGroup.circularOutput2).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.b.inputGroup.circularInput1).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.b.circularInput2).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.b.circularOutput1).isCircularInput() == false);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.b.outputGroup.circularOutput2).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.c.inputGroup.circularInput1).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.c.circularInput2).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.c.trigger).isCircularInput() == false);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.c.circularOutput1).isCircularInput() == false);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.c.outputGroup.circularOutput2).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.inputGroup.circularInput1).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.circularInput2).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.circularOutput1).isCircularInput() == false);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.outputGroup.circularOutput2).isCircularInput() == false);
-  // although there are inputs from and outputs to the same device this is not part of the circular network
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.i1).isCircularInput() == false);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.i3).isCircularInput() == false);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.o1).isCircularInput() == false);
-}
-
-/** \anchor dataValidity_test_OneInvalidVariable
- * Tests Technical specification: data validity propagation
- *  * \ref dataValidity_4_1_4 "4.1.4"  Propagation of the invalidity flag in a circle.
- *  * \ref dataValidity_4_1_5 "4.1.5"  Breaking the circular dependency.
- *
- *  This test intentionally does set more than one external input to faulty to make it easier to see where problems are
- * coming from.
- */
-BOOST_FIXTURE_TEST_CASE(OneInvalidVariable, CircularAppTestFixcture<TestApplication1>) {
-  a.setDataValidity(ctk::DataValidity::faulty);
-  a.write();
-  cTrigger.write();
-  test.stepApplication();
-
-  readAllLatest();
-  checkAllDataValidity(ctk::DataValidity::faulty);
-
-  // getting a valid variable in the same module does not resolve the flag
-  b.write();
-  cTrigger.write();
-  test.stepApplication();
-
-  readAllLatest();
-  checkAllDataValidity(ctk::DataValidity::faulty);
-
-  // now resolve the faulty condition
-  a.setDataValidity(ctk::DataValidity::ok);
-  a.write();
-  test.stepApplication();
-
-  readAllLatest();
-  // we check in the app that the input is still invalid, not in the CS
-  BOOST_CHECK(app.a.inputGroup.circularInput1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(app.a.circularInput2.dataValidity() == ctk::DataValidity::faulty);
-  // the circular outputs of A and B are now valid
-  BOOST_CHECK(aOut1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(bOut1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(bIn2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(cIn2.dataValidity() == ctk::DataValidity::ok);
-  // the outputs of C, D and the circularResult have not been written yet
-  BOOST_CHECK(cOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(dOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(aIn2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(dIn2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(circleResult.dataValidity() == ctk::DataValidity::faulty);
-
-  // Now trigger C. The whole circle resolves
-  cTrigger.write();
-  test.stepApplication();
-  readAllLatest();
-
-  checkAllDataValidity(ctk::DataValidity::ok);
-}
-
-/** \anchor dataValidity_test_TwoFaultyInOneModule
- * Tests Technical specification: data validity propagation
- *  * \ref dataValidity_4_1_5 "4.1.5"  Breaking the circular dependency only when all variables go to ok.
- */
-BOOST_FIXTURE_TEST_CASE(TwoFaultyInOneModule, CircularAppTestFixcture<TestApplication1>) {
-  a.setDataValidity(ctk::DataValidity::faulty);
-  a.write();
-  cTrigger.write();
-  test.stepApplication();
-  // new in this test: an additional variable comes in while the internal and other external inputs are invalid
-  b.setDataValidity(ctk::DataValidity::faulty);
-  b.write();
-  cTrigger.write();
-  test.stepApplication();
-
-  // just a cross check
-  readAllLatest();
-  checkAllDataValidity(ctk::DataValidity::faulty);
-
-  a.setDataValidity(ctk::DataValidity::ok);
-  a.write();
-  cTrigger.write();
-  test.stepApplication();
-
-  // everything still faulty as b is faulty
-  readAllLatest();
-  checkAllDataValidity(ctk::DataValidity::faulty);
-
-  b.setDataValidity(ctk::DataValidity::ok);
-  b.write();
-  cTrigger.write();
-  test.stepApplication();
-
-  readAllLatest();
-  checkAllDataValidity(ctk::DataValidity::ok);
-}
-
-/** \anchor dataValidity_test_outputManuallyFaulty
- * Tests Technical specification: data validity propagation
- *  * \ref dataValidity_4_1_8 "4.1.8"  Programmatically setting an output to faulty behaves like external input faulty.
- */
-BOOST_FIXTURE_TEST_CASE(OutputManuallyFaulty, CircularAppTestFixcture<TestApplication1>) {
-  app.a.circularOutput1.setDataValidity(ctk::DataValidity::faulty);
-  a.write();
-  test.stepApplication();
-
-  readAllLatest();
-  // The data validity flag is not ignored, although only circular inputs are invalid
-  // B transports the flag. The A.outputGroup.circularOutput2 is still valid because all inputs are valid.
-  BOOST_CHECK(aOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(bOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(bIn2.dataValidity() == ctk::DataValidity::ok); // this is A.outputGroup.circularOutput2
-  BOOST_CHECK(cIn2.dataValidity() == ctk::DataValidity::faulty);
-  // the outputs of C, D and the circularResult have already been written yet
-  BOOST_CHECK(cOut1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(dOut1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(aIn2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(dIn2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(circleResult.dataValidity() == ctk::DataValidity::ok);
-
-  cTrigger.write();
-  test.stepApplication();
-
-  // Now the whole circle is invalid, except for A.outputGroup.circularOutput2 which has not been written again yet.
-  // (Module A stops the circular propagation because it is using readAny(), which otherwises would lead to more and more
-  //  data packages piling up in the cirle because each external read adds one)
-  readAllLatest();
-  BOOST_CHECK(aOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(bOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(bIn2.dataValidity() == ctk::DataValidity::ok); // this is A.outputGroup.circularOutput2
-  BOOST_CHECK(cIn2.dataValidity() == ctk::DataValidity::faulty);
-  // the outputs of C, D and the circularResult have already been written yet
-  BOOST_CHECK(cOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(dOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(aIn2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(dIn2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(circleResult.dataValidity() == ctk::DataValidity::faulty);
-
-  // If we now complete the circle again, the faulty flag is propagated everywhere
-  a.write();
-  cTrigger.write();
-  test.stepApplication();
-
-  readAllLatest();
-  checkAllDataValidity(ctk::DataValidity::faulty);
-
-  // Check that the situation resolved when the data validity of the output is back to ok
-  app.a.circularOutput1.setDataValidity(ctk::DataValidity::ok);
-  a.write();
-  test.stepApplication();
-
-  readAllLatest();
-  // Module A goes to valid immediately and ignored the invalid circular inputs
-  BOOST_CHECK(aOut1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(bOut1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(bIn2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(cIn2.dataValidity() == ctk::DataValidity::ok);
-  // the outputs of C, D and the circularResult have not been written yet
-  BOOST_CHECK(cOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(dOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(aIn2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(dIn2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(circleResult.dataValidity() == ctk::DataValidity::faulty);
-
-  cTrigger.write();
-  test.stepApplication();
-
-  readAllLatest();
-  checkAllDataValidity(ctk::DataValidity::ok);
-}
-
-/** \anchor dataValidity_test_TwoFaultyInTwoModules
- * Tests Technical specification: data validity propagation
- *  * \ref dataValidity_4_1_5 "4.1.5"  Breaking the circular dependency only when all variables go to ok.
- */
-BOOST_FIXTURE_TEST_CASE(TwoFaultyInTwoModules, CircularAppTestFixcture<TestApplication1>) {
-  a.setDataValidity(ctk::DataValidity::faulty);
-  a.write();
-  cTrigger.write();
-  test.stepApplication();
-  // new in this test: the trigger in C bring an additional invalidity flag.
-  a.write();
-  cTrigger.setDataValidity(ctk::DataValidity::faulty);
-  cTrigger.write();
-  test.stepApplication();
-
-  // just a cross check
-  readAllLatest();
-  checkAllDataValidity(ctk::DataValidity::faulty);
-
-  a.setDataValidity(ctk::DataValidity::ok);
-  a.write();
-  cTrigger.write();
-  test.stepApplication();
-
-  // everything still faulty as b is faulty
-  readAllLatest();
-  checkAllDataValidity(ctk::DataValidity::faulty);
-
-  a.write();
-  cTrigger.setDataValidity(ctk::DataValidity::ok);
-  cTrigger.write();
-  test.stepApplication();
-
-  readAllLatest();
-  // the first half of the circle is not OK yet because no external triggers have arrived at A since
-  // the faultly condition was resolved
-  BOOST_CHECK(aOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(bOut1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(bIn2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(cIn2.dataValidity() == ctk::DataValidity::faulty);
-  // the outputs of C, D and the circularResult have already been written yet
-  BOOST_CHECK(cOut1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(dOut1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(aIn2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(dIn2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(circleResult.dataValidity() == ctk::DataValidity::ok);
-
-  // writing a  resolves the remainging variables
-  a.write();
-  test.stepApplication();
-  readAllLatest();
-  checkAllDataValidity(ctk::DataValidity::ok);
-}
-
-// A more complicated network with three entangled circles and one separate circle.
-// AA-->BB-->CC-->DD-->AA    /->HH
-// ^     |   |     ^       GG<-/
-// |-EE<-|   |->FF-|
-//
-// The important part of this test is to check that the whole network AA,..,FF is always detected for each input,
-// even if the scan is only for a variable that starts the scan in only in a local circle (like AA/fromEE).
-// In addition it tests that not everything is mixed into a single circular network (GG,HH is detected as separate
-// circular network).
-
-// Don't try to pass any data through the network. It will be stuck because there are no real main loops. Only the initial
-// value is passed (write exaclty once, then never read). It's just used to test the static circular network detection.
-
-struct TestModuleBase2 : ctk::ApplicationModule {
-  using ApplicationModule::ApplicationModule;
-
-  // available in all modules
-  ctk::ScalarPushInput<int> fromCS{this, "fromCS", "", ""};
-
-  // default main loop which provides initial values, but does not read or write anything else
-  void mainLoop() override { writeAll(); }
-};
-
-struct AA : TestModuleBase2 {
-  using TestModuleBase2::TestModuleBase2;
-
-  ctk::ScalarPushInput<int> fromEE{this, "fromEE", "", ""};
-  ctk::ScalarPushInput<int> fromDD{this, "fromDD", "", ""};
-
-  struct /*OutputGroup*/ : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> fromAA{this, "fromAA", "", ""};
-  } outputGroup{this, "../BB", ""};
-
-  void prepare() override { writeAll(); } // break circular waiting for initial values
-  void mainLoop() override {}
-};
-
-struct BB : TestModuleBase2 {
-  using TestModuleBase2::TestModuleBase2;
-
-  ctk::ScalarPushInput<int> fromAA{this, "fromAA", "", ""};
-
-  struct /*OutputGroup*/ : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> fromBB{this, "fromBB", "", ""};
-  } outputGroup{this, "../CC", ""};
-
-  struct OutputGroup2 : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> fromBB{this, "fromBB", "", ""};
-  } outputGroup2{this, "../EE", ""};
-};
-
-struct EE : TestModuleBase2 {
-  using TestModuleBase2::TestModuleBase2;
-
-  ctk::ScalarPushInput<int> fromBB{this, "fromBB", "", ""};
-
-  struct /*OutputGroup*/ : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> fromEE{this, "fromEE", "", ""};
-  } outputGroup{this, "../AA", ""};
-};
-
-struct CC : TestModuleBase2 {
-  using TestModuleBase2::TestModuleBase2;
-
-  ctk::ScalarPushInput<int> fromBB{this, "fromBB", "", ""};
-
-  struct /*OutputGroup*/ : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> fromCC{this, "fromCC", "", ""};
-  } outputGroup{this, "../DD", ""};
-
-  struct OutputGroup2 : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> fromCC{this, "fromCC", "", ""};
-  } outputGroup2{this, "../FF", ""};
-};
-
-struct DD : TestModuleBase2 {
-  using TestModuleBase2::TestModuleBase2;
-
-  ctk::ScalarPushInput<int> fromCC{this, "fromCC", "", ""};
-  ctk::ScalarPushInput<int> fromFF{this, "fromFF", "", ""};
-
-  struct /*OutputGroup*/ : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> fromDD{this, "fromDD", "", ""};
-  } outputGroup{this, "../AA", ""};
-};
-
-struct FF : TestModuleBase2 {
-  using TestModuleBase2::TestModuleBase2;
-
-  ctk::ScalarPushInput<int> fromCC{this, "fromCC", "", ""};
-
-  struct /*OutputGroup*/ : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> fromFF{this, "fromFF", "", ""};
-  } outputGroup{this, "../DD", ""};
-};
-
-struct GG : TestModuleBase2 {
-  using TestModuleBase2::TestModuleBase2;
-
-  ctk::ScalarPushInput<int> fromHH{this, "fromHH", "", ""};
-
-  struct /*OutputGroup*/ : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> fromGG{this, "fromGG", "", ""};
-  } outputGroup{this, "../HH", ""};
-
-  void prepare() override { writeAll(); } // break circular waiting for initial values
-  void mainLoop() override {}
-};
-
-struct HH : TestModuleBase2 {
-  using TestModuleBase2::TestModuleBase2;
-
-  ctk::ScalarPushInput<int> fromGG{this, "fromGG", "", ""};
-
-  struct /*OutputGroup*/ : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarOutput<int> fromHH{this, "fromHH", "", ""};
-  } outputGroup{this, "../GG", ""};
-};
-
-struct TestApplication2 : ctk::Application {
-  TestApplication2() : Application("connectionTestSuite") {}
-  ~TestApplication2() override { shutdown(); }
-
-  AA aa{this, "AA", ""};
-  BB bb{this, "BB", ""};
-  CC cc{this, "CC", ""};
-  DD dd{this, "DD", ""};
-  EE ee{this, "EE", ""};
-  FF ff{this, "FF", ""};
-  GG gg{this, "GG", ""};
-  HH hh{this, "HH", ""};
-
- public:
-  // get a copy of the protected circularDependencyNetworks
-  std::map<size_t, std::list<EntityOwner*>> getCircularDependencyNetworks() {
-    return Application::_circularDependencyNetworks;
-  }
-};
-
-/** \anchor dataValidity_test_TestCircularInputDetection2
- * Tests Technical specification: data validity propagation
- *  * \ref dataValidity_4_1_2_1 "4.1.2.1" Entangled circles belong to the same circular network.
- *  * \ref dataValidity_4_1_2_2 "4.1.2.2" There can be multiple disconnected circular networks.
- *  * \ref dataValidity_4_3_2 "4.3.2" Each module and each circular input knows its circular network.
- */
-BOOST_AUTO_TEST_CASE(TestCircularInputDetection2) {
-  TestApplication2 app;
-  ctk::TestFacility test(app);
-
-  test.runApplication();
-  // app.dumpConnections();
-
-  // Check that all inputs have been identified correctly
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.aa.fromEE).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.aa.fromDD).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.aa.fromCS).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.bb.fromAA).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.bb.fromCS).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.cc.fromBB).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.cc.fromCS).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.cc.fromBB).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.cc.fromCS).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.dd.fromCC).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.dd.fromFF).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.dd.fromCS).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.ee.fromBB).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.ee.fromCS).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.ff.fromCC).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.ff.fromCS).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.gg.fromHH).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.gg.fromCS).isCircularInput() == false);
-
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.hh.fromGG).isCircularInput() == true);
-  BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.hh.fromCS).isCircularInput() == false);
-
-  // Check that the networks have been identified correctly
-  auto circularNetworks = app.getCircularDependencyNetworks();
-  BOOST_CHECK_EQUAL(circularNetworks.size(), 2);
-  for(auto& networkIter : app.getCircularDependencyNetworks()) {
-    const auto& id = networkIter.first;
-    auto& network = networkIter.second;
-    // networks have the correct size
-    if(network.size() == 6) {
-      std::list<ctk::EntityOwner*> modules = {&app.aa, &app.bb, &app.cc, &app.dd, &app.ee, &app.ff};
-      for(auto* module : modules) {
-        // all modules are in the network
-        BOOST_CHECK(std::count(network.begin(), network.end(), module) == 1);
-        // each module has the correct network associated
-        BOOST_CHECK_EQUAL(module->getCircularNetworkHash(), id);
+        trigger.read();
       }
     }
-    else if(network.size() == 2) {
-      std::list<ctk::EntityOwner*> modules = {&app.gg, &app.hh};
-      for(auto* module : modules) {
-        BOOST_CHECK(std::count(network.begin(), network.end(), module) == 1);
-        BOOST_CHECK_EQUAL(module->getCircularNetworkHash(), id);
+  };
+
+  /// Involve the DeviceModule. Here are some variables from a test device.
+  struct ModuleD : TestModuleBase {
+    using TestModuleBase::TestModuleBase;
+    ctk::ScalarPollInput<int> i1{this, "/m1/i1", "", ""};
+    ctk::ScalarPollInput<int> i3{this, "/m1/i3", "", ""};
+    ctk::ScalarOutput<int> o1{this, "/m1/o1", "", ""};
+  };
+
+  struct TestApplication1 : ctk::Application {
+    TestApplication1() : Application("testSuite") {}
+    ~TestApplication1() override { shutdown(); }
+
+    ModuleA a{"D", "B", this, "A", ""}; // reads like: This is A, gets input from D and writes to B
+    TestModuleBase b{"A", "C", this, "B", ""};
+    ModuleC c{"B", "D", this, "C", ""};
+    ModuleD d{"C", "A", this, "D", ""};
+
+    ctk::DeviceModule device{this, "(dummy?map=testDataValidity1.map)"};
+  };
+
+  template<typename APP_TYPE>
+  struct CircularAppTestFixcture {
+    APP_TYPE app;
+    ctk::TestFacility test{app};
+
+    ctk::ScalarRegisterAccessor<int> a{test.getScalar<int>("A/a")};
+    ctk::ScalarRegisterAccessor<int> b{test.getScalar<int>("A/b")};
+    ctk::ScalarRegisterAccessor<int> cTrigger{test.getScalar<int>("C/trigger")};
+    ctk::ScalarRegisterAccessor<int> aOut1{test.getScalar<int>("A/circularOutput1")};
+    ctk::ScalarRegisterAccessor<int> bOut1{test.getScalar<int>("B/circularOutput1")};
+    ctk::ScalarRegisterAccessor<int> cOut1{test.getScalar<int>("C/circularOutput1")};
+    ctk::ScalarRegisterAccessor<int> dOut1{test.getScalar<int>("D/circularOutput1")};
+    ctk::ScalarRegisterAccessor<int> aIn2{test.getScalar<int>("A/circularInput2")};
+    ctk::ScalarRegisterAccessor<int> bIn2{test.getScalar<int>("B/circularInput2")};
+    ctk::ScalarRegisterAccessor<int> cIn2{test.getScalar<int>("C/circularInput2")};
+    ctk::ScalarRegisterAccessor<int> dIn2{test.getScalar<int>("D/circularInput2")};
+    ctk::ScalarRegisterAccessor<int> circleResult{test.getScalar<int>("A/circleResult")};
+
+    void readAllLatest() {
+      aOut1.readLatest();
+      bOut1.readLatest();
+      cOut1.readLatest();
+      dOut1.readLatest();
+      aIn2.readLatest();
+      bIn2.readLatest();
+      cIn2.readLatest();
+      dIn2.readLatest();
+      circleResult.readLatest();
+    }
+
+    void checkAllDataValidity(ctk::DataValidity validity) {
+      BOOST_CHECK(aOut1.dataValidity() == validity);
+      BOOST_CHECK(bOut1.dataValidity() == validity);
+      BOOST_CHECK(cOut1.dataValidity() == validity);
+      BOOST_CHECK(dOut1.dataValidity() == validity);
+      BOOST_CHECK(aIn2.dataValidity() == validity);
+      BOOST_CHECK(bIn2.dataValidity() == validity);
+      BOOST_CHECK(cIn2.dataValidity() == validity);
+      BOOST_CHECK(dIn2.dataValidity() == validity);
+      BOOST_CHECK(circleResult.dataValidity() == validity);
+    }
+
+    CircularAppTestFixcture() { test.runApplication(); }
+  };
+
+  /** \anchor dataValidity_test_TestCircularInputDetection
+   * Tests Technical specification: data validity propagation
+   *  * \ref dataValidity_4_1_1 "4.1.1"  Inputs which are part of a circular dependency are marked as circular input.
+   *  * \ref dataValidity_4_1_1_1 "4.1.1.1"  (partly, DeviceModule and other ApplciationModules not tested) Inputs from
+   * CS are external inputs.
+   *  * \ref dataValidity_4_1_2 "4.1.2"  All modules which have a circular dependency form a circular network.
+   */
+  BOOST_AUTO_TEST_CASE(TestCircularInputDetection) {
+    TestApplication1 app;
+    ctk::TestFacility test(app);
+
+    test.runApplication();
+    // app.dumpConnections();
+    // app.dump();
+
+    // just test that the circular inputs have been detected correctly
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.a.inputGroup.circularInput1).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.a.circularInput2).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.a.a).isCircularInput() == false);
+    // Check that the circular outputs are not marked as circular inputs. They are in the circle, but they are not inputs.
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.a.circularOutput1).isCircularInput() == false);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.a.outputGroup.circularOutput2).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.b.inputGroup.circularInput1).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.b.circularInput2).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.b.circularOutput1).isCircularInput() == false);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.b.outputGroup.circularOutput2).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.c.inputGroup.circularInput1).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.c.circularInput2).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.c.trigger).isCircularInput() == false);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.c.circularOutput1).isCircularInput() == false);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.c.outputGroup.circularOutput2).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.inputGroup.circularInput1).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.circularInput2).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.circularOutput1).isCircularInput() == false);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.outputGroup.circularOutput2).isCircularInput() == false);
+    // although there are inputs from and outputs to the same device this is not part of the circular network
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.i1).isCircularInput() == false);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.i3).isCircularInput() == false);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.d.o1).isCircularInput() == false);
+  }
+
+  /** \anchor dataValidity_test_OneInvalidVariable
+   * Tests Technical specification: data validity propagation
+   *  * \ref dataValidity_4_1_4 "4.1.4"  Propagation of the invalidity flag in a circle.
+   *  * \ref dataValidity_4_1_5 "4.1.5"  Breaking the circular dependency.
+   *
+   *  This test intentionally does set more than one external input to faulty to make it easier to see where problems
+   * are coming from.
+   */
+  BOOST_FIXTURE_TEST_CASE(OneInvalidVariable, CircularAppTestFixcture<TestApplication1>) {
+    a.setDataValidity(ctk::DataValidity::faulty);
+    a.write();
+    cTrigger.write();
+    test.stepApplication();
+
+    readAllLatest();
+    checkAllDataValidity(ctk::DataValidity::faulty);
+
+    // getting a valid variable in the same module does not resolve the flag
+    b.write();
+    cTrigger.write();
+    test.stepApplication();
+
+    readAllLatest();
+    checkAllDataValidity(ctk::DataValidity::faulty);
+
+    // now resolve the faulty condition
+    a.setDataValidity(ctk::DataValidity::ok);
+    a.write();
+    test.stepApplication();
+
+    readAllLatest();
+    // we check in the app that the input is still invalid, not in the CS
+    BOOST_CHECK(app.a.inputGroup.circularInput1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(app.a.circularInput2.dataValidity() == ctk::DataValidity::faulty);
+    // the circular outputs of A and B are now valid
+    BOOST_CHECK(aOut1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(bOut1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(bIn2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(cIn2.dataValidity() == ctk::DataValidity::ok);
+    // the outputs of C, D and the circularResult have not been written yet
+    BOOST_CHECK(cOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(dOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(aIn2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(dIn2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(circleResult.dataValidity() == ctk::DataValidity::faulty);
+
+    // Now trigger C. The whole circle resolves
+    cTrigger.write();
+    test.stepApplication();
+    readAllLatest();
+
+    checkAllDataValidity(ctk::DataValidity::ok);
+  }
+
+  /** \anchor dataValidity_test_TwoFaultyInOneModule
+   * Tests Technical specification: data validity propagation
+   *  * \ref dataValidity_4_1_5 "4.1.5"  Breaking the circular dependency only when all variables go to ok.
+   */
+  BOOST_FIXTURE_TEST_CASE(TwoFaultyInOneModule, CircularAppTestFixcture<TestApplication1>) {
+    a.setDataValidity(ctk::DataValidity::faulty);
+    a.write();
+    cTrigger.write();
+    test.stepApplication();
+    // new in this test: an additional variable comes in while the internal and other external inputs are invalid
+    b.setDataValidity(ctk::DataValidity::faulty);
+    b.write();
+    cTrigger.write();
+    test.stepApplication();
+
+    // just a cross check
+    readAllLatest();
+    checkAllDataValidity(ctk::DataValidity::faulty);
+
+    a.setDataValidity(ctk::DataValidity::ok);
+    a.write();
+    cTrigger.write();
+    test.stepApplication();
+
+    // everything still faulty as b is faulty
+    readAllLatest();
+    checkAllDataValidity(ctk::DataValidity::faulty);
+
+    b.setDataValidity(ctk::DataValidity::ok);
+    b.write();
+    cTrigger.write();
+    test.stepApplication();
+
+    readAllLatest();
+    checkAllDataValidity(ctk::DataValidity::ok);
+  }
+
+  /** \anchor dataValidity_test_outputManuallyFaulty
+   * Tests Technical specification: data validity propagation
+   *  * \ref dataValidity_4_1_8 "4.1.8"  Programmatically setting an output to faulty behaves like external input faulty.
+   */
+  BOOST_FIXTURE_TEST_CASE(OutputManuallyFaulty, CircularAppTestFixcture<TestApplication1>) {
+    app.a.circularOutput1.setDataValidity(ctk::DataValidity::faulty);
+    a.write();
+    test.stepApplication();
+
+    readAllLatest();
+    // The data validity flag is not ignored, although only circular inputs are invalid
+    // B transports the flag. The A.outputGroup.circularOutput2 is still valid because all inputs are valid.
+    BOOST_CHECK(aOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(bOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(bIn2.dataValidity() == ctk::DataValidity::ok); // this is A.outputGroup.circularOutput2
+    BOOST_CHECK(cIn2.dataValidity() == ctk::DataValidity::faulty);
+    // the outputs of C, D and the circularResult have already been written yet
+    BOOST_CHECK(cOut1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(dOut1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(aIn2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(dIn2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(circleResult.dataValidity() == ctk::DataValidity::ok);
+
+    cTrigger.write();
+    test.stepApplication();
+
+    // Now the whole circle is invalid, except for A.outputGroup.circularOutput2 which has not been written again yet.
+    // (Module A stops the circular propagation because it is using readAny(), which otherwises would lead to more and more
+    //  data packages piling up in the cirle because each external read adds one)
+    readAllLatest();
+    BOOST_CHECK(aOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(bOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(bIn2.dataValidity() == ctk::DataValidity::ok); // this is A.outputGroup.circularOutput2
+    BOOST_CHECK(cIn2.dataValidity() == ctk::DataValidity::faulty);
+    // the outputs of C, D and the circularResult have already been written yet
+    BOOST_CHECK(cOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(dOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(aIn2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(dIn2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(circleResult.dataValidity() == ctk::DataValidity::faulty);
+
+    // If we now complete the circle again, the faulty flag is propagated everywhere
+    a.write();
+    cTrigger.write();
+    test.stepApplication();
+
+    readAllLatest();
+    checkAllDataValidity(ctk::DataValidity::faulty);
+
+    // Check that the situation resolved when the data validity of the output is back to ok
+    app.a.circularOutput1.setDataValidity(ctk::DataValidity::ok);
+    a.write();
+    test.stepApplication();
+
+    readAllLatest();
+    // Module A goes to valid immediately and ignored the invalid circular inputs
+    BOOST_CHECK(aOut1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(bOut1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(bIn2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(cIn2.dataValidity() == ctk::DataValidity::ok);
+    // the outputs of C, D and the circularResult have not been written yet
+    BOOST_CHECK(cOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(dOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(aIn2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(dIn2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(circleResult.dataValidity() == ctk::DataValidity::faulty);
+
+    cTrigger.write();
+    test.stepApplication();
+
+    readAllLatest();
+    checkAllDataValidity(ctk::DataValidity::ok);
+  }
+
+  /** \anchor dataValidity_test_TwoFaultyInTwoModules
+   * Tests Technical specification: data validity propagation
+   *  * \ref dataValidity_4_1_5 "4.1.5"  Breaking the circular dependency only when all variables go to ok.
+   */
+  BOOST_FIXTURE_TEST_CASE(TwoFaultyInTwoModules, CircularAppTestFixcture<TestApplication1>) {
+    a.setDataValidity(ctk::DataValidity::faulty);
+    a.write();
+    cTrigger.write();
+    test.stepApplication();
+    // new in this test: the trigger in C bring an additional invalidity flag.
+    a.write();
+    cTrigger.setDataValidity(ctk::DataValidity::faulty);
+    cTrigger.write();
+    test.stepApplication();
+
+    // just a cross check
+    readAllLatest();
+    checkAllDataValidity(ctk::DataValidity::faulty);
+
+    a.setDataValidity(ctk::DataValidity::ok);
+    a.write();
+    cTrigger.write();
+    test.stepApplication();
+
+    // everything still faulty as b is faulty
+    readAllLatest();
+    checkAllDataValidity(ctk::DataValidity::faulty);
+
+    a.write();
+    cTrigger.setDataValidity(ctk::DataValidity::ok);
+    cTrigger.write();
+    test.stepApplication();
+
+    readAllLatest();
+    // the first half of the circle is not OK yet because no external triggers have arrived at A since
+    // the faultly condition was resolved
+    BOOST_CHECK(aOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(bOut1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(bIn2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(cIn2.dataValidity() == ctk::DataValidity::faulty);
+    // the outputs of C, D and the circularResult have already been written yet
+    BOOST_CHECK(cOut1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(dOut1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(aIn2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(dIn2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(circleResult.dataValidity() == ctk::DataValidity::ok);
+
+    // writing a  resolves the remainging variables
+    a.write();
+    test.stepApplication();
+    readAllLatest();
+    checkAllDataValidity(ctk::DataValidity::ok);
+  }
+
+  // A more complicated network with three entangled circles and one separate circle.
+  // AA-->BB-->CC-->DD-->AA    /->HH
+  // ^     |   |     ^       GG<-/
+  // |-EE<-|   |->FF-|
+  //
+  // The important part of this test is to check that the whole network AA,..,FF is always detected for each input,
+  // even if the scan is only for a variable that starts the scan in only in a local circle (like AA/fromEE).
+  // In addition it tests that not everything is mixed into a single circular network (GG,HH is detected as separate
+  // circular network).
+
+  // Don't try to pass any data through the network. It will be stuck because there are no real main loops. Only the initial
+  // value is passed (write exaclty once, then never read). It's just used to test the static circular network detection.
+
+  struct TestModuleBase2 : ctk::ApplicationModule {
+    using ApplicationModule::ApplicationModule;
+
+    // available in all modules
+    ctk::ScalarPushInput<int> fromCS{this, "fromCS", "", ""};
+
+    // default main loop which provides initial values, but does not read or write anything else
+    void mainLoop() override { writeAll(); }
+  };
+
+  struct AA : TestModuleBase2 {
+    using TestModuleBase2::TestModuleBase2;
+
+    ctk::ScalarPushInput<int> fromEE{this, "fromEE", "", ""};
+    ctk::ScalarPushInput<int> fromDD{this, "fromDD", "", ""};
+
+    struct /*OutputGroup*/ : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> fromAA{this, "fromAA", "", ""};
+    } outputGroup{this, "../BB", ""};
+
+    void prepare() override { writeAll(); } // break circular waiting for initial values
+    void mainLoop() override {}
+  };
+
+  struct BB : TestModuleBase2 {
+    using TestModuleBase2::TestModuleBase2;
+
+    ctk::ScalarPushInput<int> fromAA{this, "fromAA", "", ""};
+
+    struct /*OutputGroup*/ : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> fromBB{this, "fromBB", "", ""};
+    } outputGroup{this, "../CC", ""};
+
+    struct OutputGroup2 : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> fromBB{this, "fromBB", "", ""};
+    } outputGroup2{this, "../EE", ""};
+  };
+
+  struct EE : TestModuleBase2 {
+    using TestModuleBase2::TestModuleBase2;
+
+    ctk::ScalarPushInput<int> fromBB{this, "fromBB", "", ""};
+
+    struct /*OutputGroup*/ : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> fromEE{this, "fromEE", "", ""};
+    } outputGroup{this, "../AA", ""};
+  };
+
+  struct CC : TestModuleBase2 {
+    using TestModuleBase2::TestModuleBase2;
+
+    ctk::ScalarPushInput<int> fromBB{this, "fromBB", "", ""};
+
+    struct /*OutputGroup*/ : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> fromCC{this, "fromCC", "", ""};
+    } outputGroup{this, "../DD", ""};
+
+    struct OutputGroup2 : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> fromCC{this, "fromCC", "", ""};
+    } outputGroup2{this, "../FF", ""};
+  };
+
+  struct DD : TestModuleBase2 {
+    using TestModuleBase2::TestModuleBase2;
+
+    ctk::ScalarPushInput<int> fromCC{this, "fromCC", "", ""};
+    ctk::ScalarPushInput<int> fromFF{this, "fromFF", "", ""};
+
+    struct /*OutputGroup*/ : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> fromDD{this, "fromDD", "", ""};
+    } outputGroup{this, "../AA", ""};
+  };
+
+  struct FF : TestModuleBase2 {
+    using TestModuleBase2::TestModuleBase2;
+
+    ctk::ScalarPushInput<int> fromCC{this, "fromCC", "", ""};
+
+    struct /*OutputGroup*/ : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> fromFF{this, "fromFF", "", ""};
+    } outputGroup{this, "../DD", ""};
+  };
+
+  struct GG : TestModuleBase2 {
+    using TestModuleBase2::TestModuleBase2;
+
+    ctk::ScalarPushInput<int> fromHH{this, "fromHH", "", ""};
+
+    struct /*OutputGroup*/ : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> fromGG{this, "fromGG", "", ""};
+    } outputGroup{this, "../HH", ""};
+
+    void prepare() override { writeAll(); } // break circular waiting for initial values
+    void mainLoop() override {}
+  };
+
+  struct HH : TestModuleBase2 {
+    using TestModuleBase2::TestModuleBase2;
+
+    ctk::ScalarPushInput<int> fromGG{this, "fromGG", "", ""};
+
+    struct /*OutputGroup*/ : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarOutput<int> fromHH{this, "fromHH", "", ""};
+    } outputGroup{this, "../GG", ""};
+  };
+
+  struct TestApplication2 : ctk::Application {
+    TestApplication2() : Application("connectionTestSuite") {}
+    ~TestApplication2() override { shutdown(); }
+
+    AA aa{this, "AA", ""};
+    BB bb{this, "BB", ""};
+    CC cc{this, "CC", ""};
+    DD dd{this, "DD", ""};
+    EE ee{this, "EE", ""};
+    FF ff{this, "FF", ""};
+    GG gg{this, "GG", ""};
+    HH hh{this, "HH", ""};
+
+   public:
+    // get a copy of the protected circularDependencyNetworks
+    std::map<size_t, std::list<EntityOwner*>> getCircularDependencyNetworks() {
+      return Application::_circularDependencyNetworks;
+    }
+  };
+
+  /** \anchor dataValidity_test_TestCircularInputDetection2
+   * Tests Technical specification: data validity propagation
+   *  * \ref dataValidity_4_1_2_1 "4.1.2.1" Entangled circles belong to the same circular network.
+   *  * \ref dataValidity_4_1_2_2 "4.1.2.2" There can be multiple disconnected circular networks.
+   *  * \ref dataValidity_4_3_2 "4.3.2" Each module and each circular input knows its circular network.
+   */
+  BOOST_AUTO_TEST_CASE(TestCircularInputDetection2) {
+    TestApplication2 app;
+    ctk::TestFacility test(app);
+
+    test.runApplication();
+    // app.dumpConnections();
+
+    // Check that all inputs have been identified correctly
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.aa.fromEE).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.aa.fromDD).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.aa.fromCS).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.bb.fromAA).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.bb.fromCS).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.cc.fromBB).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.cc.fromCS).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.cc.fromBB).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.cc.fromCS).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.dd.fromCC).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.dd.fromFF).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.dd.fromCS).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.ee.fromBB).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.ee.fromCS).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.ff.fromCC).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.ff.fromCS).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.gg.fromHH).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.gg.fromCS).isCircularInput() == false);
+
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.hh.fromGG).isCircularInput() == true);
+    BOOST_CHECK(static_cast<ctk::VariableNetworkNode>(app.hh.fromCS).isCircularInput() == false);
+
+    // Check that the networks have been identified correctly
+    auto circularNetworks = app.getCircularDependencyNetworks();
+    BOOST_CHECK_EQUAL(circularNetworks.size(), 2);
+    for(auto& networkIter : app.getCircularDependencyNetworks()) {
+      const auto& id = networkIter.first;
+      auto& network = networkIter.second;
+      // networks have the correct size
+      if(network.size() == 6) {
+        std::list<ctk::EntityOwner*> modules = {&app.aa, &app.bb, &app.cc, &app.dd, &app.ee, &app.ff};
+        for(auto* module : modules) {
+          // all modules are in the network
+          BOOST_CHECK(std::count(network.begin(), network.end(), module) == 1);
+          // each module has the correct network associated
+          BOOST_CHECK_EQUAL(module->getCircularNetworkHash(), id);
+        }
+      }
+      else if(network.size() == 2) {
+        std::list<ctk::EntityOwner*> modules = {&app.gg, &app.hh};
+        for(auto* module : modules) {
+          BOOST_CHECK(std::count(network.begin(), network.end(), module) == 1);
+          BOOST_CHECK_EQUAL(module->getCircularNetworkHash(), id);
+        }
+      }
+      else {
+        BOOST_CHECK_MESSAGE(false, "Network with wrong number of modules detected: " + std::to_string(network.size()));
       }
     }
-    else {
-      BOOST_CHECK_MESSAGE(false, "Network with wrong number of modules detected: " + std::to_string(network.size()));
-    }
   }
-}
+
+} // namespace Tests::testCircularDependencyFaultyFlags

--- a/tests/executables_src/testConfigReader.cc
+++ b/tests/executables_src/testConfigReader.cc
@@ -18,305 +18,309 @@ namespace ctk = ChimeraTK;
 
 std::string cdd{"(dummy?map=configReaderDevice.map)"};
 
-/*********************************************************************************************************************/
-/* Module to receive the config values */
+namespace Tests::testConfigReader {
 
-struct TestModule : ctk::ApplicationModule {
-  TestModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description)
-  : ctk::ApplicationModule(owner, name, description) {
-    try {
-      theConfigReader = &appConfig();
+  /*********************************************************************************************************************/
+  /* Module to receive the config values */
+
+  struct TestModule : ctk::ApplicationModule {
+    TestModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description)
+    : ctk::ApplicationModule(owner, name, description) {
+      try {
+        theConfigReader = &appConfig();
+      }
+      catch(ctk::logic_error&) {
+        appConfigHasThrown = true;
+      }
     }
-    catch(ctk::logic_error&) {
-      appConfigHasThrown = true;
-    }
-  }
 
-  ctk::ConfigReader* theConfigReader; // just to compare if the correct instance is returned
-  bool appConfigHasThrown{false};
+    ctk::ConfigReader* theConfigReader; // just to compare if the correct instance is returned
+    bool appConfigHasThrown{false};
 
-  ctk::ScalarPushInput<int8_t> var8{this, "var8", "MV/m", "Desc"};
-  ctk::ScalarPushInput<uint8_t> var8u{this, "var8u", "MV/m", "Desc"};
-  ctk::ScalarPushInput<int16_t> var16{this, "var16", "MV/m", "Desc"};
-  ctk::ScalarPushInput<uint16_t> var16u{this, "var16u", "MV/m", "Desc"};
-  ctk::ScalarPushInput<int32_t> var32{this, "var32", "MV/m", "Desc"};
-  ctk::ScalarPushInput<uint32_t> var32u{this, "var32u", "MV/m", "Desc"};
-  ctk::ScalarPushInput<int64_t> var64{this, "var64", "MV/m", "Desc"};
-  ctk::ScalarPushInput<uint64_t> var64u{this, "var64u", "MV/m", "Desc"};
-  ctk::ScalarPushInput<float> varFloat{this, "varFloat", "MV/m", "Desc"};
-  ctk::ScalarPushInput<double> varDouble{this, "varDouble", "MV/m", "Desc"};
-  ctk::ScalarPushInput<std::string> varString{this, "varString", "MV/m", "Desc"};
-  ctk::ScalarPushInput<int32_t> varAnotherInt{this, "varAnotherInt", "MV/m", "Desc"};
-  ctk::ArrayPushInput<int32_t> intArray{this, "intArray", "MV/m", 10, "Desc"};
-  ctk::ArrayPushInput<std::string> stringArray{this, "stringArray", "", 8, "Desc"};
-
-  struct Module1 : ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
+    ctk::ScalarPushInput<int8_t> var8{this, "var8", "MV/m", "Desc"};
+    ctk::ScalarPushInput<uint8_t> var8u{this, "var8u", "MV/m", "Desc"};
     ctk::ScalarPushInput<int16_t> var16{this, "var16", "MV/m", "Desc"};
     ctk::ScalarPushInput<uint16_t> var16u{this, "var16u", "MV/m", "Desc"};
     ctk::ScalarPushInput<int32_t> var32{this, "var32", "MV/m", "Desc"};
     ctk::ScalarPushInput<uint32_t> var32u{this, "var32u", "MV/m", "Desc"};
+    ctk::ScalarPushInput<int64_t> var64{this, "var64", "MV/m", "Desc"};
+    ctk::ScalarPushInput<uint64_t> var64u{this, "var64u", "MV/m", "Desc"};
+    ctk::ScalarPushInput<float> varFloat{this, "varFloat", "MV/m", "Desc"};
+    ctk::ScalarPushInput<double> varDouble{this, "varDouble", "MV/m", "Desc"};
     ctk::ScalarPushInput<std::string> varString{this, "varString", "MV/m", "Desc"};
+    ctk::ScalarPushInput<int32_t> varAnotherInt{this, "varAnotherInt", "MV/m", "Desc"};
+    ctk::ArrayPushInput<int32_t> intArray{this, "intArray", "MV/m", 10, "Desc"};
+    ctk::ArrayPushInput<std::string> stringArray{this, "stringArray", "", 8, "Desc"};
 
-    struct SubModule : ctk::VariableGroup {
+    struct Module1 : ctk::VariableGroup {
       using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarPushInput<int16_t> var16{this, "var16", "MV/m", "Desc"};
+      ctk::ScalarPushInput<uint16_t> var16u{this, "var16u", "MV/m", "Desc"};
+      ctk::ScalarPushInput<int32_t> var32{this, "var32", "MV/m", "Desc"};
       ctk::ScalarPushInput<uint32_t> var32u{this, "var32u", "MV/m", "Desc"};
-      ctk::ArrayPushInput<int32_t> intArray{this, "intArray", "MV/m", 10, "Desc"};
-      ctk::ArrayPushInput<std::string> stringArray{this, "stringArray", "", 8, "Desc"};
+      ctk::ScalarPushInput<std::string> varString{this, "varString", "MV/m", "Desc"};
 
-      struct SubSubModule : ctk::VariableGroup {
+      struct SubModule : ctk::VariableGroup {
         using ctk::VariableGroup::VariableGroup;
-        ctk::ScalarPushInput<int32_t> var32{this, "var32", "MV/m", "Desc"};
         ctk::ScalarPushInput<uint32_t> var32u{this, "var32u", "MV/m", "Desc"};
-      } subsubmodule{this, "subsubmodule", ""};
-    } submodule{this, "submodule", ""};
+        ctk::ArrayPushInput<int32_t> intArray{this, "intArray", "MV/m", 10, "Desc"};
+        ctk::ArrayPushInput<std::string> stringArray{this, "stringArray", "", 8, "Desc"};
 
-  } module1{this, "module1", ""};
+        struct SubSubModule : ctk::VariableGroup {
+          using ctk::VariableGroup::VariableGroup;
+          ctk::ScalarPushInput<int32_t> var32{this, "var32", "MV/m", "Desc"};
+          ctk::ScalarPushInput<uint32_t> var32u{this, "var32u", "MV/m", "Desc"};
+        } subsubmodule{this, "subsubmodule", ""};
+      } submodule{this, "submodule", ""};
 
-  struct Module2 : ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
+    } module1{this, "module1", ""};
 
-    struct AnotherSubModule : ctk::VariableGroup {
+    struct Module2 : ctk::VariableGroup {
       using ctk::VariableGroup::VariableGroup;
-      ctk::ScalarPushInput<double> var1{this, "var1", "m", "Desc"};
-      ctk::ScalarPushInput<double> var2{this, "var2", "kg", "Desc"};
-    } submodule1{this, "submodule1", ""}, submodule2{this, "submodule2", ""};
-  } module2{this, "module2", ""};
 
-  std::atomic<bool> done{false};
+      struct AnotherSubModule : ctk::VariableGroup {
+        using ctk::VariableGroup::VariableGroup;
+        ctk::ScalarPushInput<double> var1{this, "var1", "m", "Desc"};
+        ctk::ScalarPushInput<double> var2{this, "var2", "kg", "Desc"};
+      } submodule1{this, "submodule1", ""}, submodule2{this, "submodule2", ""};
+    } module2{this, "module2", ""};
 
-  void mainLoop() override {
-    // values should be available right away
-    BOOST_CHECK_EQUAL((int8_t)var8, -123);
-    BOOST_CHECK_EQUAL((uint8_t)var8u, 34);
-    BOOST_CHECK_EQUAL((int16_t)var16, -567);
-    BOOST_CHECK_EQUAL((uint16_t)var16u, 678);
-    BOOST_CHECK_EQUAL((int32_t)var32, -345678);
-    BOOST_CHECK_EQUAL((uint32_t)var32u, 234567);
-    BOOST_CHECK_EQUAL((int64_t)var64, -2345678901234567890);
-    BOOST_CHECK_EQUAL((uint64_t)var64u, 12345678901234567890U);
-    BOOST_CHECK_CLOSE((float)varFloat, 3.1415, 0.000001);
-    BOOST_CHECK_CLOSE((double)varDouble, -2.8, 0.000001);
-    BOOST_CHECK_EQUAL((std::string)varString, "My dear mister singing club!");
+    std::atomic<bool> done{false};
 
+    void mainLoop() override {
+      // values should be available right away
+      BOOST_CHECK_EQUAL((int8_t)var8, -123);
+      BOOST_CHECK_EQUAL((uint8_t)var8u, 34);
+      BOOST_CHECK_EQUAL((int16_t)var16, -567);
+      BOOST_CHECK_EQUAL((uint16_t)var16u, 678);
+      BOOST_CHECK_EQUAL((int32_t)var32, -345678);
+      BOOST_CHECK_EQUAL((uint32_t)var32u, 234567);
+      BOOST_CHECK_EQUAL((int64_t)var64, -2345678901234567890);
+      BOOST_CHECK_EQUAL((uint64_t)var64u, 12345678901234567890U);
+      BOOST_CHECK_CLOSE((float)varFloat, 3.1415, 0.000001);
+      BOOST_CHECK_CLOSE((double)varDouble, -2.8, 0.000001);
+      BOOST_CHECK_EQUAL((std::string)varString, "My dear mister singing club!");
+
+      BOOST_CHECK_EQUAL(intArray.getNElements(), 10);
+      for(size_t i = 0; i < 10; ++i) {
+        BOOST_CHECK_EQUAL(intArray[i], 10 - i);
+      }
+
+      BOOST_CHECK_EQUAL(stringArray.getNElements(), 8);
+      for(size_t i = 0; i < 8; ++i) {
+        BOOST_CHECK_EQUAL(stringArray[i], "Hallo" + std::to_string(i + 1));
+      }
+
+      BOOST_CHECK_EQUAL((int16_t)module1.var16, -567);
+      BOOST_CHECK_EQUAL((uint16_t)module1.var16u, 678);
+      BOOST_CHECK_EQUAL((int32_t)module1.var32, -345678);
+      BOOST_CHECK_EQUAL((uint32_t)module1.var32u, 234567);
+      BOOST_CHECK_EQUAL((uint32_t)module1.submodule.var32u, 234567);
+
+      BOOST_CHECK_EQUAL(module1.submodule.intArray.getNElements(), 10);
+      for(size_t i = 0; i < 10; ++i) {
+        BOOST_CHECK_EQUAL(module1.submodule.intArray[i], 10 - i);
+      }
+
+      BOOST_CHECK_EQUAL(module1.submodule.stringArray.getNElements(), 8);
+      for(size_t i = 0; i < 8; ++i) {
+        BOOST_CHECK_EQUAL(module1.submodule.stringArray[i], "Hallo" + std::to_string(i + 1));
+      }
+
+      // no further update shall be received
+      usleep(1000000); // 1 second
+      BOOST_CHECK(!var8.readNonBlocking());
+      BOOST_CHECK(!var8u.readNonBlocking());
+      BOOST_CHECK(!var16.readNonBlocking());
+      BOOST_CHECK(!var16u.readNonBlocking());
+      BOOST_CHECK(!var32.readNonBlocking());
+      BOOST_CHECK(!var32u.readNonBlocking());
+      BOOST_CHECK(!var64.readNonBlocking());
+      BOOST_CHECK(!var64u.readNonBlocking());
+      BOOST_CHECK(!varFloat.readNonBlocking());
+      BOOST_CHECK(!varDouble.readNonBlocking());
+      BOOST_CHECK(!varString.readNonBlocking());
+      BOOST_CHECK(!intArray.readNonBlocking());
+
+      BOOST_CHECK(!module1.var16.readNonBlocking());
+      BOOST_CHECK(!module1.var16u.readNonBlocking());
+      BOOST_CHECK(!module1.var32.readNonBlocking());
+      BOOST_CHECK(!module1.var32u.readNonBlocking());
+      BOOST_CHECK(!module1.submodule.var32u.readNonBlocking());
+      BOOST_CHECK(!module1.submodule.intArray.readNonBlocking());
+      BOOST_CHECK(!module1.submodule.stringArray.readNonBlocking());
+
+      // inform main thread that we are done
+      done = true;
+    }
+  };
+
+  /*********************************************************************************************************************/
+  /* dummy application */
+
+  struct TestApplication : public ctk::Application {
+    TestApplication() : Application("TestApplication") {}
+    ~TestApplication() override { shutdown(); }
+
+    ctk::ConfigReader config{this, "config", "validConfig.xml", {"MyTAG"}};
+    TestModule testModule{this, "config", "The test module"};
+  };
+
+  /*********************************************************************************************************************/
+  /* dummy application with two config readers (to check the exception in ApplicationModule::appConfig()) */
+
+  struct TestApplicationTwoConfigs : public ctk::Application {
+    TestApplicationTwoConfigs() : Application("TestApplicationTwoConfigs") {}
+    ~TestApplicationTwoConfigs() override { shutdown(); }
+
+    ctk::ConfigReader config{this, "config", "validConfig.xml", {"MyTAG"}};
+    ctk::ConfigReader config2{this, "config2", "validConfig.xml"};
+    TestModule testModule{this, "TestModule", "The test module"};
+  };
+
+  /*********************************************************************************************************************/
+  /* dummy application with no config readers (to check the exception in ApplicationModule::appConfig()) */
+
+  struct TestApplicationNoConfigs : public ctk::Application {
+    TestApplicationNoConfigs() : Application("TestApplicationTwoConfigs") {}
+    ~TestApplicationNoConfigs() override { shutdown(); }
+
+    TestModule testModule{this, "TestModule", "The test module"};
+  };
+
+  /*********************************************************************************************************************/
+  /* dummy application which directly connects config reader variables to a device */
+
+  struct TestApplicationWithDevice : public ctk::Application {
+    TestApplicationWithDevice() : Application("TestApplicationWithDevice") {}
+    ~TestApplicationWithDevice() override { shutdown(); }
+
+    ctk::ConfigReader config{this, ".", "validConfig.xml", {"MyTAG"}};
+    ctk::DeviceModule device{this, cdd};
+  };
+
+  /*********************************************************************************************************************/
+  /* test trigger by app variable when connecting a polled device register to an
+   * app variable */
+
+  BOOST_AUTO_TEST_CASE(testConfigReader) {
+    std::cout << "==> testConfigReader" << std::endl;
+
+    TestApplication app;
+    BOOST_CHECK(!app.testModule.appConfigHasThrown);
+    BOOST_CHECK(&(app.config) == app.testModule.theConfigReader);
+
+    // check if values are already accessible
+    BOOST_CHECK_EQUAL(app.config.get<int8_t>("var8"), -123);
+    BOOST_CHECK_EQUAL(app.config.get<uint8_t>("var8u"), 34);
+    BOOST_CHECK_EQUAL(app.config.get<int16_t>("var16"), -567);
+    BOOST_CHECK_EQUAL(app.config.get<uint16_t>("var16u"), 678);
+    BOOST_CHECK_EQUAL(app.config.get<int32_t>("var32"), -345678);
+    BOOST_CHECK_EQUAL(app.config.get<uint32_t>("var32u"), 234567);
+    BOOST_CHECK_EQUAL(app.config.get<int64_t>("var64"), -2345678901234567890);
+    BOOST_CHECK_EQUAL(app.config.get<uint64_t>("var64u"), 12345678901234567890U);
+    BOOST_CHECK_CLOSE(app.config.get<float>("varFloat"), 3.1415, 0.000001);
+    BOOST_CHECK_CLOSE(app.config.get<double>("varDouble"), -2.8, 0.000001);
+    BOOST_CHECK_EQUAL(app.config.get<std::string>("varString"), "My dear mister singing club!");
+
+    std::vector<int> arrayValue = app.config.get<std::vector<int>>("intArray");
+    BOOST_CHECK_EQUAL(arrayValue.size(), 10);
+    for(size_t i = 0; i < 10; ++i) {
+      BOOST_CHECK_EQUAL(arrayValue[i], 10 - i);
+    }
+
+    std::vector<std::string> arrayValueString = app.config.get<std::vector<std::string>>("stringArray");
+    BOOST_CHECK_EQUAL(arrayValueString.size(), 8);
+    for(size_t i = 0; i < 8; ++i) {
+      BOOST_CHECK_EQUAL(arrayValueString[i], "Hallo" + std::to_string(i + 1));
+    }
+
+    BOOST_CHECK_EQUAL(app.config.get<int16_t>("module1/var16"), -567);
+    BOOST_CHECK_EQUAL(app.config.get<uint16_t>("module1/var16u"), 678);
+    BOOST_CHECK_EQUAL(app.config.get<int32_t>("module1/var32"), -345678);
+    BOOST_CHECK_EQUAL(app.config.get<uint32_t>("module1/var32u"), 234567);
+    BOOST_CHECK_EQUAL(app.config.get<uint32_t>("module1/submodule/var32u"), 234567);
+    BOOST_CHECK_EQUAL(app.config.get<uint32_t>("module1/submodule/subsubmodule/var32u"), 234568);
+
+    arrayValue = app.config.get<std::vector<int>>("module1/submodule/intArray");
+    BOOST_CHECK_EQUAL(arrayValue.size(), 10);
+    for(size_t i = 0; i < 10; ++i) {
+      BOOST_CHECK_EQUAL(arrayValue[i], 10 - i);
+    }
+
+    arrayValueString = app.config.get<std::vector<std::string>>("module1/submodule/stringArray");
+    BOOST_CHECK_EQUAL(arrayValueString.size(), 8);
+    for(size_t i = 0; i < 8; ++i) {
+      BOOST_CHECK_EQUAL(arrayValueString[i], "Hallo" + std::to_string(i + 1));
+    }
+
+    // app.config.virtualise().dump();
+    // app.config.connectTo(app.testModule);
+
+    // Cheap way to get a PV manager
+    ctk::TestFacility tf{app, false};
+    tf.runApplication();
+
+    // wait until tests in TestModule::mainLoop() are complete
+    while(!app.testModule.done) {
+      usleep(10000);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testExceptions) {
+    std::cout << "==> testExceptions" << std::endl;
+    {
+      TestApplicationTwoConfigs app;
+      BOOST_CHECK(app.testModule.appConfigHasThrown);
+    }
+    {
+      TestApplicationNoConfigs app;
+      BOOST_CHECK(app.testModule.appConfigHasThrown);
+    }
+    {
+      TestApplication app;
+      // Test get with types mismatch
+      BOOST_CHECK_THROW(app.config.get<uint16_t>("var32u"), ctk::logic_error);
+
+      // Test getting nonexisting varibale
+      BOOST_CHECK_THROW(app.config.get<int>("nonexistentVariable"), ctk::logic_error);
+
+      // Same for arrays
+      // Test get with types mismatch
+      BOOST_CHECK_THROW(app.config.get<std::vector<float>>("module1/submodule/intArray"), ctk::logic_error);
+
+      // Test getting nonexisting varibale
+      BOOST_CHECK_THROW(app.config.get<std::vector<int>>("nonexistentVariable"), ctk::logic_error);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDirectWriteToDevice) {
+    std::cout << "==> testDirectWriteToDevice" << std::endl;
+    TestApplicationWithDevice app;
+    ctk::TestFacility test(app);
+    test.runApplication();
+
+    ctk::Device device(cdd);
+
+    auto var32u = device.getScalarRegisterAccessor<uint32_t>("var32u");
+    auto var16 = device.getScalarRegisterAccessor<int16_t>("var16");
+    auto module1var16 = device.getScalarRegisterAccessor<int16_t>("module1/var16");
+    auto intArray = device.getOneDRegisterAccessor<int32_t>("intArray");
+    var32u.read();
+    var16.read();
+    module1var16.read();
+    intArray.read();
+    BOOST_CHECK_EQUAL(var32u, 234567);
+    BOOST_CHECK_EQUAL(var16, -567);
+    BOOST_CHECK_EQUAL(module1var16, -567);
     BOOST_CHECK_EQUAL(intArray.getNElements(), 10);
     for(size_t i = 0; i < 10; ++i) {
       BOOST_CHECK_EQUAL(intArray[i], 10 - i);
     }
-
-    BOOST_CHECK_EQUAL(stringArray.getNElements(), 8);
-    for(size_t i = 0; i < 8; ++i) {
-      BOOST_CHECK_EQUAL(stringArray[i], "Hallo" + std::to_string(i + 1));
-    }
-
-    BOOST_CHECK_EQUAL((int16_t)module1.var16, -567);
-    BOOST_CHECK_EQUAL((uint16_t)module1.var16u, 678);
-    BOOST_CHECK_EQUAL((int32_t)module1.var32, -345678);
-    BOOST_CHECK_EQUAL((uint32_t)module1.var32u, 234567);
-    BOOST_CHECK_EQUAL((uint32_t)module1.submodule.var32u, 234567);
-
-    BOOST_CHECK_EQUAL(module1.submodule.intArray.getNElements(), 10);
-    for(size_t i = 0; i < 10; ++i) {
-      BOOST_CHECK_EQUAL(module1.submodule.intArray[i], 10 - i);
-    }
-
-    BOOST_CHECK_EQUAL(module1.submodule.stringArray.getNElements(), 8);
-    for(size_t i = 0; i < 8; ++i) {
-      BOOST_CHECK_EQUAL(module1.submodule.stringArray[i], "Hallo" + std::to_string(i + 1));
-    }
-
-    // no further update shall be received
-    usleep(1000000); // 1 second
-    BOOST_CHECK(!var8.readNonBlocking());
-    BOOST_CHECK(!var8u.readNonBlocking());
-    BOOST_CHECK(!var16.readNonBlocking());
-    BOOST_CHECK(!var16u.readNonBlocking());
-    BOOST_CHECK(!var32.readNonBlocking());
-    BOOST_CHECK(!var32u.readNonBlocking());
-    BOOST_CHECK(!var64.readNonBlocking());
-    BOOST_CHECK(!var64u.readNonBlocking());
-    BOOST_CHECK(!varFloat.readNonBlocking());
-    BOOST_CHECK(!varDouble.readNonBlocking());
-    BOOST_CHECK(!varString.readNonBlocking());
-    BOOST_CHECK(!intArray.readNonBlocking());
-
-    BOOST_CHECK(!module1.var16.readNonBlocking());
-    BOOST_CHECK(!module1.var16u.readNonBlocking());
-    BOOST_CHECK(!module1.var32.readNonBlocking());
-    BOOST_CHECK(!module1.var32u.readNonBlocking());
-    BOOST_CHECK(!module1.submodule.var32u.readNonBlocking());
-    BOOST_CHECK(!module1.submodule.intArray.readNonBlocking());
-    BOOST_CHECK(!module1.submodule.stringArray.readNonBlocking());
-
-    // inform main thread that we are done
-    done = true;
-  }
-};
-
-/*********************************************************************************************************************/
-/* dummy application */
-
-struct TestApplication : public ctk::Application {
-  TestApplication() : Application("TestApplication") {}
-  ~TestApplication() override { shutdown(); }
-
-  ctk::ConfigReader config{this, "config", "validConfig.xml", {"MyTAG"}};
-  TestModule testModule{this, "config", "The test module"};
-};
-
-/*********************************************************************************************************************/
-/* dummy application with two config readers (to check the exception in ApplicationModule::appConfig()) */
-
-struct TestApplicationTwoConfigs : public ctk::Application {
-  TestApplicationTwoConfigs() : Application("TestApplicationTwoConfigs") {}
-  ~TestApplicationTwoConfigs() override { shutdown(); }
-
-  ctk::ConfigReader config{this, "config", "validConfig.xml", {"MyTAG"}};
-  ctk::ConfigReader config2{this, "config2", "validConfig.xml"};
-  TestModule testModule{this, "TestModule", "The test module"};
-};
-
-/*********************************************************************************************************************/
-/* dummy application with no config readers (to check the exception in ApplicationModule::appConfig()) */
-
-struct TestApplicationNoConfigs : public ctk::Application {
-  TestApplicationNoConfigs() : Application("TestApplicationTwoConfigs") {}
-  ~TestApplicationNoConfigs() override { shutdown(); }
-
-  TestModule testModule{this, "TestModule", "The test module"};
-};
-
-/*********************************************************************************************************************/
-/* dummy application which directly connects config reader variables to a device */
-
-struct TestApplicationWithDevice : public ctk::Application {
-  TestApplicationWithDevice() : Application("TestApplicationWithDevice") {}
-  ~TestApplicationWithDevice() override { shutdown(); }
-
-  ctk::ConfigReader config{this, ".", "validConfig.xml", {"MyTAG"}};
-  ctk::DeviceModule device{this, cdd};
-};
-
-/*********************************************************************************************************************/
-/* test trigger by app variable when connecting a polled device register to an
- * app variable */
-
-BOOST_AUTO_TEST_CASE(testConfigReader) {
-  std::cout << "==> testConfigReader" << std::endl;
-
-  TestApplication app;
-  BOOST_CHECK(!app.testModule.appConfigHasThrown);
-  BOOST_CHECK(&(app.config) == app.testModule.theConfigReader);
-
-  // check if values are already accessible
-  BOOST_CHECK_EQUAL(app.config.get<int8_t>("var8"), -123);
-  BOOST_CHECK_EQUAL(app.config.get<uint8_t>("var8u"), 34);
-  BOOST_CHECK_EQUAL(app.config.get<int16_t>("var16"), -567);
-  BOOST_CHECK_EQUAL(app.config.get<uint16_t>("var16u"), 678);
-  BOOST_CHECK_EQUAL(app.config.get<int32_t>("var32"), -345678);
-  BOOST_CHECK_EQUAL(app.config.get<uint32_t>("var32u"), 234567);
-  BOOST_CHECK_EQUAL(app.config.get<int64_t>("var64"), -2345678901234567890);
-  BOOST_CHECK_EQUAL(app.config.get<uint64_t>("var64u"), 12345678901234567890U);
-  BOOST_CHECK_CLOSE(app.config.get<float>("varFloat"), 3.1415, 0.000001);
-  BOOST_CHECK_CLOSE(app.config.get<double>("varDouble"), -2.8, 0.000001);
-  BOOST_CHECK_EQUAL(app.config.get<std::string>("varString"), "My dear mister singing club!");
-
-  std::vector<int> arrayValue = app.config.get<std::vector<int>>("intArray");
-  BOOST_CHECK_EQUAL(arrayValue.size(), 10);
-  for(size_t i = 0; i < 10; ++i) {
-    BOOST_CHECK_EQUAL(arrayValue[i], 10 - i);
   }
 
-  std::vector<std::string> arrayValueString = app.config.get<std::vector<std::string>>("stringArray");
-  BOOST_CHECK_EQUAL(arrayValueString.size(), 8);
-  for(size_t i = 0; i < 8; ++i) {
-    BOOST_CHECK_EQUAL(arrayValueString[i], "Hallo" + std::to_string(i + 1));
-  }
-
-  BOOST_CHECK_EQUAL(app.config.get<int16_t>("module1/var16"), -567);
-  BOOST_CHECK_EQUAL(app.config.get<uint16_t>("module1/var16u"), 678);
-  BOOST_CHECK_EQUAL(app.config.get<int32_t>("module1/var32"), -345678);
-  BOOST_CHECK_EQUAL(app.config.get<uint32_t>("module1/var32u"), 234567);
-  BOOST_CHECK_EQUAL(app.config.get<uint32_t>("module1/submodule/var32u"), 234567);
-  BOOST_CHECK_EQUAL(app.config.get<uint32_t>("module1/submodule/subsubmodule/var32u"), 234568);
-
-  arrayValue = app.config.get<std::vector<int>>("module1/submodule/intArray");
-  BOOST_CHECK_EQUAL(arrayValue.size(), 10);
-  for(size_t i = 0; i < 10; ++i) {
-    BOOST_CHECK_EQUAL(arrayValue[i], 10 - i);
-  }
-
-  arrayValueString = app.config.get<std::vector<std::string>>("module1/submodule/stringArray");
-  BOOST_CHECK_EQUAL(arrayValueString.size(), 8);
-  for(size_t i = 0; i < 8; ++i) {
-    BOOST_CHECK_EQUAL(arrayValueString[i], "Hallo" + std::to_string(i + 1));
-  }
-
-  // app.config.virtualise().dump();
-  // app.config.connectTo(app.testModule);
-
-  // Cheap way to get a PV manager
-  ctk::TestFacility tf{app, false};
-  tf.runApplication();
-
-  // wait until tests in TestModule::mainLoop() are complete
-  while(!app.testModule.done) {
-    usleep(10000);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testExceptions) {
-  std::cout << "==> testExceptions" << std::endl;
-  {
-    TestApplicationTwoConfigs app;
-    BOOST_CHECK(app.testModule.appConfigHasThrown);
-  }
-  {
-    TestApplicationNoConfigs app;
-    BOOST_CHECK(app.testModule.appConfigHasThrown);
-  }
-  {
-    TestApplication app;
-    // Test get with types mismatch
-    BOOST_CHECK_THROW(app.config.get<uint16_t>("var32u"), ctk::logic_error);
-
-    // Test getting nonexisting varibale
-    BOOST_CHECK_THROW(app.config.get<int>("nonexistentVariable"), ctk::logic_error);
-
-    // Same for arrays
-    // Test get with types mismatch
-    BOOST_CHECK_THROW(app.config.get<std::vector<float>>("module1/submodule/intArray"), ctk::logic_error);
-
-    // Test getting nonexisting varibale
-    BOOST_CHECK_THROW(app.config.get<std::vector<int>>("nonexistentVariable"), ctk::logic_error);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testDirectWriteToDevice) {
-  std::cout << "==> testDirectWriteToDevice" << std::endl;
-  TestApplicationWithDevice app;
-  ctk::TestFacility test(app);
-  test.runApplication();
-
-  ctk::Device device(cdd);
-
-  auto var32u = device.getScalarRegisterAccessor<uint32_t>("var32u");
-  auto var16 = device.getScalarRegisterAccessor<int16_t>("var16");
-  auto module1var16 = device.getScalarRegisterAccessor<int16_t>("module1/var16");
-  auto intArray = device.getOneDRegisterAccessor<int32_t>("intArray");
-  var32u.read();
-  var16.read();
-  module1var16.read();
-  intArray.read();
-  BOOST_CHECK_EQUAL(var32u, 234567);
-  BOOST_CHECK_EQUAL(var16, -567);
-  BOOST_CHECK_EQUAL(module1var16, -567);
-  BOOST_CHECK_EQUAL(intArray.getNElements(), 10);
-  for(size_t i = 0; i < 10; ++i) {
-    BOOST_CHECK_EQUAL(intArray[i], 10 - i);
-  }
-}
+} // namespace Tests::testConfigReader

--- a/tests/executables_src/testDataValidityPropagation.cc
+++ b/tests/executables_src/testDataValidityPropagation.cc
@@ -26,593 +26,597 @@
 using namespace boost::unit_test_framework;
 namespace ctk = ChimeraTK;
 
-/*********************************************************************************************************************/
+namespace Tests::testDataValidityPropagation {
 
-// A module used for initial value tests:
-// It has an output which is never written to.
-struct TestModule0 : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-  ctk::ScalarPushInput<int> i1{this, "i1", "", ""};
-  ctk::ScalarOutput<int> oNothing{this, "oNothing", "", ""};
-  void mainLoop() override {
-    auto group = readAnyGroup();
-    while(true) {
-      group.readAny();
+  /*********************************************************************************************************************/
+
+  // A module used for initial value tests:
+  // It has an output which is never written to.
+  struct TestModule0 : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+    ctk::ScalarPushInput<int> i1{this, "i1", "", ""};
+    ctk::ScalarOutput<int> oNothing{this, "oNothing", "", ""};
+    void mainLoop() override {
+      auto group = readAnyGroup();
+      while(true) {
+        group.readAny();
+      }
     }
-  }
-};
+  };
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-// module for most of hte data validity propagation tests
-struct TestModule1 : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
+  // module for most of hte data validity propagation tests
+  struct TestModule1 : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  ctk::ScalarPushInput<int> i1{this, "i1", "", ""};
+    ctk::ScalarPushInput<int> i1{this, "i1", "", ""};
 
-  ctk::ScalarOutput<int> o1{this, "o1", "", ""};
+    ctk::ScalarOutput<int> o1{this, "o1", "", ""};
 
-  ctk::ScalarOutput<int> oconst{this, "oconst", "", ""};
+    ctk::ScalarOutput<int> oconst{this, "oconst", "", ""};
 
-  void prepare() override { writeAll(); }
+    void prepare() override { writeAll(); }
 
-  void mainLoop() override {
-    oconst = 1;
-    oconst.setDataValidity(outputValidity);
-    oconst.write();
-    // also provide initial value for o1, in case some module waits on it.
-    // this is important for the testable mode
-    o1 = -1;
-    o1.setDataValidity(outputValidity);
-    o1.write();
-    auto group = readAnyGroup();
-    while(true) {
-      group.readAny();
-      o1 = int(i1);
+    void mainLoop() override {
+      oconst = 1;
+      oconst.setDataValidity(outputValidity);
+      oconst.write();
+      // also provide initial value for o1, in case some module waits on it.
+      // this is important for the testable mode
+      o1 = -1;
       o1.setDataValidity(outputValidity);
       o1.write();
+      auto group = readAnyGroup();
+      while(true) {
+        group.readAny();
+        o1 = int(i1);
+        o1.setDataValidity(outputValidity);
+        o1.write();
+      }
     }
-  }
 
-  // used for overwriting the outputs validities.
-  ctk::DataValidity outputValidity = ctk::DataValidity::ok;
-  int incCalled = 0;
-  int decCalled = 0;
+    // used for overwriting the outputs validities.
+    ctk::DataValidity outputValidity = ctk::DataValidity::ok;
+    int incCalled = 0;
+    int decCalled = 0;
 
-  void incrementDataFaultCounter() override {
-    incCalled++;
-    ctk::ApplicationModule::incrementDataFaultCounter();
-  }
-
-  void decrementDataFaultCounter() override {
-    decCalled++;
-    ctk::ApplicationModule::decrementDataFaultCounter();
-  }
-};
-
-/*********************************************************************************************************************/
-
-struct TestModule2 : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-  ctk::ScalarPushInput<int> i1{this, "i1", "", ""};
-  bool dataValidity1 = true, dataValidity2 = true;
-  void mainLoop() override {
-    auto group = readAnyGroup();
-    while(true) {
-      dataValidity1 = this->getDataValidity() == ctk::DataValidity::ok;
-      this->incrementDataFaultCounter();
-      dataValidity2 = this->getDataValidity() == ctk::DataValidity::ok;
-      this->decrementDataFaultCounter();
-
-      group.readAny();
+    void incrementDataFaultCounter() override {
+      incCalled++;
+      ctk::ApplicationModule::incrementDataFaultCounter();
     }
-  }
-};
 
-/*********************************************************************************************************************/
-
-struct TriggerModule : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-  ctk::ScalarOutput<int> o1{this, "o1", "", ""};
-  void mainLoop() override {
-    // do nothing, we trigger o1 manually in the tests
-    //    while(true) {
-    //      // using boost sleep helps for the interruption point
-    //      boost::this_thread::sleep_for(boost::chrono::milliseconds(200));
-    //      o1=1;
-    //      o1.write();
-    //    }
-  }
-};
-
-/*********************************************************************************************************************/
-
-template<typename ModuleT>
-struct TestApplication1 : ctk::Application {
-  TestApplication1() : Application("testSuite") {}
-  ~TestApplication1() override { shutdown(); }
-
-  ModuleT mod{this, "m1", ""};
-
-  const std::string dummyCdd{"(ExceptionDummy?map=testDataValidityPropagation.map)"};
-
-  TriggerModule m2{this, "m2", ""};
-  ctk::DeviceModule dev{this, dummyCdd, "/m2/o1", &initialiseDev};
-  std::atomic_bool deviceError = false;
-  static void initialiseDev(ChimeraTK::Device&) {
-    bool err = ((TestApplication1&)Application::getInstance()).deviceError;
-    if(err) {
-      throw ChimeraTK::runtime_error("device is not ready.");
+    void decrementDataFaultCounter() override {
+      decCalled++;
+      ctk::ApplicationModule::decrementDataFaultCounter();
     }
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TestModule2 : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+    ctk::ScalarPushInput<int> i1{this, "i1", "", ""};
+    bool dataValidity1 = true, dataValidity2 = true;
+    void mainLoop() override {
+      auto group = readAnyGroup();
+      while(true) {
+        dataValidity1 = this->getDataValidity() == ctk::DataValidity::ok;
+        this->incrementDataFaultCounter();
+        dataValidity2 = this->getDataValidity() == ctk::DataValidity::ok;
+        this->decrementDataFaultCounter();
+
+        group.readAny();
+      }
+    }
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TriggerModule : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+    ctk::ScalarOutput<int> o1{this, "o1", "", ""};
+    void mainLoop() override {
+      // do nothing, we trigger o1 manually in the tests
+      //    while(true) {
+      //      // using boost sleep helps for the interruption point
+      //      boost::this_thread::sleep_for(boost::chrono::milliseconds(200));
+      //      o1=1;
+      //      o1.write();
+      //    }
+    }
+  };
+
+  /*********************************************************************************************************************/
+
+  template<typename ModuleT>
+  struct TestApplication1 : ctk::Application {
+    TestApplication1() : Application("testSuite") {}
+    ~TestApplication1() override { shutdown(); }
+
+    ModuleT mod{this, "m1", ""};
+
+    const std::string dummyCdd{"(ExceptionDummy?map=testDataValidityPropagation.map)"};
+
+    TriggerModule m2{this, "m2", ""};
+    ctk::DeviceModule dev{this, dummyCdd, "/m2/o1", &initialiseDev};
+    std::atomic_bool deviceError = false;
+    static void initialiseDev(ChimeraTK::Device&) {
+      bool err = ((TestApplication1&)Application::getInstance()).deviceError;
+      if(err) {
+        throw ChimeraTK::runtime_error("device is not ready.");
+      }
+    }
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TestApplication3 : ctk::Application {
+    constexpr static char const* ExceptionDummyCDD = "(ExceptionDummy?map=testDataValidityPropagation2.map)";
+    TestApplication3() : Application("testPartiallyInvalidDevice") {}
+    ~TestApplication3() override { shutdown(); }
+
+    TriggerModule m2{this, "m2", ""};
+
+    ctk::DeviceModule device1{this, ExceptionDummyCDD, "/m2/o1"};
+  };
+
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
+
+  /**
+   *  tests the ExceptionDummyPollDecorator of the ExceptionDummyBackend, which provides a way for
+   *  forcing individual (poll-type) device outputs to DataValidity=faulty
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_exceptionDummy) {
+    TestApplication3 app;
+    ctk::TestFacility test{app};
+
+    ChimeraTK::Device dev(TestApplication3::ExceptionDummyCDD);
+
+    auto devI1 = test.getScalar<int>("/dev/i1");
+    auto devI2 = test.getScalar<int>("/dev/i2");
+    test.runApplication();
+    // it seems that the exceptionDummy is created only when app starts.
+    auto exceptionDummy = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(dev.getBackend());
+    assert(exceptionDummy);
+    exceptionDummy->setValidity("/dev/i1", ctk::DataValidity::faulty);
+
+    app.m2.o1 = 1;
+    app.m2.o1.write();
+    test.stepApplication();
+    devI1.read();
+    devI2.read();
+    BOOST_CHECK(devI1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(devI2.dataValidity() == ctk::DataValidity::ok);
   }
-};
-
-/*********************************************************************************************************************/
-
-struct TestApplication3 : ctk::Application {
-  constexpr static char const* ExceptionDummyCDD = "(ExceptionDummy?map=testDataValidityPropagation2.map)";
-  TestApplication3() : Application("testPartiallyInvalidDevice") {}
-  ~TestApplication3() override { shutdown(); }
-
-  TriggerModule m2{this, "m2", ""};
-
-  ctk::DeviceModule device1{this, ExceptionDummyCDD, "/m2/o1"};
-};
-
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
-
-/**
- *  tests the ExceptionDummyPollDecorator of the ExceptionDummyBackend, which provides a way for
- *  forcing individual (poll-type) device outputs to DataValidity=faulty
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_exceptionDummy) {
-  TestApplication3 app;
-  ctk::TestFacility test{app};
-
-  ChimeraTK::Device dev(TestApplication3::ExceptionDummyCDD);
-
-  auto devI1 = test.getScalar<int>("/dev/i1");
-  auto devI2 = test.getScalar<int>("/dev/i2");
-  test.runApplication();
-  // it seems that the exceptionDummy is created only when app starts.
-  auto exceptionDummy = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(dev.getBackend());
-  assert(exceptionDummy);
-  exceptionDummy->setValidity("/dev/i1", ctk::DataValidity::faulty);
-
-  app.m2.o1 = 1;
-  app.m2.o1.write();
-  test.stepApplication();
-  devI1.read();
-  devI2.read();
-  BOOST_CHECK(devI1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(devI2.dataValidity() == ctk::DataValidity::ok);
-}
-
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_1_1 \ref dataValidity_1_1 "1.1"
- * In ApplicationCore each variable has a data validiy flag attached to it. DataValidity can be 'ok' or 'faulty'.
- *
- * Explicit test does not make sense since this is clear if this suite compiles, i.e. expressions
- * testmod1.i1.dataValidity() and testmod1.o1.dataValidity();
- */
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_1_2 \ref dataValidity_1_2 "1.2"
- * This flag is automatically propagated: If any of the inputs of an ApplicationModule is faulty, the data validity of
- * the module becomes faulty, which means all outputs of this module will automatically be flagged as faulty. Fan-outs
- * might be special cases (see 2.4).
- *
- * See \ref testDataValidity_2_3_3
- */
-
-/*********************************************************************************************************************/
-
-/**
- * \anchor testDataValidity_1_3 \ref dataValidity_1_3 "1.3"
- * If a device is in error state, all variables which are read from it shall be marked as 'faulty'. This flag is then
- * propagated through all the modules (via 1.2) so it shows up in the control system.
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_1_3) {
-  // set up an application with a faulty device
-  TestApplication1<TestModule1> app;
-  app.deviceError = true;
-  // testable mode cannot be used here, since it would wait on initial values (which are not provided)
-  ctk::TestFacility test(app, false);
-
-  auto i1 = test.getScalar<int>("/dev/i1");
-  test.runApplication();
-
-  // i1.read() would block here
-  i1.readLatest();
-
-  BOOST_CHECK(i1.dataValidity() == ctk::DataValidity::faulty);
-
-  // if Application does not shutdown, this could be an applicationcore bug that requires a workaround for this test
-  // redmine issue: #8550
-}
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_1_4 \ref dataValidity_1_4 "1.4"
- * The user code has the possibility to query the data validity of the module
- *
- * No explicit test, if test suite compiles it's ok.
- */
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_1_5 \ref dataValidity_1_5 "1.5"
- * The user code has the possibility to set the data validity of the module to 'faulty'. However, the user code cannot
- * actively set the module to 'ok' if any of the module inputs are 'faulty'.
- *
- * No explicit test. The module should use increment/decrement mechanism to set invalid state,
- * which implies it cannot override faulty state.
- * BUT it is actually possible to override getDataValidity in the Module, so spec does not hold strictly!
- *
- */
-
-/*********************************************************************************************************************/
-
-/**
- * app with two chained modules, for \ref testDataValidity_1_6
- */
-struct TestApplication16 : ctk::Application {
-  TestApplication16() : Application("testSuite") {}
-  ~TestApplication16() override { shutdown(); }
-
-  TestModule1 mod1{this, "m1", ""};
-  TestModule1 mod2{this, "m2", ""};
-};
-
-/**
- * \anchor testDataValidity_1_6 \ref dataValidity_1_6 "1.6"
- * The user code can flag individual outputs as bad. However, the user code cannot actively set an output to 'ok' if
- * the data validity of the module is 'faulty'.
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_1_6) {
-  TestApplication16 app;
-  app.mod2.i1 = {&app.mod2, "/m1/o1", "", ""};
-
-  app.mod1.outputValidity = ctk::DataValidity::faulty;
-  app.mod2.outputValidity = ctk::DataValidity::ok;
-  ctk::TestFacility test{app};
-
-  // app.dumpConnections();
-  auto input = test.getScalar<int>("/m1/i1");
-  auto result = test.getScalar<int>("/m2/o1");
-  test.runApplication();
-  result.readLatest();
-
-  input.write();
-  test.stepApplication();
-  input.write();
-  test.stepApplication();
-
-  // module 2 must be flagged bad because of the faulty input from module 1
-  BOOST_CHECK(app.mod2.getDataValidity() == ctk::DataValidity::faulty);
-  result.read();
-  // output of module 2 cannot be valid, even if module tries to set it to valid
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
-}
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_1_7 \ref dataValidity_1_7 "1.7"
- *  The user code can get the data validity flag of individual inputs and take special actions.
- *
- *  No explicit test required.
- */
-
-/*********************************************************************************************************************/
-
-/**
- * \anchor testDataValidity_1_8 \ref dataValidity_1_8 "1.8"
- * The data validity of receiving variables is set to 'faulty' on construction. Like this, data is marked as faulty as
- * long as no sensible initial values have been propagated.
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_1_8) {
-  TestApplication1<TestModule0> app;
-  // testable mode cannot be used here, since it would wait on initial values (which are not provided)
-  ctk::TestFacility test(app, false);
-
-  auto o0 = test.getScalar<int>("/m1/oNothing");
-  test.runApplication();
-
-  // o0.read() would block here
-  BOOST_CHECK(o0.readNonBlocking() == false);
-
-  BOOST_CHECK(o0.dataValidity() == ctk::DataValidity::faulty);
-}
-
-/*********************************************************************************************************************/
-
-/**
- * \anchor testDataValidity_2_1_1 \ref dataValidity_2_1_1 "2.1.1"
- * Each input and each output of a module (or fan out) is decorated with a MetaDataPropagatingRegisterDecorator
- *  (except for the TriggerFanOut, see. \ref dataValidity_2_4 "2.4")
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_2_1_1) {
-  TestApplication1<TestModule1> app;
-  ctk::TestFacility test{app};
-  auto i1 = test.getScalar<int>("/m1/i1");
-  test.runApplication();
-  assert(app.mod.getDataValidity() == ctk::DataValidity::ok);
-  // we cannot check inputs via dynamic_cast to MetaDataPropagatingRegisterDecorator, since implementation detail is
-  // hidden by TransferElementAbstractor instead, check what the decorator is supposed to do. check that the
-  // MetaDataPropagatingRegisterDecorator counts data validity changes ( in doPostRead)
-  i1 = 0;
-  i1.write();
-  test.stepApplication(); // triggers m1.i1.read()
-  i1.setDataValidity(ctk::DataValidity::faulty);
-  i1.write();
-  test.stepApplication(); // triggers m1.i1.read()
-  BOOST_CHECK(app.mod.incCalled == 1);
-  BOOST_CHECK(app.mod.decCalled == 0);
-
-  // check that the MetaDataPropagatingRegisterDecorator takes over faulty data validity from owning module ( in doPreWrite)
-  BOOST_CHECK(app.mod.getDataValidity() == ctk::DataValidity::faulty);
-}
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_2_1_2 \ref dataValidity_2_1_2 "2.1.2"
- * The decorator knows about the module it is connected to. It is called the 'owner'.
- *
- * There is no public function for getting the owner, but implicitly this was tested in \ref testDataValidity_2_1_1.
- */
-
-/*********************************************************************************************************************/
-
-/**
- * \anchor testDataValidity_2_1_3 \ref dataValidity_2_1_3 "2.1.3"
- *  **read:** For each read operation it checks the incoming data validity and increases/decreases the data fault
- *  counter of the owner.
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_2_1_3) {
-  TestApplication1<TestModule1> app;
-  ctk::TestFacility test{app};
-
-  auto i1 = test.getScalar<int>("/m1/i1");
-
-  test.runApplication();
-  // mark input faulty
-  i1 = 1;
-  i1.setDataValidity(ctk::DataValidity::faulty);
-  i1.write();
-  // propagate value
-  test.stepApplication();
-  // check that fault counter was incremented
-  BOOST_CHECK(app.mod.incCalled == 1);
-  // mark input ok
-  i1.setDataValidity(ctk::DataValidity::ok);
-  i1.write();
-  // propagate value
-  test.stepApplication();
-  // check that fault counter was decremented
-  BOOST_CHECK(app.mod.decCalled == 1);
-}
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_2_1_5 \ref dataValidity_2_1_5 "2.1.5"
- * **write:** When writing, the decorator is checking the validity of the owner and the individual flag of the output
- * set by the user. Only if both are 'ok' the output validity is 'ok', otherwise the outgoing data is send as 'faulty'.
- *
- * Test ist identical to \ref testDataValidity_1_6
- */
-
-/*********************************************************************************************************************/
-
-/**
- * \anchor testDataValidity_2_3_1 \ref dataValidity_2_3_1  "2.3.1"
- * Each ApplicationModule has one data fault counter variable which is increased/decreased by
- * EntityOwner::incrementDataFaultCounter() and  EntityOwner::decrementDataFaultCounter.
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_2_3_1) {
-  TestModule1 testmod1;
-  BOOST_CHECK(testmod1.getDataValidity() == ctk::DataValidity::ok);
-  testmod1.incrementDataFaultCounter();
-  BOOST_CHECK(testmod1.getDataValidity() == ctk::DataValidity::faulty);
-  testmod1.decrementDataFaultCounter();
-  BOOST_CHECK(testmod1.getDataValidity() == ctk::DataValidity::ok);
-}
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_2_3_2 \ref dataValidity_2_3_2 "2.3.2"
- * All inputs and outputs have a MetaDataPropagatingRegisterDecorator.
- *
- * Tested in \ref testDataValidity_2_1_1
- */
-
-/*********************************************************************************************************************/
-
-/**
- * \anchor testDataValidity_2_3_3 \ref dataValidity_2_3_3 "2.3.3"
- * The main loop of the module usually does not care about data validity. If any input is invalid, all outputs are
- * automatically invalid. The loop just runs through normally, even if an input has invalid data.
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_2_3_3) {
-  TestApplication1<TestModule1> app;
-  ctk::TestFacility test{app};
-
-  auto i1 = test.getScalar<int>("/m1/i1");
-  auto o1 = test.getScalar<int>("/m1/o1");
-  auto oconst = test.getScalar<int>("/m1/oconst");
-  test.runApplication();
-  o1.readLatest();
-  oconst.readLatest();
-
-  i1 = 1;
-  i1.setDataValidity(ctk::DataValidity::faulty);
-  i1.write();
-
-  test.stepApplication();
-
-  // check that an output which is re-calculated becomes invalid
-  // we need to get the destination of o1.write(), which is unlike o1.dataValidity() inside the module main loop
-  o1.read();
-  BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
-  // check that an output which is not re-calculated stays valid
-  BOOST_CHECK(oconst.readLatest() == false);
-}
-
-/*********************************************************************************************************************/
-
-/**
- * \anchor testDataValidity_2_3_4 \ref dataValidity_2_3_4 "2.3.4"
- * Inside the ApplicationModule main loop the module's data fault counter is accessible. The user can increment and
- * decrement it, but has to be careful to do this in pairs. The more common use case will be to query the module's
- * data validity.
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_2_3_4) {
-  TestApplication1<TestModule2> app;
-  ctk::TestFacility test{app};
-
-  auto i1 = test.getScalar<int>("/m1/i1");
-  test.runApplication();
-  i1.write();
-  test.stepApplication();
-  // check that module variable v2 reports faulty
-  BOOST_CHECK(app.mod.dataValidity2 == false);
-
-  i1 = 1;
-  i1.setDataValidity(ctk::DataValidity::faulty);
-  i1.write();
-  test.stepApplication();
-  // check that module variable v1 now also reports faulty
-  BOOST_CHECK(app.mod.dataValidity1 == false);
-}
-
-/*********************************************************************************************************************/
-
-/**
- * \anchor testDataValidity_2_4_1 \ref dataValidity_2_4_1 "2.4.1"
- * Only the push-type trigger input of the TriggerFanOut is equiped with a MetaDataPropagatingRegisterDecorator.
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_2_4_1) {
-  TestApplication1<TestModule1> app;
-  ctk::TestFacility test{app};
-  // app.debugTestableMode();
-
-  // the TriggerFanOut is realized via device module connected to control system,
-  // using a trigger from TriggerModule
-  auto result1 = test.getScalar<int>("dev/i3"); // RO
-
-  test.runApplication();
-
-  // check that setting trigger to invalid propagates to outputs of TriggerFanOut
-  app.m2.o1.setDataValidity(ctk::DataValidity::faulty);
-  app.m2.o1.write();
-
-  test.stepApplication();
-  result1.read();
-  BOOST_CHECK(result1.dataValidity() == ctk::DataValidity::faulty);
-}
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_2_4_2 \ref dataValidity_2_4_2 "2.4.2"
- * The poll-type data inputs do not have a MetaDataPropagatingRegisterDecorator.
- *
- * No functionality that needs testing
- */
-
-/*********************************************************************************************************************/
-
-/**
- * \anchor testDataValidity_2_4_3 \ref dataValidity_2_4_3 "2.4.3"
- * The individual poll-type inputs propagate the data validity flag only to the corresponding outputs.
- */
-BOOST_AUTO_TEST_CASE(testDataValidity_2_4_3) {
-  TestApplication1<TestModule1> app;
-  ctk::TestFacility test{app};
-
-  // the TriggerFanOut is realized via device module connected to control system,
-  // using a trigger from TriggerModule
-  auto result1 = test.getScalar<int>("/dev/i1");
-  auto result2 = test.getScalar<int>("/dev/i3");
-
-  ctk::Device dev(app.dummyCdd);
-
-  test.runApplication();
-  auto exceptionDummy = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(dev.getBackend());
-  assert(exceptionDummy);
-  exceptionDummy->setValidity("/dev/i1", ctk::DataValidity::faulty);
-
-  app.m2.o1.write();
-  test.stepApplication();
-  result1.read();
-  BOOST_CHECK(result1.dataValidity() == ctk::DataValidity::faulty);
-  result2.read();
-  BOOST_CHECK(result2.dataValidity() == ctk::DataValidity::ok);
-}
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_2_4_4 \ref dataValidity_2_4_4 "2.4.4"
- * Although the trigger conceptually has data type 'void', it can also be `faulty`. An invalid trigger is processed,
- * but all read out data is flagged as `faulty`.
- *
- * Already tested in \ref testDataValidity_2_4_1
- */
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_2_5_1 \ref dataValidity_2_5_1 "2.5.1"
- * The MetaDataPropagatingRegisterDecorator is always placed *around* the ExceptionHandlingDecorator if both
- * decorators are used on a process variable. Like this a `faulty` flag raised by the ExceptionHandlingDecorator is
- * automatically picked up by the MetaDataPropagatingRegisterDecorator.
- *
- * Already tested in  \ref testDataValidity_1_3
- */
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_2_5_2 \ref dataValidity_2_5_2 "2.5.2"
- * The first failing read returns with the old data and the 'faulty' flag. Like this the flag is propagated to the
- * outputs. Only further reads might freeze until the device is available again.
- *
- *  Already tested in  \ref testDataValidity_1_3
- */
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidity_2_6_1 \ref dataValidity_2_6_1 "2.6.1"
- * For device variables, the requirement of setting receiving endpoints to 'faulty' on construction can not be
- * fulfilled. In DeviceAccess the accessors are bidirectional and provide no possibility to distinguish sender and
- * receiver. Instead, the validity is set right after construction in Application::createDeviceVariable() for receivers.
- *
- * Already tested in  \ref testDataValidity_1_3
- */
-
-/*********************************************************************************************************************/
-
-/*
- * \anchor testDataValidiy_3_1 \ref dataValidity_3_1 "3.1"
- * The decorators which manipulate the data fault counter are responsible for counting up and down in pairs, such that
- * the counter goes back to 0 if all data is ok, and never becomes negative.
- *
- * Not tested since it's an implementation detail.
- */
-
-/*********************************************************************************************************************/
-
-// BOOST_AUTO_TEST_SUITE_END()
+
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_1_1 \ref dataValidity_1_1 "1.1"
+   * In ApplicationCore each variable has a data validiy flag attached to it. DataValidity can be 'ok' or 'faulty'.
+   *
+   * Explicit test does not make sense since this is clear if this suite compiles, i.e. expressions
+   * testmod1.i1.dataValidity() and testmod1.o1.dataValidity();
+   */
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_1_2 \ref dataValidity_1_2 "1.2"
+   * This flag is automatically propagated: If any of the inputs of an ApplicationModule is faulty, the data validity of
+   * the module becomes faulty, which means all outputs of this module will automatically be flagged as faulty. Fan-outs
+   * might be special cases (see 2.4).
+   *
+   * See \ref testDataValidity_2_3_3
+   */
+
+  /*********************************************************************************************************************/
+
+  /**
+   * \anchor testDataValidity_1_3 \ref dataValidity_1_3 "1.3"
+   * If a device is in error state, all variables which are read from it shall be marked as 'faulty'. This flag is then
+   * propagated through all the modules (via 1.2) so it shows up in the control system.
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_1_3) {
+    // set up an application with a faulty device
+    TestApplication1<TestModule1> app;
+    app.deviceError = true;
+    // testable mode cannot be used here, since it would wait on initial values (which are not provided)
+    ctk::TestFacility test(app, false);
+
+    auto i1 = test.getScalar<int>("/dev/i1");
+    test.runApplication();
+
+    // i1.read() would block here
+    i1.readLatest();
+
+    BOOST_CHECK(i1.dataValidity() == ctk::DataValidity::faulty);
+
+    // if Application does not shutdown, this could be an applicationcore bug that requires a workaround for this test
+    // redmine issue: #8550
+  }
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_1_4 \ref dataValidity_1_4 "1.4"
+   * The user code has the possibility to query the data validity of the module
+   *
+   * No explicit test, if test suite compiles it's ok.
+   */
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_1_5 \ref dataValidity_1_5 "1.5"
+   * The user code has the possibility to set the data validity of the module to 'faulty'. However, the user code cannot
+   * actively set the module to 'ok' if any of the module inputs are 'faulty'.
+   *
+   * No explicit test. The module should use increment/decrement mechanism to set invalid state,
+   * which implies it cannot override faulty state.
+   * BUT it is actually possible to override getDataValidity in the Module, so spec does not hold strictly!
+   *
+   */
+
+  /*********************************************************************************************************************/
+
+  /**
+   * app with two chained modules, for \ref testDataValidity_1_6
+   */
+  struct TestApplication16 : ctk::Application {
+    TestApplication16() : Application("testSuite") {}
+    ~TestApplication16() override { shutdown(); }
+
+    TestModule1 mod1{this, "m1", ""};
+    TestModule1 mod2{this, "m2", ""};
+  };
+
+  /**
+   * \anchor testDataValidity_1_6 \ref dataValidity_1_6 "1.6"
+   * The user code can flag individual outputs as bad. However, the user code cannot actively set an output to 'ok' if
+   * the data validity of the module is 'faulty'.
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_1_6) {
+    TestApplication16 app;
+    app.mod2.i1 = {&app.mod2, "/m1/o1", "", ""};
+
+    app.mod1.outputValidity = ctk::DataValidity::faulty;
+    app.mod2.outputValidity = ctk::DataValidity::ok;
+    ctk::TestFacility test{app};
+
+    // app.dumpConnections();
+    auto input = test.getScalar<int>("/m1/i1");
+    auto result = test.getScalar<int>("/m2/o1");
+    test.runApplication();
+    result.readLatest();
+
+    input.write();
+    test.stepApplication();
+    input.write();
+    test.stepApplication();
+
+    // module 2 must be flagged bad because of the faulty input from module 1
+    BOOST_CHECK(app.mod2.getDataValidity() == ctk::DataValidity::faulty);
+    result.read();
+    // output of module 2 cannot be valid, even if module tries to set it to valid
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+  }
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_1_7 \ref dataValidity_1_7 "1.7"
+   *  The user code can get the data validity flag of individual inputs and take special actions.
+   *
+   *  No explicit test required.
+   */
+
+  /*********************************************************************************************************************/
+
+  /**
+   * \anchor testDataValidity_1_8 \ref dataValidity_1_8 "1.8"
+   * The data validity of receiving variables is set to 'faulty' on construction. Like this, data is marked as faulty as
+   * long as no sensible initial values have been propagated.
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_1_8) {
+    TestApplication1<TestModule0> app;
+    // testable mode cannot be used here, since it would wait on initial values (which are not provided)
+    ctk::TestFacility test(app, false);
+
+    auto o0 = test.getScalar<int>("/m1/oNothing");
+    test.runApplication();
+
+    // o0.read() would block here
+    BOOST_CHECK(o0.readNonBlocking() == false);
+
+    BOOST_CHECK(o0.dataValidity() == ctk::DataValidity::faulty);
+  }
+
+  /*********************************************************************************************************************/
+
+  /**
+   * \anchor testDataValidity_2_1_1 \ref dataValidity_2_1_1 "2.1.1"
+   * Each input and each output of a module (or fan out) is decorated with a MetaDataPropagatingRegisterDecorator
+   *  (except for the TriggerFanOut, see. \ref dataValidity_2_4 "2.4")
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_2_1_1) {
+    TestApplication1<TestModule1> app;
+    ctk::TestFacility test{app};
+    auto i1 = test.getScalar<int>("/m1/i1");
+    test.runApplication();
+    assert(app.mod.getDataValidity() == ctk::DataValidity::ok);
+    // we cannot check inputs via dynamic_cast to MetaDataPropagatingRegisterDecorator, since implementation detail is
+    // hidden by TransferElementAbstractor instead, check what the decorator is supposed to do. check that the
+    // MetaDataPropagatingRegisterDecorator counts data validity changes ( in doPostRead)
+    i1 = 0;
+    i1.write();
+    test.stepApplication(); // triggers m1.i1.read()
+    i1.setDataValidity(ctk::DataValidity::faulty);
+    i1.write();
+    test.stepApplication(); // triggers m1.i1.read()
+    BOOST_CHECK(app.mod.incCalled == 1);
+    BOOST_CHECK(app.mod.decCalled == 0);
+
+    // check that the MetaDataPropagatingRegisterDecorator takes over faulty data validity from owning module ( in doPreWrite)
+    BOOST_CHECK(app.mod.getDataValidity() == ctk::DataValidity::faulty);
+  }
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_2_1_2 \ref dataValidity_2_1_2 "2.1.2"
+   * The decorator knows about the module it is connected to. It is called the 'owner'.
+   *
+   * There is no public function for getting the owner, but implicitly this was tested in \ref testDataValidity_2_1_1.
+   */
+
+  /*********************************************************************************************************************/
+
+  /**
+   * \anchor testDataValidity_2_1_3 \ref dataValidity_2_1_3 "2.1.3"
+   *  **read:** For each read operation it checks the incoming data validity and increases/decreases the data fault
+   *  counter of the owner.
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_2_1_3) {
+    TestApplication1<TestModule1> app;
+    ctk::TestFacility test{app};
+
+    auto i1 = test.getScalar<int>("/m1/i1");
+
+    test.runApplication();
+    // mark input faulty
+    i1 = 1;
+    i1.setDataValidity(ctk::DataValidity::faulty);
+    i1.write();
+    // propagate value
+    test.stepApplication();
+    // check that fault counter was incremented
+    BOOST_CHECK(app.mod.incCalled == 1);
+    // mark input ok
+    i1.setDataValidity(ctk::DataValidity::ok);
+    i1.write();
+    // propagate value
+    test.stepApplication();
+    // check that fault counter was decremented
+    BOOST_CHECK(app.mod.decCalled == 1);
+  }
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_2_1_5 \ref dataValidity_2_1_5 "2.1.5"
+   * **write:** When writing, the decorator is checking the validity of the owner and the individual flag of the output
+   * set by the user. Only if both are 'ok' the output validity is 'ok', otherwise the outgoing data is send as 'faulty'.
+   *
+   * Test ist identical to \ref testDataValidity_1_6
+   */
+
+  /*********************************************************************************************************************/
+
+  /**
+   * \anchor testDataValidity_2_3_1 \ref dataValidity_2_3_1  "2.3.1"
+   * Each ApplicationModule has one data fault counter variable which is increased/decreased by
+   * EntityOwner::incrementDataFaultCounter() and  EntityOwner::decrementDataFaultCounter.
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_2_3_1) {
+    TestModule1 testmod1;
+    BOOST_CHECK(testmod1.getDataValidity() == ctk::DataValidity::ok);
+    testmod1.incrementDataFaultCounter();
+    BOOST_CHECK(testmod1.getDataValidity() == ctk::DataValidity::faulty);
+    testmod1.decrementDataFaultCounter();
+    BOOST_CHECK(testmod1.getDataValidity() == ctk::DataValidity::ok);
+  }
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_2_3_2 \ref dataValidity_2_3_2 "2.3.2"
+   * All inputs and outputs have a MetaDataPropagatingRegisterDecorator.
+   *
+   * Tested in \ref testDataValidity_2_1_1
+   */
+
+  /*********************************************************************************************************************/
+
+  /**
+   * \anchor testDataValidity_2_3_3 \ref dataValidity_2_3_3 "2.3.3"
+   * The main loop of the module usually does not care about data validity. If any input is invalid, all outputs are
+   * automatically invalid. The loop just runs through normally, even if an input has invalid data.
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_2_3_3) {
+    TestApplication1<TestModule1> app;
+    ctk::TestFacility test{app};
+
+    auto i1 = test.getScalar<int>("/m1/i1");
+    auto o1 = test.getScalar<int>("/m1/o1");
+    auto oconst = test.getScalar<int>("/m1/oconst");
+    test.runApplication();
+    o1.readLatest();
+    oconst.readLatest();
+
+    i1 = 1;
+    i1.setDataValidity(ctk::DataValidity::faulty);
+    i1.write();
+
+    test.stepApplication();
+
+    // check that an output which is re-calculated becomes invalid
+    // we need to get the destination of o1.write(), which is unlike o1.dataValidity() inside the module main loop
+    o1.read();
+    BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
+    // check that an output which is not re-calculated stays valid
+    BOOST_CHECK(oconst.readLatest() == false);
+  }
+
+  /*********************************************************************************************************************/
+
+  /**
+   * \anchor testDataValidity_2_3_4 \ref dataValidity_2_3_4 "2.3.4"
+   * Inside the ApplicationModule main loop the module's data fault counter is accessible. The user can increment and
+   * decrement it, but has to be careful to do this in pairs. The more common use case will be to query the module's
+   * data validity.
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_2_3_4) {
+    TestApplication1<TestModule2> app;
+    ctk::TestFacility test{app};
+
+    auto i1 = test.getScalar<int>("/m1/i1");
+    test.runApplication();
+    i1.write();
+    test.stepApplication();
+    // check that module variable v2 reports faulty
+    BOOST_CHECK(app.mod.dataValidity2 == false);
+
+    i1 = 1;
+    i1.setDataValidity(ctk::DataValidity::faulty);
+    i1.write();
+    test.stepApplication();
+    // check that module variable v1 now also reports faulty
+    BOOST_CHECK(app.mod.dataValidity1 == false);
+  }
+
+  /*********************************************************************************************************************/
+
+  /**
+   * \anchor testDataValidity_2_4_1 \ref dataValidity_2_4_1 "2.4.1"
+   * Only the push-type trigger input of the TriggerFanOut is equiped with a MetaDataPropagatingRegisterDecorator.
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_2_4_1) {
+    TestApplication1<TestModule1> app;
+    ctk::TestFacility test{app};
+    // app.debugTestableMode();
+
+    // the TriggerFanOut is realized via device module connected to control system,
+    // using a trigger from TriggerModule
+    auto result1 = test.getScalar<int>("dev/i3"); // RO
+
+    test.runApplication();
+
+    // check that setting trigger to invalid propagates to outputs of TriggerFanOut
+    app.m2.o1.setDataValidity(ctk::DataValidity::faulty);
+    app.m2.o1.write();
+
+    test.stepApplication();
+    result1.read();
+    BOOST_CHECK(result1.dataValidity() == ctk::DataValidity::faulty);
+  }
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_2_4_2 \ref dataValidity_2_4_2 "2.4.2"
+   * The poll-type data inputs do not have a MetaDataPropagatingRegisterDecorator.
+   *
+   * No functionality that needs testing
+   */
+
+  /*********************************************************************************************************************/
+
+  /**
+   * \anchor testDataValidity_2_4_3 \ref dataValidity_2_4_3 "2.4.3"
+   * The individual poll-type inputs propagate the data validity flag only to the corresponding outputs.
+   */
+  BOOST_AUTO_TEST_CASE(testDataValidity_2_4_3) {
+    TestApplication1<TestModule1> app;
+    ctk::TestFacility test{app};
+
+    // the TriggerFanOut is realized via device module connected to control system,
+    // using a trigger from TriggerModule
+    auto result1 = test.getScalar<int>("/dev/i1");
+    auto result2 = test.getScalar<int>("/dev/i3");
+
+    ctk::Device dev(app.dummyCdd);
+
+    test.runApplication();
+    auto exceptionDummy = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(dev.getBackend());
+    assert(exceptionDummy);
+    exceptionDummy->setValidity("/dev/i1", ctk::DataValidity::faulty);
+
+    app.m2.o1.write();
+    test.stepApplication();
+    result1.read();
+    BOOST_CHECK(result1.dataValidity() == ctk::DataValidity::faulty);
+    result2.read();
+    BOOST_CHECK(result2.dataValidity() == ctk::DataValidity::ok);
+  }
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_2_4_4 \ref dataValidity_2_4_4 "2.4.4"
+   * Although the trigger conceptually has data type 'void', it can also be `faulty`. An invalid trigger is processed,
+   * but all read out data is flagged as `faulty`.
+   *
+   * Already tested in \ref testDataValidity_2_4_1
+   */
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_2_5_1 \ref dataValidity_2_5_1 "2.5.1"
+   * The MetaDataPropagatingRegisterDecorator is always placed *around* the ExceptionHandlingDecorator if both
+   * decorators are used on a process variable. Like this a `faulty` flag raised by the ExceptionHandlingDecorator is
+   * automatically picked up by the MetaDataPropagatingRegisterDecorator.
+   *
+   * Already tested in  \ref testDataValidity_1_3
+   */
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_2_5_2 \ref dataValidity_2_5_2 "2.5.2"
+   * The first failing read returns with the old data and the 'faulty' flag. Like this the flag is propagated to the
+   * outputs. Only further reads might freeze until the device is available again.
+   *
+   *  Already tested in  \ref testDataValidity_1_3
+   */
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidity_2_6_1 \ref dataValidity_2_6_1 "2.6.1"
+   * For device variables, the requirement of setting receiving endpoints to 'faulty' on construction can not be
+   * fulfilled. In DeviceAccess the accessors are bidirectional and provide no possibility to distinguish sender and
+   * receiver. Instead, the validity is set right after construction in Application::createDeviceVariable() for receivers.
+   *
+   * Already tested in  \ref testDataValidity_1_3
+   */
+
+  /*********************************************************************************************************************/
+
+  /*
+   * \anchor testDataValidiy_3_1 \ref dataValidity_3_1 "3.1"
+   * The decorators which manipulate the data fault counter are responsible for counting up and down in pairs, such that
+   * the counter goes back to 0 if all data is ok, and never becomes negative.
+   *
+   * Not tested since it's an implementation detail.
+   */
+
+  /*********************************************************************************************************************/
+
+  // BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace Tests::testDataValidityPropagation

--- a/tests/executables_src/testDeviceAccessors.cc
+++ b/tests/executables_src/testDeviceAccessors.cc
@@ -20,7 +20,9 @@
 using namespace boost::unit_test_framework;
 namespace ctk = ChimeraTK;
 
-/*********************************************************************************************************************/
+namespace Tests::testDeviceAccessors {
+
+  /*********************************************************************************************************************/
 
 #define CHECK_TIMEOUT(condition, maxMilliseconds)                                                                      \
   {                                                                                                                    \
@@ -33,445 +35,448 @@ namespace ctk = ChimeraTK;
     }                                                                                                                  \
   }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-struct TestModule : public ctk::ApplicationModule {
-  TestModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
-      const std::unordered_set<std::string>& tags = {})
-  : ApplicationModule(owner, name, description, tags) {}
+  struct TestModule : public ctk::ApplicationModule {
+    TestModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
+        const std::unordered_set<std::string>& tags = {})
+    : ApplicationModule(owner, name, description, tags) {}
 
-  ctk::ScalarPollInput<int> consumingPoll{this, "consumingPoll", "MV/m", "Description"};
+    ctk::ScalarPollInput<int> consumingPoll{this, "consumingPoll", "MV/m", "Description"};
 
-  ctk::ScalarPushInput<int> consumingPush{this, "consumingPush", "MV/m", "Description"};
-  ctk::ScalarPushInput<int> consumingPush2{this, "consumingPush2", "MV/m", "Description"};
+    ctk::ScalarPushInput<int> consumingPush{this, "consumingPush", "MV/m", "Description"};
+    ctk::ScalarPushInput<int> consumingPush2{this, "consumingPush2", "MV/m", "Description"};
 
-  ctk::ScalarOutput<int> feedingToDevice{this, "feedingToDevice", "MV/m", "Description"};
+    ctk::ScalarOutput<int> feedingToDevice{this, "feedingToDevice", "MV/m", "Description"};
 
-  void prepare() override {
-    incrementDataFaultCounter(); // force data to be flagged as faulty
-    writeAll();
-    decrementDataFaultCounter(); // data validity depends on inputs
-  }
-
-  void mainLoop() override {}
-};
-
-/*********************************************************************************************************************/
-/* dummy application */
-
-struct TestApplication : public ctk::Application {
-  TestApplication() : Application("testSuite") {}
-  ~TestApplication() override { shutdown(); }
-
-  TestModule testModule{this, "testModule", "The test module"};
-  ctk::DeviceModule dev{this, "Dummy0", "/dummyTriggerForUnusedVariables"};
-  ctk::DeviceModule dev2;
-
-  // note: direct device-to-controlsystem connections are tested in testControlSystemAccessors!
-};
-
-/*********************************************************************************************************************/
-/* test feeding a scalar to a device */
-
-BOOST_AUTO_TEST_CASE(testFeedToDevice) {
-  std::cout << "testFeedToDevice" << std::endl;
-
-  ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
-
-  TestApplication app;
-
-  app.testModule.feedingToDevice = ctk::ScalarOutput<int>{&app.testModule, "/MyModule/actuator", "MV/m", ""};
-
-  ctk::TestFacility test{app};
-  test.runApplication();
-  ChimeraTK::Device dev;
-  dev.open("Dummy0");
-  auto regacc = dev.getScalarRegisterAccessor<int>("/MyModule/actuator");
-
-  regacc = 0;
-  app.testModule.feedingToDevice = 42;
-  app.testModule.feedingToDevice.write();
-  regacc.read();
-  BOOST_CHECK(regacc == 42);
-  app.testModule.feedingToDevice = 120;
-  regacc.read();
-  BOOST_CHECK(regacc == 42);
-  app.testModule.feedingToDevice.write();
-  regacc.read();
-  BOOST_CHECK(regacc == 120);
-}
-
-/*********************************************************************************************************************/
-/* test feeding a scalar to two different device registers */
-
-BOOST_AUTO_TEST_CASE(testFeedToDeviceFanOut) {
-  std::cout << "testFeedToDeviceFanOut" << std::endl;
-
-  ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
-
-  TestApplication app;
-
-  app.testModule.feedingToDevice = {&app.testModule, "/MyModule/actuator", "MV/m", ""};
-  app.dev2 = {&app, "Dummy0wo"};
-
-  app.getModel().writeGraphViz("testFeedToDeviceFanOut.dot");
-
-  ctk::TestFacility test{app};
-  test.runApplication();
-
-  ChimeraTK::Device dev("Dummy0");
-  ChimeraTK::Device dev2("Dummy0wo");
-
-  auto regac = dev.getScalarRegisterAccessor<int>("/MyModule/actuator");
-  auto regrb = dev2.getScalarRegisterAccessor<int>("/MyModule/actuator");
-
-  regac = 0;
-  regrb = 0;
-  app.testModule.feedingToDevice = 42;
-  app.testModule.feedingToDevice.write();
-  regac.read();
-  BOOST_CHECK(regac == 42);
-  regrb.read();
-  BOOST_CHECK(regrb == 42);
-  app.testModule.feedingToDevice = 120;
-  regac.read();
-  BOOST_CHECK(regac == 42);
-  regrb.read();
-  BOOST_CHECK(regrb == 42);
-  app.testModule.feedingToDevice.write();
-  regac.read();
-  BOOST_CHECK(regac == 120);
-  regrb.read();
-  BOOST_CHECK(regrb == 120);
-}
-
-/*********************************************************************************************************************/
-/* test consuming a scalar from a device */
-
-BOOST_AUTO_TEST_CASE(testConsumeFromDevice) {
-  std::cout << "testConsumeFromDevice" << std::endl;
-
-  ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
-
-  TestApplication app;
-
-  app.testModule.consumingPoll = {&app.testModule, "/MyModule/readBack", "MV/m", ""};
-
-  ctk::TestFacility test{app};
-
-  // Set the default value through the CS. The actuator and readBack map to the same register in the map file
-  // Not setting a default will overwrite whatever is put into the device before the TestFacility::runApplication()
-  // So we feed the default for the register through the IV mechanism of TestFacility.
-  test.setScalarDefault<int>("/MyModule/actuator", 1);
-  test.runApplication();
-
-  ChimeraTK::Device dev;
-  dev.open("Dummy0");
-  auto regacc = dev.getScalarRegisterAccessor<int>("/MyModule/readBack.DUMMY_WRITEABLE");
-
-  BOOST_REQUIRE(app.testModule.hasReachedTestableMode());
-
-  BOOST_CHECK(app.testModule.consumingPoll == 1);
-  regacc = 42;
-  regacc.write();
-  BOOST_CHECK(app.testModule.consumingPoll == 1);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPoll == 42);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPoll == 42);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPoll == 42);
-  regacc = 120;
-  regacc.write();
-  BOOST_CHECK(app.testModule.consumingPoll == 42);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPoll == 120);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPoll == 120);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPoll == 120);
-}
-
-/*********************************************************************************************************************/
-/* test consuming a scalar from a device with a ConsumingFanOut (i.e. one
- * poll-type consumer and several push-type consumers). */
-
-BOOST_AUTO_TEST_CASE(testConsumingFanOut) {
-  std::cout << "testConsumingFanOut" << std::endl;
-
-  ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
-
-  TestApplication app;
-
-  app.testModule.consumingPoll = {&app.testModule, "/MyModule/readBack", "MV/m", ""};
-  app.testModule.consumingPush = {&app.testModule, "/MyModule/readBack", "MV/m", ""};
-  app.testModule.consumingPush2 = {&app.testModule, "/MyModule/readBack", "MV/m", ""};
-
-  ctk::TestFacility test{app};
-
-  // Set the default value through the CS. The actuator and readBack map to the same register in the map file
-  // Not setting a default will overwrite whatever is put into the device before the TestFacility::runApplication()
-  // So we feed the default for the register through the IV mechanism of TestFacility.
-  test.setScalarDefault<int>("/MyModule/actuator", 1);
-  ChimeraTK::Device dev;
-  dev.open("Dummy0");
-  auto regacc = dev.getScalarRegisterAccessor<int>("/MyModule/readBack.DUMMY_WRITEABLE");
-  test.runApplication();
-
-  // single threaded test only, since read() does not block in this case
-  BOOST_CHECK(app.testModule.consumingPoll == 1);
-  BOOST_CHECK(app.testModule.consumingPush2 == 1);
-  regacc = 42;
-  regacc.write();
-
-  BOOST_CHECK(app.testModule.consumingPoll == 1);
-  BOOST_CHECK(app.testModule.consumingPush2 == 1);
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
-  BOOST_CHECK(app.testModule.consumingPush == 1);
-  BOOST_CHECK(app.testModule.consumingPush2 == 1);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPoll == 42);
-  BOOST_CHECK(app.testModule.consumingPush == 42);
-  BOOST_CHECK(app.testModule.consumingPush2 == 42);
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPoll == 42);
-  BOOST_CHECK(app.testModule.consumingPush == 42);
-  BOOST_CHECK(app.testModule.consumingPush2 == 42);
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPoll == 42);
-  BOOST_CHECK(app.testModule.consumingPush == 42);
-  BOOST_CHECK(app.testModule.consumingPush2 == 42);
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
-  regacc = 120;
-  regacc.write();
-  BOOST_CHECK(app.testModule.consumingPoll == 42);
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
-  BOOST_CHECK(app.testModule.consumingPush == 42);
-  BOOST_CHECK(app.testModule.consumingPush2 == 42);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPoll == 120);
-  BOOST_CHECK(app.testModule.consumingPush == 120);
-  BOOST_CHECK(app.testModule.consumingPush2 == 120);
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPoll == 120);
-  BOOST_CHECK(app.testModule.consumingPush == 120);
-  BOOST_CHECK(app.testModule.consumingPush2 == 120);
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
-  app.testModule.consumingPoll.read();
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
-  BOOST_CHECK(app.testModule.consumingPoll == 120);
-  BOOST_CHECK(app.testModule.consumingPush == 120);
-  BOOST_CHECK(app.testModule.consumingPush2 == 120);
-  BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
-  BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
-}
-
-/*********************************************************************************************************************/
-/* Application for tests of DeviceModule */
-
-struct TestModule2 : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  ctk::ScalarOutput<int> actuator{this, "actuator", "MV/m", "Description"};
-  ctk::ScalarPollInput<int> readback{this, "readBack", "MV/m", "Description"};
-
-  void mainLoop() override {}
-};
-
-struct Deeper : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  struct Hierarchies : ctk::VariableGroup {
-    using ctk::VariableGroup ::VariableGroup;
-    struct Need : ctk::VariableGroup {
-      using ctk::VariableGroup ::VariableGroup;
-      ctk::ScalarPollInput<int> tests{this, "tests", "MV/m", "Description"};
-    } need{this, "need", ""};
-    ctk::ScalarOutput<int> also{this, "also", "MV/m", "Description", {"ALSO"}};
-  } hierarchies{this, "hierarchies", ""};
-
-  void mainLoop() override {}
-};
-
-struct Deeper2 : ctk::ModuleGroup {
-  using ctk::ModuleGroup::ModuleGroup;
-
-  ctk::DeviceModule dev{this, "Dummy1", "/Deeper/hierarchies/trigger", nullptr, "/MyModule"};
-
-  struct Hierarchies : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
-
-    struct Need : ctk::VariableGroup {
-      using ctk::VariableGroup ::VariableGroup;
-      ctk::ScalarPollInput<int> tests{this, "tests", "MV/m", "Description"};
-    } need{this, "need", ""};
-    ctk::ScalarOutput<int> also{this, "also", "MV/m", "Description", {"ALSO"}};
-    ctk::ScalarOutput<int> trigger{this, "trigger", "MV/m", "Description", {"ALSO"}};
+    void prepare() override {
+      incrementDataFaultCounter(); // force data to be flagged as faulty
+      writeAll();
+      decrementDataFaultCounter(); // data validity depends on inputs
+    }
 
     void mainLoop() override {}
-  } hierarchies{this, "hierarchies", ""};
-};
+  };
 
-struct TestApplication3 : public ctk::Application {
-  TestApplication3() : Application("testSuite") {}
-  ~TestApplication3() override { shutdown(); }
+  /*********************************************************************************************************************/
+  /* dummy application */
 
-  TestModule2 testModule{this, "MyModule", "The test module"};
-  Deeper2 deeper{this, "Deeper", ""};
+  struct TestApplication : public ctk::Application {
+    TestApplication() : Application("testSuite") {}
+    ~TestApplication() override { shutdown(); }
 
-  std::atomic<size_t> initHandlerCallCount{0};
-  ctk::DeviceModule dev{this, "Dummy0", "", [this](ChimeraTK::Device&) { initHandlerCallCount++; }};
-};
+    TestModule testModule{this, "testModule", "The test module"};
+    ctk::DeviceModule dev{this, "Dummy0", "/dummyTriggerForUnusedVariables"};
+    ctk::DeviceModule dev2;
 
-/*********************************************************************************************************************/
+    // note: direct device-to-controlsystem connections are tested in testControlSystemAccessors!
+  };
 
-BOOST_AUTO_TEST_CASE(testDeviceModuleExceptions) {
-  std::cout << "testDeviceModuleExceptions" << std::endl;
+  /*********************************************************************************************************************/
+  /* test feeding a scalar to a device */
 
-  ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
-  TestApplication3 app;
+  BOOST_AUTO_TEST_CASE(testFeedToDevice) {
+    std::cout << "testFeedToDevice" << std::endl;
 
-  // non-absolute trigger path
-  BOOST_CHECK_THROW(
-      ctk::DeviceModule(&app.deeper, "Dummy0", "unqualifiedName", nullptr, "/MyModule"), ctk::logic_error);
-  BOOST_CHECK_THROW(ctk::DeviceModule(&app.deeper, "Dummy0", "relative/name", nullptr, "/MyModule"), ctk::logic_error);
-  BOOST_CHECK_THROW(
-      ctk::DeviceModule(&app.deeper, "Dummy0", "./also/relative", nullptr, "/MyModule"), ctk::logic_error);
-  BOOST_CHECK_THROW(
-      ctk::DeviceModule(&app.deeper, "Dummy0", "../another/relative/name", nullptr, "/MyModule"), ctk::logic_error);
-}
+    ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
 
-/*********************************************************************************************************************/
+    TestApplication app;
 
-BOOST_AUTO_TEST_CASE(testDeviceModule) {
-  std::cout << "testDeviceModule" << std::endl;
+    app.testModule.feedingToDevice = ctk::ScalarOutput<int>{&app.testModule, "/MyModule/actuator", "MV/m", ""};
 
-  ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
-  TestApplication3 app;
+    ctk::TestFacility test{app};
+    test.runApplication();
+    ChimeraTK::Device dev;
+    dev.open("Dummy0");
+    auto regacc = dev.getScalarRegisterAccessor<int>("/MyModule/actuator");
 
-  ctk::TestFacility test{app};
-  test.runApplication();
-  BOOST_CHECK_EQUAL(app.initHandlerCallCount, 1);
+    regacc = 0;
+    app.testModule.feedingToDevice = 42;
+    app.testModule.feedingToDevice.write();
+    regacc.read();
+    BOOST_CHECK(regacc == 42);
+    app.testModule.feedingToDevice = 120;
+    regacc.read();
+    BOOST_CHECK(regacc == 42);
+    app.testModule.feedingToDevice.write();
+    regacc.read();
+    BOOST_CHECK(regacc == 120);
+  }
 
-  ctk::Device dev;
-  dev.open("Dummy0");
-  auto actuator = dev.getScalarRegisterAccessor<int>("MyModule/actuator");
-  auto& readback = actuator; // same address in map file
-  auto tests = dev.getScalarRegisterAccessor<int>("Deeper/hierarchies/need/tests/DUMMY_WRITEABLE");
-  auto also = dev.getScalarRegisterAccessor<int>("Deeper/hierarchies/also");
+  /*********************************************************************************************************************/
+  /* test feeding a scalar to two different device registers */
 
-  app.testModule.actuator = 42;
-  app.testModule.actuator.write();
-  actuator.read();
-  BOOST_CHECK_EQUAL(actuator, 42);
+  BOOST_AUTO_TEST_CASE(testFeedToDeviceFanOut) {
+    std::cout << "testFeedToDeviceFanOut" << std::endl;
 
-  app.testModule.actuator = 12;
-  app.testModule.actuator.write();
-  actuator.read();
-  BOOST_CHECK_EQUAL(actuator, 12);
+    ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
 
-  readback = 120;
-  readback.write();
-  app.testModule.readback.read();
-  BOOST_CHECK_EQUAL(app.testModule.readback, 120);
+    TestApplication app;
 
-  readback = 66;
-  readback.write();
-  app.testModule.readback.read();
-  BOOST_CHECK_EQUAL(app.testModule.readback, 66);
+    app.testModule.feedingToDevice = {&app.testModule, "/MyModule/actuator", "MV/m", ""};
+    app.dev2 = {&app, "Dummy0wo"};
 
-  tests = 120;
-  tests.write();
-  app.deeper.hierarchies.need.tests.read();
-  BOOST_CHECK_EQUAL(app.deeper.hierarchies.need.tests, 120);
+    app.getModel().writeGraphViz("testFeedToDeviceFanOut.dot");
 
-  tests = 66;
-  tests.write();
-  app.deeper.hierarchies.need.tests.read();
-  BOOST_CHECK_EQUAL(app.deeper.hierarchies.need.tests, 66);
+    ctk::TestFacility test{app};
+    test.runApplication();
 
-  app.deeper.hierarchies.also = 42;
-  app.deeper.hierarchies.also.write();
-  also.read();
-  BOOST_CHECK_EQUAL(also, 42);
+    ChimeraTK::Device dev("Dummy0");
+    ChimeraTK::Device dev2("Dummy0wo");
 
-  app.deeper.hierarchies.also = 12;
-  app.deeper.hierarchies.also.write();
-  also.read();
-  BOOST_CHECK_EQUAL(also, 12);
+    auto regac = dev.getScalarRegisterAccessor<int>("/MyModule/actuator");
+    auto regrb = dev2.getScalarRegisterAccessor<int>("/MyModule/actuator");
 
-  // test the second DeviceModule with the trigger
-  ctk::Device dev2;
-  dev2.open("Dummy1");
-  auto readback2 = dev2.getScalarRegisterAccessor<int>("/MyModule/readBack/DUMMY_WRITEABLE");
-  readback2 = 543;
-  readback2.write();
+    regac = 0;
+    regrb = 0;
+    app.testModule.feedingToDevice = 42;
+    app.testModule.feedingToDevice.write();
+    regac.read();
+    BOOST_CHECK(regac == 42);
+    regrb.read();
+    BOOST_CHECK(regrb == 42);
+    app.testModule.feedingToDevice = 120;
+    regac.read();
+    BOOST_CHECK(regac == 42);
+    regrb.read();
+    BOOST_CHECK(regrb == 42);
+    app.testModule.feedingToDevice.write();
+    regac.read();
+    BOOST_CHECK(regac == 120);
+    regrb.read();
+    BOOST_CHECK(regrb == 120);
+  }
 
-  app.deeper.hierarchies.trigger.write();
-  test.stepApplication();
-  BOOST_CHECK_EQUAL(test.readScalar<int>("/Deeper/readBack"), 543);
+  /*********************************************************************************************************************/
+  /* test consuming a scalar from a device */
 
-  // make sure init handler is not called somehow a second time
-  BOOST_CHECK_EQUAL(app.initHandlerCallCount, 1);
-}
+  BOOST_AUTO_TEST_CASE(testConsumeFromDevice) {
+    std::cout << "testConsumeFromDevice" << std::endl;
 
-/*********************************************************************************************************************/
-/* Application for tests of DeviceModule move constructor/assignment */
+    ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
 
-struct TestApplication4 : public ctk::Application {
-  TestApplication4() : Application("testSuite") {}
-  ~TestApplication4() override { shutdown(); }
+    TestApplication app;
 
-  ctk::DeviceModule dev{this, "Dummy1"};
-  ctk::DeviceModule dev2{this, "Dummy0"};
+    app.testModule.consumingPoll = {&app.testModule, "/MyModule/readBack", "MV/m", ""};
 
-  std::vector<ctk::DeviceModule> cdevs;
+    ctk::TestFacility test{app};
 
-  TestModule2 m{this, "MyModule", ""};
-  Deeper deeper{this, "Deeper", ""};
-};
+    // Set the default value through the CS. The actuator and readBack map to the same register in the map file
+    // Not setting a default will overwrite whatever is put into the device before the TestFacility::runApplication()
+    // So we feed the default for the register through the IV mechanism of TestFacility.
+    test.setScalarDefault<int>("/MyModule/actuator", 1);
+    test.runApplication();
 
-/*********************************************************************************************************************/
+    ChimeraTK::Device dev;
+    dev.open("Dummy0");
+    auto regacc = dev.getScalarRegisterAccessor<int>("/MyModule/readBack.DUMMY_WRITEABLE");
 
-BOOST_AUTO_TEST_CASE(testDeviceModuleMove) {
-  std::cout << "testDeviceModuleMove" << std::endl;
-  ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
+    BOOST_REQUIRE(app.testModule.hasReachedTestableMode());
 
-  TestApplication4 app;
-  app.dev = std::move(app.dev2);           // test move-assign
-  app.cdevs.push_back(std::move(app.dev)); // test move-construct
+    BOOST_CHECK(app.testModule.consumingPoll == 1);
+    regacc = 42;
+    regacc.write();
+    BOOST_CHECK(app.testModule.consumingPoll == 1);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPoll == 42);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPoll == 42);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPoll == 42);
+    regacc = 120;
+    regacc.write();
+    BOOST_CHECK(app.testModule.consumingPoll == 42);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPoll == 120);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPoll == 120);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPoll == 120);
+  }
 
-  app.getModel().writeGraphViz("testDeviceModuleMove.dot");
+  /*********************************************************************************************************************/
+  /* test consuming a scalar from a device with a ConsumingFanOut (i.e. one
+   * poll-type consumer and several push-type consumers). */
 
-  ctk::TestFacility test{app};
+  BOOST_AUTO_TEST_CASE(testConsumingFanOut) {
+    std::cout << "testConsumingFanOut" << std::endl;
 
-  test.runApplication();
-  ctk::Device dummy0("Dummy0");
-  auto readBack = dummy0.getScalarRegisterAccessor<int>("MyModule/readBack/DUMMY_WRITEABLE");
-  readBack = 432;
-  readBack.write();
-  app.m.readback.read();
-  BOOST_CHECK_EQUAL(app.m.readback, 432);
-}
-/*********************************************************************************************************************/
+    ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
+
+    TestApplication app;
+
+    app.testModule.consumingPoll = {&app.testModule, "/MyModule/readBack", "MV/m", ""};
+    app.testModule.consumingPush = {&app.testModule, "/MyModule/readBack", "MV/m", ""};
+    app.testModule.consumingPush2 = {&app.testModule, "/MyModule/readBack", "MV/m", ""};
+
+    ctk::TestFacility test{app};
+
+    // Set the default value through the CS. The actuator and readBack map to the same register in the map file
+    // Not setting a default will overwrite whatever is put into the device before the TestFacility::runApplication()
+    // So we feed the default for the register through the IV mechanism of TestFacility.
+    test.setScalarDefault<int>("/MyModule/actuator", 1);
+    ChimeraTK::Device dev;
+    dev.open("Dummy0");
+    auto regacc = dev.getScalarRegisterAccessor<int>("/MyModule/readBack.DUMMY_WRITEABLE");
+    test.runApplication();
+
+    // single threaded test only, since read() does not block in this case
+    BOOST_CHECK(app.testModule.consumingPoll == 1);
+    BOOST_CHECK(app.testModule.consumingPush2 == 1);
+    regacc = 42;
+    regacc.write();
+
+    BOOST_CHECK(app.testModule.consumingPoll == 1);
+    BOOST_CHECK(app.testModule.consumingPush2 == 1);
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
+    BOOST_CHECK(app.testModule.consumingPush == 1);
+    BOOST_CHECK(app.testModule.consumingPush2 == 1);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPoll == 42);
+    BOOST_CHECK(app.testModule.consumingPush == 42);
+    BOOST_CHECK(app.testModule.consumingPush2 == 42);
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPoll == 42);
+    BOOST_CHECK(app.testModule.consumingPush == 42);
+    BOOST_CHECK(app.testModule.consumingPush2 == 42);
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPoll == 42);
+    BOOST_CHECK(app.testModule.consumingPush == 42);
+    BOOST_CHECK(app.testModule.consumingPush2 == 42);
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
+    regacc = 120;
+    regacc.write();
+    BOOST_CHECK(app.testModule.consumingPoll == 42);
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
+    BOOST_CHECK(app.testModule.consumingPush == 42);
+    BOOST_CHECK(app.testModule.consumingPush2 == 42);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPoll == 120);
+    BOOST_CHECK(app.testModule.consumingPush == 120);
+    BOOST_CHECK(app.testModule.consumingPush2 == 120);
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPoll == 120);
+    BOOST_CHECK(app.testModule.consumingPush == 120);
+    BOOST_CHECK(app.testModule.consumingPush2 == 120);
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
+    app.testModule.consumingPoll.read();
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == true);
+    BOOST_CHECK(app.testModule.consumingPoll == 120);
+    BOOST_CHECK(app.testModule.consumingPush == 120);
+    BOOST_CHECK(app.testModule.consumingPush2 == 120);
+    BOOST_CHECK(app.testModule.consumingPush.readNonBlocking() == false);
+    BOOST_CHECK(app.testModule.consumingPush2.readNonBlocking() == false);
+  }
+
+  /*********************************************************************************************************************/
+  /* Application for tests of DeviceModule */
+
+  struct TestModule2 : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+
+    ctk::ScalarOutput<int> actuator{this, "actuator", "MV/m", "Description"};
+    ctk::ScalarPollInput<int> readback{this, "readBack", "MV/m", "Description"};
+
+    void mainLoop() override {}
+  };
+
+  struct Deeper : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+
+    struct Hierarchies : ctk::VariableGroup {
+      using ctk::VariableGroup ::VariableGroup;
+      struct Need : ctk::VariableGroup {
+        using ctk::VariableGroup ::VariableGroup;
+        ctk::ScalarPollInput<int> tests{this, "tests", "MV/m", "Description"};
+      } need{this, "need", ""};
+      ctk::ScalarOutput<int> also{this, "also", "MV/m", "Description", {"ALSO"}};
+    } hierarchies{this, "hierarchies", ""};
+
+    void mainLoop() override {}
+  };
+
+  struct Deeper2 : ctk::ModuleGroup {
+    using ctk::ModuleGroup::ModuleGroup;
+
+    ctk::DeviceModule dev{this, "Dummy1", "/Deeper/hierarchies/trigger", nullptr, "/MyModule"};
+
+    struct Hierarchies : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
+
+      struct Need : ctk::VariableGroup {
+        using ctk::VariableGroup ::VariableGroup;
+        ctk::ScalarPollInput<int> tests{this, "tests", "MV/m", "Description"};
+      } need{this, "need", ""};
+      ctk::ScalarOutput<int> also{this, "also", "MV/m", "Description", {"ALSO"}};
+      ctk::ScalarOutput<int> trigger{this, "trigger", "MV/m", "Description", {"ALSO"}};
+
+      void mainLoop() override {}
+    } hierarchies{this, "hierarchies", ""};
+  };
+
+  struct TestApplication3 : public ctk::Application {
+    TestApplication3() : Application("testSuite") {}
+    ~TestApplication3() override { shutdown(); }
+
+    TestModule2 testModule{this, "MyModule", "The test module"};
+    Deeper2 deeper{this, "Deeper", ""};
+
+    std::atomic<size_t> initHandlerCallCount{0};
+    ctk::DeviceModule dev{this, "Dummy0", "", [this](ChimeraTK::Device&) { initHandlerCallCount++; }};
+  };
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDeviceModuleExceptions) {
+    std::cout << "testDeviceModuleExceptions" << std::endl;
+
+    ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
+    TestApplication3 app;
+
+    // non-absolute trigger path
+    BOOST_CHECK_THROW(
+        ctk::DeviceModule(&app.deeper, "Dummy0", "unqualifiedName", nullptr, "/MyModule"), ctk::logic_error);
+    BOOST_CHECK_THROW(
+        ctk::DeviceModule(&app.deeper, "Dummy0", "relative/name", nullptr, "/MyModule"), ctk::logic_error);
+    BOOST_CHECK_THROW(
+        ctk::DeviceModule(&app.deeper, "Dummy0", "./also/relative", nullptr, "/MyModule"), ctk::logic_error);
+    BOOST_CHECK_THROW(
+        ctk::DeviceModule(&app.deeper, "Dummy0", "../another/relative/name", nullptr, "/MyModule"), ctk::logic_error);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDeviceModule) {
+    std::cout << "testDeviceModule" << std::endl;
+
+    ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
+    TestApplication3 app;
+
+    ctk::TestFacility test{app};
+    test.runApplication();
+    BOOST_CHECK_EQUAL(app.initHandlerCallCount, 1);
+
+    ctk::Device dev;
+    dev.open("Dummy0");
+    auto actuator = dev.getScalarRegisterAccessor<int>("MyModule/actuator");
+    auto& readback = actuator; // same address in map file
+    auto tests = dev.getScalarRegisterAccessor<int>("Deeper/hierarchies/need/tests/DUMMY_WRITEABLE");
+    auto also = dev.getScalarRegisterAccessor<int>("Deeper/hierarchies/also");
+
+    app.testModule.actuator = 42;
+    app.testModule.actuator.write();
+    actuator.read();
+    BOOST_CHECK_EQUAL(actuator, 42);
+
+    app.testModule.actuator = 12;
+    app.testModule.actuator.write();
+    actuator.read();
+    BOOST_CHECK_EQUAL(actuator, 12);
+
+    readback = 120;
+    readback.write();
+    app.testModule.readback.read();
+    BOOST_CHECK_EQUAL(app.testModule.readback, 120);
+
+    readback = 66;
+    readback.write();
+    app.testModule.readback.read();
+    BOOST_CHECK_EQUAL(app.testModule.readback, 66);
+
+    tests = 120;
+    tests.write();
+    app.deeper.hierarchies.need.tests.read();
+    BOOST_CHECK_EQUAL(app.deeper.hierarchies.need.tests, 120);
+
+    tests = 66;
+    tests.write();
+    app.deeper.hierarchies.need.tests.read();
+    BOOST_CHECK_EQUAL(app.deeper.hierarchies.need.tests, 66);
+
+    app.deeper.hierarchies.also = 42;
+    app.deeper.hierarchies.also.write();
+    also.read();
+    BOOST_CHECK_EQUAL(also, 42);
+
+    app.deeper.hierarchies.also = 12;
+    app.deeper.hierarchies.also.write();
+    also.read();
+    BOOST_CHECK_EQUAL(also, 12);
+
+    // test the second DeviceModule with the trigger
+    ctk::Device dev2;
+    dev2.open("Dummy1");
+    auto readback2 = dev2.getScalarRegisterAccessor<int>("/MyModule/readBack/DUMMY_WRITEABLE");
+    readback2 = 543;
+    readback2.write();
+
+    app.deeper.hierarchies.trigger.write();
+    test.stepApplication();
+    BOOST_CHECK_EQUAL(test.readScalar<int>("/Deeper/readBack"), 543);
+
+    // make sure init handler is not called somehow a second time
+    BOOST_CHECK_EQUAL(app.initHandlerCallCount, 1);
+  }
+
+  /*********************************************************************************************************************/
+  /* Application for tests of DeviceModule move constructor/assignment */
+
+  struct TestApplication4 : public ctk::Application {
+    TestApplication4() : Application("testSuite") {}
+    ~TestApplication4() override { shutdown(); }
+
+    ctk::DeviceModule dev{this, "Dummy1"};
+    ctk::DeviceModule dev2{this, "Dummy0"};
+
+    std::vector<ctk::DeviceModule> cdevs;
+
+    TestModule2 m{this, "MyModule", ""};
+    Deeper deeper{this, "Deeper", ""};
+  };
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDeviceModuleMove) {
+    std::cout << "testDeviceModuleMove" << std::endl;
+    ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
+
+    TestApplication4 app;
+    app.dev = std::move(app.dev2);           // test move-assign
+    app.cdevs.push_back(std::move(app.dev)); // test move-construct
+
+    app.getModel().writeGraphViz("testDeviceModuleMove.dot");
+
+    ctk::TestFacility test{app};
+
+    test.runApplication();
+    ctk::Device dummy0("Dummy0");
+    auto readBack = dummy0.getScalarRegisterAccessor<int>("MyModule/readBack/DUMMY_WRITEABLE");
+    readBack = 432;
+    readBack.write();
+    app.m.readback.read();
+    BOOST_CHECK_EQUAL(app.m.readback, 432);
+  }
+  /*********************************************************************************************************************/
+
+} // namespace Tests::testDeviceAccessors

--- a/tests/executables_src/testDeviceExceptionFlagPropagation.cc
+++ b/tests/executables_src/testDeviceExceptionFlagPropagation.cc
@@ -20,188 +20,192 @@ using namespace boost::unit_test_framework;
 
 namespace ctk = ChimeraTK;
 
-constexpr std::string_view ExceptionDummyCDD1{"(ExceptionDummy:1?map=test3.map)"};
+namespace Tests::testDeviceExceptionFlagPropagation {
 
-/*********************************************************************************************************************/
+  constexpr std::string_view ExceptionDummyCDD1{"(ExceptionDummy:1?map=test3.map)"};
 
-struct TestApplication : ctk::Application {
-  TestApplication() : Application("testSuite") {}
-  ~TestApplication() override { shutdown(); }
+  /*********************************************************************************************************************/
 
-  struct Name : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
+  struct TestApplication : ctk::Application {
+    TestApplication() : Application("testSuite") {}
+    ~TestApplication() override { shutdown(); }
 
-    struct Name2 : ctk::VariableGroup {
-      using ctk::VariableGroup::VariableGroup;
-      ctk::ScalarOutput<uint64_t> tick{this, "tick", "", ""};
-    } name{(this), "name", ""}; // extra parentheses are for doxygen...
+    struct Name : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
 
-    void prepare() override { name.tick.write(); /* send initial value */ }
-    void mainLoop() override {}
-  } name{this, "name", ""};
+      struct Name2 : ctk::VariableGroup {
+        using ctk::VariableGroup::VariableGroup;
+        ctk::ScalarOutput<uint64_t> tick{this, "tick", "", ""};
+      } name{(this), "name", ""}; // extra parentheses are for doxygen...
 
-  struct Module : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
+      void prepare() override { name.tick.write(); /* send initial value */ }
+      void mainLoop() override {}
+    } name{this, "name", ""};
 
-    mutable int readMode{0};
+    struct Module : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
 
-    struct Vars : ctk::VariableGroup {
-      using ctk::VariableGroup::VariableGroup;
-      ctk::ScalarPushInput<uint64_t> tick{this, "/trigger/tick", "", ""};
-      ctk::ScalarPollInput<int> read{this, "/MyModule/readBack", "", ""};
-      ctk::ScalarOutput<int> set{this, "/MyModule/actuator", "", ""};
-    } vars{this, ".", ""};
+      mutable int readMode{0};
 
-    std::atomic<ctk::DataValidity> readDataValidity{ctk::DataValidity::ok};
+      struct Vars : ctk::VariableGroup {
+        using ctk::VariableGroup::VariableGroup;
+        ctk::ScalarPushInput<uint64_t> tick{this, "/trigger/tick", "", ""};
+        ctk::ScalarPollInput<int> read{this, "/MyModule/readBack", "", ""};
+        ctk::ScalarOutput<int> set{this, "/MyModule/actuator", "", ""};
+      } vars{this, ".", ""};
 
-    void prepare() override {
-      readDataValidity = vars.read.dataValidity();
-      // The receiving end of all accessor implementations should be constructed with faulty (Initial value propagation
-      // spec, D.1)
-      BOOST_CHECK(readDataValidity == ctk::DataValidity::faulty);
-      vars.set.write(); /* send initial value */
-    }
+      std::atomic<ctk::DataValidity> readDataValidity{ctk::DataValidity::ok};
 
-    void mainLoop() override {
-      readDataValidity = vars.read.dataValidity();
-      while(true) {
-        vars.tick.read();
+      void prepare() override {
         readDataValidity = vars.read.dataValidity();
-        switch(readMode) {
-          case 0:
-            vars.read.readNonBlocking();
-            break;
-          case 1:
-            vars.read.readLatest();
-            break;
-          case 2:
-            vars.read.read();
-            break;
-          case 3:
-            vars.set.write();
-            break;
-          case 4:
-            vars.set.writeDestructively();
-            break;
-          default:
-            break;
+        // The receiving end of all accessor implementations should be constructed with faulty (Initial value
+        // propagation spec, D.1)
+        BOOST_CHECK(readDataValidity == ctk::DataValidity::faulty);
+        vars.set.write(); /* send initial value */
+      }
+
+      void mainLoop() override {
+        readDataValidity = vars.read.dataValidity();
+        while(true) {
+          vars.tick.read();
+          readDataValidity = vars.read.dataValidity();
+          switch(readMode) {
+            case 0:
+              vars.read.readNonBlocking();
+              break;
+            case 1:
+              vars.read.readLatest();
+              break;
+            case 2:
+              vars.read.read();
+              break;
+            case 3:
+              vars.set.write();
+              break;
+            case 4:
+              vars.set.writeDestructively();
+              break;
+            default:
+              break;
+          }
         }
       }
+
+    } module{this, "module", ""};
+
+    ctk::DeviceModule dev{this, ExceptionDummyCDD1.data(), "/fakeTriggerToMakeUnusedPollRegsHappy"};
+  };
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDirectConnectOpen) {
+    for(int readMode = 0; readMode < 2; ++readMode) {
+      std::cout << "testDirectConnectOpen (readMode = " << readMode << ")" << std::endl;
+
+      TestApplication app;
+
+      boost::shared_ptr<ctk::ExceptionDummy> dummyBackend1 = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+          ChimeraTK::BackendFactory::getInstance().createBackend(ExceptionDummyCDD1.data()));
+
+      ctk::TestFacility test(app, false);
+
+      // Throw on device open and check if DataValidity::faulty gets propagated
+      dummyBackend1->throwExceptionOpen = true;
+      // set the read mode
+      app.module.readMode = readMode;
+      std::cout << "Read mode is: " << app.module.readMode << ". Run application.\n";
+
+      // app.run();
+      test.runApplication();
+
+      CHECK_EQUAL_TIMEOUT(
+          test.readScalar<int>("Devices/" + ctk::Utilities::escapeName(ExceptionDummyCDD1.data(), false) + "/status"),
+          1, 10000);
+
+      // Trigger and check
+      test.writeScalar<uint64_t>("/trigger/tick", 1);
+      usleep(10000);
+      BOOST_CHECK(app.module.readDataValidity == ctk::DataValidity::faulty);
+
+      // recover from error state
+      dummyBackend1->throwExceptionOpen = false;
+      CHECK_TIMEOUT(app.module.readDataValidity == ctk::DataValidity::ok, 10000);
     }
+  }
 
-  } module{this, "module", ""};
+  /*********************************************************************************************************************/
 
-  ctk::DeviceModule dev{this, ExceptionDummyCDD1.data(), "/fakeTriggerToMakeUnusedPollRegsHappy"};
-};
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testDirectConnectOpen) {
-  for(int readMode = 0; readMode < 2; ++readMode) {
-    std::cout << "testDirectConnectOpen (readMode = " << readMode << ")" << std::endl;
-
+  BOOST_AUTO_TEST_CASE(testDirectConnectRead) {
+    std::cout << "testDirectConnectRead" << std::endl;
     TestApplication app;
-
     boost::shared_ptr<ctk::ExceptionDummy> dummyBackend1 = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
         ChimeraTK::BackendFactory::getInstance().createBackend(ExceptionDummyCDD1.data()));
 
-    ctk::TestFacility test(app, false);
+    app.module.vars.tick = {&app.module.vars, "/trigger/tick", "", ""};
 
-    // Throw on device open and check if DataValidity::faulty gets propagated
-    dummyBackend1->throwExceptionOpen = true;
-    // set the read mode
-    app.module.readMode = readMode;
-    std::cout << "Read mode is: " << app.module.readMode << ". Run application.\n";
+    app.getModel().writeGraphViz("testDirectConnectRead.dot");
 
-    // app.run();
+    app.debugMakeConnections();
+
+    ctk::TestFacility test(app);
     test.runApplication();
 
-    CHECK_EQUAL_TIMEOUT(
-        test.readScalar<int>("Devices/" + ctk::Utilities::escapeName(ExceptionDummyCDD1.data(), false) + "/status"), 1,
-        10000);
+    // Advance through all read methods
+    while(app.module.readMode < 3) {
+      // Check
+      test.writeScalar<uint64_t>("/trigger/tick", 1);
+      test.stepApplication();
+      BOOST_CHECK(app.module.vars.read.dataValidity() == ctk::DataValidity::ok);
 
-    // Trigger and check
-    test.writeScalar<uint64_t>("/trigger/tick", 1);
-    usleep(10000);
-    BOOST_CHECK(app.module.readDataValidity == ctk::DataValidity::faulty);
+      // Check
+      std::cout << "Checking read mode " << app.module.readMode << "\n";
+      dummyBackend1->throwExceptionRead = true;
+      test.writeScalar<uint64_t>("/trigger/tick", 1);
+      test.stepApplication(false);
+      BOOST_CHECK(app.module.vars.read.dataValidity() == ctk::DataValidity::faulty);
 
-    // recover from error state
-    dummyBackend1->throwExceptionOpen = false;
-    CHECK_TIMEOUT(app.module.readDataValidity == ctk::DataValidity::ok, 10000);
+      // Reset throwing and let the device recover
+      dummyBackend1->throwExceptionRead = false;
+      test.stepApplication(true);
+
+      // advance to the next read
+      app.module.readMode++;
+    }
   }
-}
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(testDirectConnectRead) {
-  std::cout << "testDirectConnectRead" << std::endl;
-  TestApplication app;
-  boost::shared_ptr<ctk::ExceptionDummy> dummyBackend1 = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-      ChimeraTK::BackendFactory::getInstance().createBackend(ExceptionDummyCDD1.data()));
+  BOOST_AUTO_TEST_CASE(testDirectConnectWrite) {
+    std::cout << "testDirectConnectWrite" << std::endl;
+    TestApplication app;
+    boost::shared_ptr<ctk::ExceptionDummy> dummyBackend1 = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+        ChimeraTK::BackendFactory::getInstance().createBackend(ExceptionDummyCDD1.data()));
 
-  app.module.vars.tick = {&app.module.vars, "/trigger/tick", "", ""};
+    app.module.readMode = 3;
 
-  app.getModel().writeGraphViz("testDirectConnectRead.dot");
+    ctk::TestFacility test(app);
+    test.runApplication();
 
-  app.debugMakeConnections();
+    // Advance through all non-blocking read methods
+    while(app.module.readMode < 5) {
+      // Check
+      test.writeScalar<uint64_t>("/trigger/tick", 1);
+      test.stepApplication();
+      BOOST_CHECK(app.module.vars.set.dataValidity() == ctk::DataValidity::ok);
 
-  ctk::TestFacility test(app);
-  test.runApplication();
+      // Check
+      dummyBackend1->throwExceptionWrite = true;
+      test.writeScalar<uint64_t>("/trigger/tick", 1);
+      test.stepApplication(false);
+      // write operations failing does not invalidate data
+      BOOST_CHECK(app.module.vars.set.dataValidity() == ctk::DataValidity::ok);
 
-  // Advance through all read methods
-  while(app.module.readMode < 3) {
-    // Check
-    test.writeScalar<uint64_t>("/trigger/tick", 1);
-    test.stepApplication();
-    BOOST_CHECK(app.module.vars.read.dataValidity() == ctk::DataValidity::ok);
-
-    // Check
-    std::cout << "Checking read mode " << app.module.readMode << "\n";
-    dummyBackend1->throwExceptionRead = true;
-    test.writeScalar<uint64_t>("/trigger/tick", 1);
-    test.stepApplication(false);
-    BOOST_CHECK(app.module.vars.read.dataValidity() == ctk::DataValidity::faulty);
-
-    // Reset throwing and let the device recover
-    dummyBackend1->throwExceptionRead = false;
-    test.stepApplication(true);
-
-    // advance to the next read
-    app.module.readMode++;
+      // advance to the next read
+      dummyBackend1->throwExceptionWrite = false;
+      app.module.readMode++;
+    }
   }
-}
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(testDirectConnectWrite) {
-  std::cout << "testDirectConnectWrite" << std::endl;
-  TestApplication app;
-  boost::shared_ptr<ctk::ExceptionDummy> dummyBackend1 = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-      ChimeraTK::BackendFactory::getInstance().createBackend(ExceptionDummyCDD1.data()));
-
-  app.module.readMode = 3;
-
-  ctk::TestFacility test(app);
-  test.runApplication();
-
-  // Advance through all non-blocking read methods
-  while(app.module.readMode < 5) {
-    // Check
-    test.writeScalar<uint64_t>("/trigger/tick", 1);
-    test.stepApplication();
-    BOOST_CHECK(app.module.vars.set.dataValidity() == ctk::DataValidity::ok);
-
-    // Check
-    dummyBackend1->throwExceptionWrite = true;
-    test.writeScalar<uint64_t>("/trigger/tick", 1);
-    test.stepApplication(false);
-    // write operations failing does not invalidate data
-    BOOST_CHECK(app.module.vars.set.dataValidity() == ctk::DataValidity::ok);
-
-    // advance to the next read
-    dummyBackend1->throwExceptionWrite = false;
-    app.module.readMode++;
-  }
-}
-
-/*********************************************************************************************************************/
+} // namespace Tests::testDeviceExceptionFlagPropagation

--- a/tests/executables_src/testDeviceInitialisationHandler.cc
+++ b/tests/executables_src/testDeviceInitialisationHandler.cc
@@ -19,237 +19,243 @@
 using namespace boost::unit_test_framework;
 namespace ctk = ChimeraTK;
 
-static constexpr std::string_view deviceCDD{"(ExceptionDummy?map=test.map)"};
-static constexpr std::string_view exceptionMessage{"DEBUG: runtime error intentionally cased in device initialisation"};
+namespace Tests::testDeviceInitialisationHandler {
 
-static std::atomic<bool> throwInInitialisation{false};
-static std::atomic<int32_t> var1{0};
-static std::atomic<int32_t> var2{0};
-static std::atomic<int32_t> var3{0};
+  static constexpr std::string_view deviceCDD{"(ExceptionDummy?map=test.map)"};
+  static constexpr std::string_view exceptionMessage{
+      "DEBUG: runtime error intentionally cased in device initialisation"};
 
-void initialiseReg1(ChimeraTK::Device&) {
-  var1 = 42;
-  if(throwInInitialisation) {
-    throw ctk::runtime_error(exceptionMessage.data());
+  static std::atomic<bool> throwInInitialisation{false};
+  static std::atomic<int32_t> var1{0};
+  static std::atomic<int32_t> var2{0};
+  static std::atomic<int32_t> var3{0};
+
+  void initialiseReg1(ChimeraTK::Device&) {
+    var1 = 42;
+    if(throwInInitialisation) {
+      throw ctk::runtime_error(exceptionMessage.data());
+    }
   }
-}
 
-void initialiseReg2(ChimeraTK::Device&) {
-  // the initialisation of reg 2 must happen after the initialisation of reg1
-  var2 = var1 + 5;
-}
+  void initialiseReg2(ChimeraTK::Device&) {
+    // the initialisation of reg 2 must happen after the initialisation of reg1
+    var2 = var1 + 5;
+  }
 
-void initialiseReg3(ChimeraTK::Device&) {
-  // the initialisation of reg 3 must happen after the initialisation of reg2
-  var3 = var2 + 5;
-}
+  void initialiseReg3(ChimeraTK::Device&) {
+    // the initialisation of reg 3 must happen after the initialisation of reg2
+    var3 = var2 + 5;
+  }
 
-/* dummy application */
-struct TestApplication : public ctk::Application {
-  TestApplication() : Application("testSuite") {}
-  ~TestApplication() override { shutdown(); }
+  /* dummy application */
+  struct TestApplication : public ctk::Application {
+    TestApplication() : Application("testSuite") {}
+    ~TestApplication() override { shutdown(); }
 
-  ctk::DeviceModule dev{this, deviceCDD.data(), "", &initialiseReg1};
-};
+    ctk::DeviceModule dev{this, deviceCDD.data(), "", &initialiseReg1};
+  };
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(testBasicInitialisation) {
-  std::cout << "testBasicInitialisation" << std::endl;
-  TestApplication app;
+  BOOST_AUTO_TEST_CASE(testBasicInitialisation) {
+    std::cout << "testBasicInitialisation" << std::endl;
+    TestApplication app;
 
-  var1 = 0;
-  var2 = 0;
-  var3 = 0;
+    var1 = 0;
+    var2 = 0;
+    var3 = 0;
 
-  ctk::TestFacility test{app};
-  test.runApplication();
-  ctk::Device dummy;
-  dummy.open(deviceCDD.data());
+    ctk::TestFacility test{app};
+    test.runApplication();
+    ctk::Device dummy;
+    dummy.open(deviceCDD.data());
 
-  // ********************************************************
-  // REQUIRED TEST 1: After opening the device is initialised
-  // ********************************************************
-  BOOST_CHECK_EQUAL(var1, 42);
+    // ********************************************************
+    // REQUIRED TEST 1: After opening the device is initialised
+    // ********************************************************
+    BOOST_CHECK_EQUAL(var1, 42);
 
-  var1 = 0;
+    var1 = 0;
 
-  // check that accessing an exception triggers a reconnection with re-initialisation
-  auto dummyBackend = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-      ctk::BackendFactory::getInstance().createBackend(deviceCDD.data()));
-  dummyBackend->throwExceptionWrite = true;
+    // check that accessing an exception triggers a reconnection with re-initialisation
+    auto dummyBackend = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+        ctk::BackendFactory::getInstance().createBackend(deviceCDD.data()));
+    dummyBackend->throwExceptionWrite = true;
 
-  auto reg2_cs = test.getScalar<int32_t>("/REG2");
-  reg2_cs = 19;
-  reg2_cs.write();
-  test.stepApplication(false);
+    auto reg2_cs = test.getScalar<int32_t>("/REG2");
+    reg2_cs = 19;
+    reg2_cs.write();
+    test.stepApplication(false);
 
-  BOOST_CHECK_EQUAL(var2, 0);
-  BOOST_CHECK_EQUAL(var1, 0);
-  dummyBackend->throwExceptionWrite = false; // now the device should work again and be re-initialised
+    BOOST_CHECK_EQUAL(var2, 0);
+    BOOST_CHECK_EQUAL(var1, 0);
+    dummyBackend->throwExceptionWrite = false; // now the device should work again and be re-initialised
 
-  reg2_cs = 20;
-  reg2_cs.write();
-  test.stepApplication();
+    reg2_cs = 20;
+    reg2_cs.write();
+    test.stepApplication();
 
-  BOOST_CHECK_EQUAL(dummy.read<int32_t>("/REG2"), 20);
+    BOOST_CHECK_EQUAL(dummy.read<int32_t>("/REG2"), 20);
 
-  // ****************************************************************
-  // REQUIRED TEST 2: After an exception the device is re-initialised
-  // ****************************************************************
-  BOOST_CHECK_EQUAL(var1, 42);
-}
+    // ****************************************************************
+    // REQUIRED TEST 2: After an exception the device is re-initialised
+    // ****************************************************************
+    BOOST_CHECK_EQUAL(var1, 42);
+  }
 
-BOOST_AUTO_TEST_CASE(testMultipleInitialisationHandlers) {
-  std::cout << "testMultipleInitialisationHandlers" << std::endl;
-  TestApplication app;
+  BOOST_AUTO_TEST_CASE(testMultipleInitialisationHandlers) {
+    std::cout << "testMultipleInitialisationHandlers" << std::endl;
+    TestApplication app;
 
-  var1 = 0;
-  var2 = 0;
-  var3 = 0;
+    var1 = 0;
+    var2 = 0;
+    var3 = 0;
 
-  app.dev.addInitialisationHandler(&initialiseReg2);
-  app.dev.addInitialisationHandler(&initialiseReg3);
-  ctk::TestFacility test{app};
-  test.runApplication();
+    app.dev.addInitialisationHandler(&initialiseReg2);
+    app.dev.addInitialisationHandler(&initialiseReg3);
+    ctk::TestFacility test{app};
+    test.runApplication();
 
-  auto deviceStatus = test.getScalar<int32_t>(
-      ctk::RegisterPath("/Devices") / ctk::Utilities::escapeName(deviceCDD.data(), false) / "status");
+    auto deviceStatus = test.getScalar<int32_t>(
+        ctk::RegisterPath("/Devices") / ctk::Utilities::escapeName(deviceCDD.data(), false) / "status");
 
-  // *********************************************************
-  // REQUIRED TEST 4: Handlers are executed in the right order
-  // *********************************************************
-  BOOST_CHECK_EQUAL(var1, 42);
-  BOOST_CHECK_EQUAL(var2, 47); // the initialiser used reg1+5, so order matters
-  BOOST_CHECK_EQUAL(var3, 52); // the initialiser used reg2+5, so order matters
+    // *********************************************************
+    // REQUIRED TEST 4: Handlers are executed in the right order
+    // *********************************************************
+    BOOST_CHECK_EQUAL(var1, 42);
+    BOOST_CHECK_EQUAL(var2, 47); // the initialiser used reg1+5, so order matters
+    BOOST_CHECK_EQUAL(var3, 52); // the initialiser used reg2+5, so order matters
 
-  // check that after an exception the re-initialisation is OK
-  var1 = 0;
-  var2 = 0;
-  var3 = 0;
+    // check that after an exception the re-initialisation is OK
+    var1 = 0;
+    var2 = 0;
+    var3 = 0;
 
-  // cause an exception
-  auto dummyBackend = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-      ctk::BackendFactory::getInstance().createBackend(deviceCDD.data()));
-  dummyBackend->throwExceptionWrite = true;
+    // cause an exception
+    auto dummyBackend = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+        ctk::BackendFactory::getInstance().createBackend(deviceCDD.data()));
+    dummyBackend->throwExceptionWrite = true;
 
-  auto reg4_cs = test.getScalar<int32_t>("/REG4");
-  reg4_cs = 19;
-  reg4_cs.write();
-  test.stepApplication(false);
+    auto reg4_cs = test.getScalar<int32_t>("/REG4");
+    reg4_cs = 19;
+    reg4_cs.write();
+    test.stepApplication(false);
 
-  // recover
-  dummyBackend->throwExceptionWrite = false;
+    // recover
+    dummyBackend->throwExceptionWrite = false;
 
-  reg4_cs = 20;
-  reg4_cs.write();
-  test.stepApplication();
+    reg4_cs = 20;
+    reg4_cs.write();
+    test.stepApplication();
 
-  BOOST_CHECK_EQUAL(var1, 42);
-  BOOST_CHECK_EQUAL(var2, 47); // the initialiser used reg1+5, so order matters
-  BOOST_CHECK_EQUAL(var3, 52); // the initialiser used reg2+5, so order matters
-}
+    BOOST_CHECK_EQUAL(var1, 42);
+    BOOST_CHECK_EQUAL(var2, 47); // the initialiser used reg1+5, so order matters
+    BOOST_CHECK_EQUAL(var3, 52); // the initialiser used reg2+5, so order matters
+  }
 
-BOOST_AUTO_TEST_CASE(testInitialisationException) {
-  std::cout << "testInitialisationException" << std::endl;
+  BOOST_AUTO_TEST_CASE(testInitialisationException) {
+    std::cout << "testInitialisationException" << std::endl;
 
-  var1 = 0;
-  var2 = 0;
-  var3 = 0;
+    var1 = 0;
+    var2 = 0;
+    var3 = 0;
 
-  throwInInitialisation = true;
-  TestApplication app;
+    throwInInitialisation = true;
+    TestApplication app;
 
-  app.dev.addInitialisationHandler(&initialiseReg2);
-  app.dev.addInitialisationHandler(&initialiseReg3);
-  // app.dev.connectTo(app.cs);
-  ctk::TestFacility test(app, false); // test facility without testable mode
-  ctk::Device dummy;
-  dummy.open(deviceCDD.data());
+    app.dev.addInitialisationHandler(&initialiseReg2);
+    app.dev.addInitialisationHandler(&initialiseReg3);
+    // app.dev.connectTo(app.cs);
+    ctk::TestFacility test(app, false); // test facility without testable mode
+    ctk::Device dummy;
+    dummy.open(deviceCDD.data());
 
-  // We cannot use runApplication because the DeviceModule leaves the testable mode without variables in the queue, but
-  // has not finished error handling yet. In this special case we cannot make the programme continue, because stepApplication
-  // only works if the queues are not empty. We have to work with timeouts here (until someone comes up with a better idea)
-  app.run();
-  // app.dumpConnections();
+    // We cannot use runApplication because the DeviceModule leaves the testable mode without variables in the queue,
+    // but has not finished error handling yet. In this special case we cannot make the programme continue, because
+    // stepApplication only works if the queues are not empty. We have to work with timeouts here (until someone comes
+    // up with a better idea)
+    app.run();
+    // app.dumpConnections();
 
-  CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
-                          ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
-      1, 30000);
-  CHECK_EQUAL_TIMEOUT(test.readScalar<std::string>(ctk::RegisterPath("/Devices") /
-                          ctk::Utilities::escapeName(deviceCDD.data(), false) / "status_message"),
-      exceptionMessage, 10000);
+    CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
+                            ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
+        1, 30000);
+    CHECK_EQUAL_TIMEOUT(test.readScalar<std::string>(ctk::RegisterPath("/Devices") /
+                            ctk::Utilities::escapeName(deviceCDD.data(), false) / "status_message"),
+        exceptionMessage, 10000);
 
-  // Check that the execution of init handlers was stopped after the exception:
-  // initialiseReg2 and initialiseReg3 were not executed. As we already checked with timeout that the
-  // initialisation error has been reported, we know that the data was written to the device and don't need the timeout here.
+    // Check that the execution of init handlers was stopped after the exception:
+    // initialiseReg2 and initialiseReg3 were not executed. As we already checked with timeout that the
+    // initialisation error has been reported, we know that the data was written to the device and don't need the timeout here.
 
-  BOOST_CHECK_EQUAL(var1, 42);
-  BOOST_CHECK_EQUAL(var2, 0);
-  BOOST_CHECK_EQUAL(var3, 0);
+    BOOST_CHECK_EQUAL(var1, 42);
+    BOOST_CHECK_EQUAL(var2, 0);
+    BOOST_CHECK_EQUAL(var3, 0);
 
-  // recover the error
-  throwInInitialisation = false;
+    // recover the error
+    throwInInitialisation = false;
 
-  // wait until the device is reported to be OK again (check with timeout),
-  // then check the initialisation (again, no extra timeout needed because of the logic:
-  // success is only reported after successful init).
-  CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
-                          ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
-      0, 10000);
-  // We use the macro here for convenience, it's a test, speed should not matter
-  // NOLINTNEXTLINE(readability-container-size-empty)
-  CHECK_EQUAL_TIMEOUT(test.readScalar<std::string>(ctk::RegisterPath("/Devices") /
-                          ctk::Utilities::escapeName(deviceCDD.data(), false) / "status_message"),
-      "", 10000);
+    // wait until the device is reported to be OK again (check with timeout),
+    // then check the initialisation (again, no extra timeout needed because of the logic:
+    // success is only reported after successful init).
+    CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
+                            ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
+        0, 10000);
+    // We use the macro here for convenience, it's a test, speed should not matter
+    // NOLINTNEXTLINE(readability-container-size-empty)
+    CHECK_EQUAL_TIMEOUT(test.readScalar<std::string>(ctk::RegisterPath("/Devices") /
+                            ctk::Utilities::escapeName(deviceCDD.data(), false) / "status_message"),
+        "", 10000);
 
-  // initialisation should be correct now
-  BOOST_CHECK_EQUAL(var1, 42);
-  BOOST_CHECK_EQUAL(var2, 47);
-  BOOST_CHECK_EQUAL(var3, 52);
+    // initialisation should be correct now
+    BOOST_CHECK_EQUAL(var1, 42);
+    BOOST_CHECK_EQUAL(var2, 47);
+    BOOST_CHECK_EQUAL(var3, 52);
 
-  // now check that the initialisation error is also reportet when recovering
-  // Prepare registers to be initialised
-  var1 = 12;
-  var2 = 13;
-  var3 = 14;
+    // now check that the initialisation error is also reportet when recovering
+    // Prepare registers to be initialised
+    var1 = 12;
+    var2 = 13;
+    var3 = 14;
 
-  // Make initialisation fail when executed, and then cause an error condition
-  throwInInitialisation = true;
-  auto dummyBackend = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-      ctk::BackendFactory::getInstance().createBackend(deviceCDD.data()));
-  dummyBackend->throwExceptionWrite = true;
+    // Make initialisation fail when executed, and then cause an error condition
+    throwInInitialisation = true;
+    auto dummyBackend = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+        ctk::BackendFactory::getInstance().createBackend(deviceCDD.data()));
+    dummyBackend->throwExceptionWrite = true;
 
-  auto reg4_cs = test.getScalar<int32_t>("/REG4");
-  reg4_cs = 20;
-  reg4_cs.write();
+    auto reg4_cs = test.getScalar<int32_t>("/REG4");
+    reg4_cs = 20;
+    reg4_cs.write();
 
-  CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
-                          ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
-      1, 10000);
-  // First we see the message from the failing write
-  BOOST_CHECK(!test.readScalar<std::string>(ctk::RegisterPath("/Devices") /
-                       ctk::Utilities::escapeName(deviceCDD.data(), false) / "status_message")
-                   .empty());
-  dummyBackend->throwExceptionWrite = false;
-  // Afterwards we see a message from the failing initialisation (which we can now distinguish from the original write
-  // exception because write does not throw any more)
-  CHECK_EQUAL_TIMEOUT(test.readScalar<std::string>(ctk::RegisterPath("/Devices") /
-                          ctk::Utilities::escapeName(deviceCDD.data(), false) / "status_message"),
-      exceptionMessage, 10000);
+    CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
+                            ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
+        1, 10000);
+    // First we see the message from the failing write
+    BOOST_CHECK(!test.readScalar<std::string>(ctk::RegisterPath("/Devices") /
+                         ctk::Utilities::escapeName(deviceCDD.data(), false) / "status_message")
+                     .empty());
+    dummyBackend->throwExceptionWrite = false;
+    // Afterwards we see a message from the failing initialisation (which we can now distinguish from the original write
+    // exception because write does not throw any more)
+    CHECK_EQUAL_TIMEOUT(test.readScalar<std::string>(ctk::RegisterPath("/Devices") /
+                            ctk::Utilities::escapeName(deviceCDD.data(), false) / "status_message"),
+        exceptionMessage, 10000);
 
-  // Now fix the initialisation error and check that the device comes up.
-  throwInInitialisation = false;
-  // Wait until the device is OK again
-  CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
-                          ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
-      0, 10000);
+    // Now fix the initialisation error and check that the device comes up.
+    throwInInitialisation = false;
+    // Wait until the device is OK again
+    CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
+                            ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
+        0, 10000);
 
-  // We use the macro here for convenience, it's a test, speed should not matter
-  // NOLINTNEXTLINE(readability-container-size-empty)
-  CHECK_EQUAL_TIMEOUT(test.readScalar<std::string>(ctk::RegisterPath("/Devices") /
-                          ctk::Utilities::escapeName(deviceCDD.data(), false) / "status_message"),
-      "", 10000);
-  // Finally check that the 20 arrives on the device
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/REG4"), 20, 10000);
-}
+    // We use the macro here for convenience, it's a test, speed should not matter
+    // NOLINTNEXTLINE(readability-container-size-empty)
+    CHECK_EQUAL_TIMEOUT(test.readScalar<std::string>(ctk::RegisterPath("/Devices") /
+                            ctk::Utilities::escapeName(deviceCDD.data(), false) / "status_message"),
+        "", 10000);
+    // Finally check that the 20 arrives on the device
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/REG4"), 20, 10000);
+  }
+
+} // namespace Tests::testDeviceInitialisationHandler

--- a/tests/executables_src/testExceptionHandling.cc
+++ b/tests/executables_src/testExceptionHandling.cc
@@ -24,906 +24,911 @@
 #include <boost/test/included/unit_test.hpp>
 #undef BOOST_NO_EXCEPTIONS
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
-using Fixture = FixtureWithPollAndPushInput<false>;
-using Fixture_initHandlers = FixtureWithPollAndPushInput<false, true>;
-using Fixture_secondDeviceBroken = FixtureWithPollAndPushInput<false, false, true>;
+namespace Tests::testExceptionHandling {
 
-/*
- * This test suite checks behavior on a device related runtime error.
- */
-BOOST_AUTO_TEST_SUITE(runtimeErrorHandling)
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
+  using Fixture = FixtureWithPollAndPushInput<false>;
+  using Fixture_initHandlers = FixtureWithPollAndPushInput<false, true>;
+  using Fixture_secondDeviceBroken = FixtureWithPollAndPushInput<false, false, true>;
 
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_1 \ref exceptionHandling_b_2_1 "B.2.1"
- *
- * "The exception status is published as a process variable together with an error message."
- */
-BOOST_FIXTURE_TEST_CASE(B_2_1, Fixture) {
-  std::cout << "B_2_1 - fault indicators" << std::endl;
+  /*
+   * This test suite checks behavior on a device related runtime error.
+   */
+  BOOST_AUTO_TEST_SUITE(runtimeErrorHandling)
 
-  // These are instantiated in the fixture:
-  // status -> /Devices/(ExceptionDummy:1?map=test.map)/status
-  // message -> /Devices/(ExceptionDummy:1?map=test.map)/status_message
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_1 \ref exceptionHandling_b_2_1 "B.2.1"
+   *
+   * "The exception status is published as a process variable together with an error message."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_1, Fixture) {
+    std::cout << "B_2_1 - fault indicators" << std::endl;
 
-  BOOST_CHECK_EQUAL(status, 0);
-  BOOST_CHECK_EQUAL(static_cast<std::string>(message), "");
+    // These are instantiated in the fixture:
+    // status -> /Devices/(ExceptionDummy:1?map=test.map)/status
+    // message -> /Devices/(ExceptionDummy:1?map=test.map)/status_message
 
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  application.group1.pollModule.pollInput.read(); // causes device exception
+    BOOST_CHECK_EQUAL(status, 0);
+    BOOST_CHECK_EQUAL(static_cast<std::string>(message), "");
 
-  CHECK_TIMEOUT(status.readNonBlocking() == true, 10000);
-  CHECK_TIMEOUT(message.readNonBlocking() == true, 10000);
-  BOOST_CHECK_EQUAL(status, 1);
-  BOOST_CHECK(!static_cast<std::string>(message).empty());
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    application.group1.pollModule.pollInput.read(); // causes device exception
 
-  deviceBackend->throwExceptionRead = false;
-  deviceBackend->throwExceptionOpen = false;
+    CHECK_TIMEOUT(status.readNonBlocking() == true, 10000);
+    CHECK_TIMEOUT(message.readNonBlocking() == true, 10000);
+    BOOST_CHECK_EQUAL(status, 1);
+    BOOST_CHECK(!static_cast<std::string>(message).empty());
 
-  CHECK_TIMEOUT(status.readNonBlocking() == true, 10000);
-  CHECK_TIMEOUT(message.readNonBlocking() == true, 10000);
-  BOOST_CHECK_EQUAL(status, 0);
-  BOOST_CHECK_EQUAL(static_cast<std::string>(message), "");
-}
+    deviceBackend->throwExceptionRead = false;
+    deviceBackend->throwExceptionOpen = false;
 
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_2_poll \ref exceptionHandling_b_2_2_2 "B.2.2.2"
- *
- * "The DataValidity::faulty flag resulting from the fault state is propagated once, even if the variable had the a
- * DataValidity::faulty flag already set previously for another reason."
- *
- * TODO Set previous fault flag through Backend, and test inside TriggerFanOut (the latter needs the first)
- */
-
-BOOST_FIXTURE_TEST_CASE(B_2_2_2_poll, Fixture) {
-  std::cout << "B_2_2_2_poll - exception with previous DataValidity::faulty" << std::endl;
-
-  // initialize to known value in deviceBackend register
-  write(exceptionDummyRegister, 134);
-  pollVariable.read();
-  BOOST_REQUIRE_EQUAL(pollVariable, 134);
-  auto versionNumberBeforeRuntimeError = pollVariable.getVersionNumber();
-
-  // Modify the validity flag of the application buffer. Note: This is not a 100% sane test, since in theory it could
-  // make a difference whether the flag is actually coming from the device, but implementing such test is tedious. It
-  // does not seem worth the effort, as it is unlikely that even a future, refactored implementation would be sensitive
-  // to this difference (flag would need to be stored artifically in an additional place). It is only important to
-  // change the validity on all decorator levels.
-  pollVariable.setDataValidity(ctk::DataValidity::faulty);
-  for(auto& e : pollVariable.getHardwareAccessingElements()) {
-    e->setDataValidity(ctk::DataValidity::faulty);
+    CHECK_TIMEOUT(status.readNonBlocking() == true, 10000);
+    CHECK_TIMEOUT(message.readNonBlocking() == true, 10000);
+    BOOST_CHECK_EQUAL(status, 0);
+    BOOST_CHECK_EQUAL(static_cast<std::string>(message), "");
   }
 
-  // modify value in register after breaking the device
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 10);
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_2_poll \ref exceptionHandling_b_2_2_2 "B.2.2.2"
+   *
+   * "The DataValidity::faulty flag resulting from the fault state is propagated once, even if the variable had the a
+   * DataValidity::faulty flag already set previously for another reason."
+   *
+   * TODO Set previous fault flag through Backend, and test inside TriggerFanOut (the latter needs the first)
+   */
 
-  // This read should be skipped but obtain a new version number
-  pollVariable.read();
-  auto versionNumberOnRuntimeError = pollVariable.getVersionNumber();
-  BOOST_CHECK_EQUAL(pollVariable, 134);
-  BOOST_CHECK(pollVariable.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(versionNumberOnRuntimeError > versionNumberBeforeRuntimeError);
-}
+  BOOST_FIXTURE_TEST_CASE(B_2_2_2_poll, Fixture) {
+    std::cout << "B_2_2_2_poll - exception with previous DataValidity::faulty" << std::endl;
 
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_2_push \ref exceptionHandling_b_2_2_2 "B.2.2.2"
- *
- * "The DataValidity::faulty flag resulting from the fault state is propagated once, even if the variable had the a
- * DataValidity::faulty flag already set previously for another reason."
- *
- * TODO Set previous fault flag through Backend, and test inside ThreadedFanOut and TriggerFanOut (as trigger).
- */
+    // initialize to known value in deviceBackend register
+    write(exceptionDummyRegister, 134);
+    pollVariable.read();
+    BOOST_REQUIRE_EQUAL(pollVariable, 134);
+    auto versionNumberBeforeRuntimeError = pollVariable.getVersionNumber();
 
-BOOST_FIXTURE_TEST_CASE(B_2_2_2_push, Fixture) {
-  std::cout << "B_2_2_2_push - exception with previous DataValidity::faulty" << std::endl;
+    // Modify the validity flag of the application buffer. Note: This is not a 100% sane test, since in theory it could
+    // make a difference whether the flag is actually coming from the device, but implementing such test is tedious. It
+    // does not seem worth the effort, as it is unlikely that even a future, refactored implementation would be
+    // sensitive to this difference (flag would need to be stored artifically in an additional place). It is only
+    // important to change the validity on all decorator levels.
+    pollVariable.setDataValidity(ctk::DataValidity::faulty);
+    for(auto& e : pollVariable.getHardwareAccessingElements()) {
+      e->setDataValidity(ctk::DataValidity::faulty);
+    }
 
-  // verify normal operation
-  // initialize to known value in deviceBackend register
-  write(exceptionDummyRegister, 101);
-  ctk::VersionNumber versionNumberBeforeRuntimeError = {};
-  deviceBackend->triggerInterrupt(1);
-  pushVariable.read();
+    // modify value in register after breaking the device
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 10);
 
-  // Modify the validity flag of the application buffer (see note above in poll-type test)
-  pushVariable.setDataValidity(ctk::DataValidity::faulty);
-  for(auto& e : pushVariable.getHardwareAccessingElements()) {
-    e->setDataValidity(ctk::DataValidity::faulty);
+    // This read should be skipped but obtain a new version number
+    pollVariable.read();
+    auto versionNumberOnRuntimeError = pollVariable.getVersionNumber();
+    BOOST_CHECK_EQUAL(pollVariable, 134);
+    BOOST_CHECK(pollVariable.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(versionNumberOnRuntimeError > versionNumberBeforeRuntimeError);
   }
 
-  // modify value in register after breaking the device
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 11);
-  deviceBackend->triggerInterrupt(1);
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_2_push \ref exceptionHandling_b_2_2_2 "B.2.2.2"
+   *
+   * "The DataValidity::faulty flag resulting from the fault state is propagated once, even if the variable had the a
+   * DataValidity::faulty flag already set previously for another reason."
+   *
+   * TODO Set previous fault flag through Backend, and test inside ThreadedFanOut and TriggerFanOut (as trigger).
+   */
 
-  // This read should be skipped but obtain a new version number
-  pushVariable.read();
-  auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
-  BOOST_CHECK_EQUAL(pushVariable, 101);
-  BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(versionNumberOnRuntimeError > versionNumberBeforeRuntimeError);
-}
+  BOOST_FIXTURE_TEST_CASE(B_2_2_2_push, Fixture) {
+    std::cout << "B_2_2_2_push - exception with previous DataValidity::faulty" << std::endl;
 
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_3 \ref exceptionHandling_b_2_2_3 "B.2.2.3"
- *
- * "Read operations without AccessMode::wait_for_new_data are skipped until the device is fully recovered again (cf.
- * 3.1). The first skipped read operation will have a new VersionNumber."
- *
- * Test directly inside ApplicationModule
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_3, Fixture) {
-  std::cout << "B_2_2_3 - skip poll type reads" << std::endl;
+    // verify normal operation
+    // initialize to known value in deviceBackend register
+    write(exceptionDummyRegister, 101);
+    ctk::VersionNumber versionNumberBeforeRuntimeError = {};
+    deviceBackend->triggerInterrupt(1);
+    pushVariable.read();
 
-  // initialize to known value in deviceBackend register
-  write(exceptionDummyRegister, 100);
-  pollVariable.read();
-  auto versionNumberBeforeRuntimeError = pollVariable.getVersionNumber();
+    // Modify the validity flag of the application buffer (see note above in poll-type test)
+    pushVariable.setDataValidity(ctk::DataValidity::faulty);
+    for(auto& e : pushVariable.getHardwareAccessingElements()) {
+      e->setDataValidity(ctk::DataValidity::faulty);
+    }
 
-  // modify value in register after breaking the device
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 10);
+    // modify value in register after breaking the device
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 11);
+    deviceBackend->triggerInterrupt(1);
 
-  // This read should be skipped but obtain a new version number
-  pollVariable.read();
-  auto versionNumberOnRuntimeError = pollVariable.getVersionNumber();
-  BOOST_CHECK_EQUAL(pollVariable, 100);
-  BOOST_CHECK(pollVariable.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(versionNumberOnRuntimeError > versionNumberBeforeRuntimeError);
-
-  // This read should be skipped too, this time without a new version number
-  pollVariable.read();
-  BOOST_CHECK_EQUAL(pollVariable, 100);
-  BOOST_CHECK(pollVariable.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(pollVariable.getVersionNumber(), versionNumberOnRuntimeError);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_3_TrFO \ref exceptionHandling_b_2_2_3 "B.2.2.3"
- *
- * "Read operations without AccessMode::wait_for_new_data are skipped until the device is fully recovered again (cf.
- * 3.1). The first skipped read operation will have a new VersionNumber."
- *
- * Test inside a TriggerFanOut. This is mainly necessary to make sure the ExceptionHandlingDecorator is used for
- * variables inside the TriggerFanOut.
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_3_TriggerFanOut, Fixture) {
-  std::cout << "B_2_2_3_TriggerFanOut - skip poll type reads (in TriggerFanOut)" << std::endl;
-
-  // initialize to known value in deviceBackend register
-  triggeredInput.readLatest(); // empty queue (initial value)
-
-  write(exceptionDummy2Register, 666);
-  deviceBackend3->triggerInterrupt(1);
-  triggeredInput.read();
-  BOOST_REQUIRE_EQUAL(triggeredInput, 666);
-
-  // breaking the device and modify value
-  deviceBackend2->throwExceptionOpen = true;
-  deviceBackend2->throwExceptionRead = true;
-  write(exceptionDummy2Register, 667);
-
-  // Trigger readout of poll-type inside TriggerFanOut (should be skipped - VersionNumber is invisible in this context)
-  deviceBackend3->triggerInterrupt(1);
-  triggeredInput.read();
-  BOOST_CHECK_EQUAL(triggeredInput, 666);
-  BOOST_CHECK(triggeredInput.dataValidity() == ctk::DataValidity::faulty);
-
-  // A second read should be skipped, too
-  deviceBackend3->triggerInterrupt(1);
-  triggeredInput.read();
-  BOOST_CHECK_EQUAL(triggeredInput, 666);
-  BOOST_CHECK(triggeredInput.dataValidity() == ctk::DataValidity::faulty);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_4_blocking \ref exceptionHandling_b_2_2_4 "B.2.2.4"
- *
- * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
- * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
- * (= hasNewData), and a new VersionNumber is obtained)."
- *
- * This test is for blocking read().
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_4_blocking, Fixture) {
-  std::cout << "B_2_2_4_blocking - first skip of blocking read" << std::endl;
-
-  pushVariable.readLatest();
-
-  // go to exception state
-  ctk::VersionNumber version = {};
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 456);
-  deviceBackend->triggerInterrupt(1);
-
-  // as soon as the fault state has arrived, the operation is skipped
-  pushVariable.read();
-  BOOST_CHECK_NE(pushVariable, 456); // value did not come through
-  BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
-  auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
-  BOOST_CHECK(versionNumberOnRuntimeError > version);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_4_nonBlocking \ref exceptionHandling_b_2_2_4 "B.2.2.4"
- *
- * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
- * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
- * (= hasNewData), and a new VersionNumber is obtained)."
- *
- * This test is for readNonBlocking().
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_4_nonBlocking, Fixture) {
-  std::cout << "B_2_2_4_nonBlocking - first skip of readNonBlocking" << std::endl;
-
-  pushVariable.readLatest();
-
-  // go to exception state
-  ctk::VersionNumber version = {};
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 123);
-  deviceBackend->triggerInterrupt(1);
-
-  // as soon as the fault state has arrived, the operation is skipped
-  CHECK_TIMEOUT(pushVariable.readNonBlocking() == true, 10000);
-  BOOST_CHECK_NE(pushVariable, 123); // value did not come through
-  BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
-  auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
-  BOOST_CHECK(versionNumberOnRuntimeError > version);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_4_any \ref exceptionHandling_b_2_2_4 "B.2.2.4"
- *
- * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
- * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
- * (= hasNewData), and a new VersionNumber is obtained)."
- *
- * This test is for readAny.
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_4_any, Fixture) {
-  std::cout << "B_2_2_4_any - first skip of readAny" << std::endl;
-
-  pushVariable.readLatest();
-
-  ChimeraTK::ReadAnyGroup group({pushVariable});
-
-  // go to exception state
-  ctk::VersionNumber version = {};
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 456);
-  deviceBackend->triggerInterrupt(1);
-
-  // as soon as the fault state has arrived, the operation is skipped
-  group.readAny();
-  BOOST_CHECK_NE(pushVariable, 456); // value did not come through
-  BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
-  auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
-  BOOST_CHECK(versionNumberOnRuntimeError > version);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_4_latest \ref exceptionHandling_b_2_2_4 "B.2.2.4"
- *
- * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
- * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
- * (= hasNewData), and a new VersionNumber is obtained)."
- *
- * This test is for readLatest().
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_4_latest, Fixture) {
-  std::cout << "B_2_2_4_latest - first skip of readLatest" << std::endl;
-
-  pushVariable.readLatest();
-
-  // go to exception state
-  ctk::VersionNumber version = {};
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 234);
-  deviceBackend->triggerInterrupt(1);
-
-  // as soon as the fault state has arrived, the operation is skipped
-  CHECK_TIMEOUT(pushVariable.readLatest() == true, 10000);
-  BOOST_CHECK_NE(pushVariable, 234); // value did not come through
-  BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
-  auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
-  BOOST_CHECK(versionNumberOnRuntimeError > version);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_4_ThFO \ref exceptionHandling_b_2_2_4 "B.2.2.4"
- *
- * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
- * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
- * (= hasNewData), and a new VersionNumber is obtained)."
- *
- * This test is for read() inside a ThreadedFanOut. (The ThreadedFanOut never calles the other read functions.)
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_4_ThFO, Fixture) {
-  std::cout << "B_2_2_4_ThFO - first skip read in ThreadedFanOut" << std::endl;
-
-  // remove initial value from control system
-  pushVariable3copy.readLatest();
-  pushVariable3.readLatest();
-
-  // go to exception state
-  ctk::VersionNumber version = {};
-  deviceBackend2->throwExceptionOpen = true;
-  deviceBackend2->throwExceptionRead = true;
-  write(exceptionDummy2Register, 345);
-  deviceBackend2->triggerInterrupt(1);
-
-  // as soon as the fault state has arrived, the operation is skipped
-  pushVariable3.read();
-  BOOST_CHECK_NE(pushVariable3, 345); // value did not come through
-  BOOST_CHECK(pushVariable3.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(pushVariable3.getVersionNumber() > version);
-
-  // same state is visible at control system's copy
-  pushVariable3copy.read();
-  BOOST_CHECK_NE(pushVariable3copy, 345); // value did not come through
-  BOOST_CHECK(pushVariable3copy.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(pushVariable3copy.getVersionNumber() > version);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_4_TrFO \ref exceptionHandling_b_2_2_4 "B.2.2.4"
- *
- * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
- * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
- * (= hasNewData), and a new VersionNumber is obtained)."
- *
- * This test is for read() inside a TriggerFanOut on the trigger variable.
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_4_TrFO, Fixture) {
-  std::cout << "B_2_2_4_TrFO - first skip read in TriggerFanOut on the trigger variable" << std::endl;
-
-  triggeredInput.readLatest();
-
-  // initialize to known value in deviceBackend register
-  write(exceptionDummy2Register, 668);
-  ctk::VersionNumber versionBeforeException = {};
-  deviceBackend3->triggerInterrupt(1);
-  triggeredInput.read();
-
-  // breaking the device and modify value
-  deviceBackend3->throwExceptionOpen = true;
-  deviceBackend3->throwExceptionRead = true;
-  write(exceptionDummy2Register, 669);
-  pollVariable3.read(); // make sure framework sees exception
-
-  // as soon as the fault state has arrived, the operation is skipped (inside the TriggerFanOut), so we get the
-  // updated value (remember: the updated value comes from another device which is not broken)
-  triggeredInput.read();
-  BOOST_CHECK_EQUAL(triggeredInput, 669);
-  BOOST_CHECK(triggeredInput.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(triggeredInput.getVersionNumber() > versionBeforeException);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_4_1_nonBlocking \ref exceptionHandling_b_2_2_4_1 "B.2.2.4.1"
- *
- * [After first skipped read operation in 2.2.4, the following] "non-blocking read operations (readNonBlocking() and
- * readLatest()) are skipped and return false (= no new data), until the device is recovered".
- *
- * This test is for readNonBlocking().
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_4_1_nonBlocking, Fixture) {
-  std::cout << "B_2_2_4_1_nonBlocking - following skip readNonBlocking" << std::endl;
-
-  pushVariable.readLatest();
-
-  // go to exception state
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 100);
-  deviceBackend->triggerInterrupt(1);
-
-  // perform first skipped operation
-  pushVariable.read();
-  auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
-
-  // subsequent calls to readLatest on runtime error are skipped.
-  for(size_t i = 0; i < 5; ++i) {
-    usleep(1000);
-    BOOST_CHECK_EQUAL(pushVariable.readNonBlocking(), false);
-    BOOST_CHECK(versionNumberOnRuntimeError == pushVariable.getVersionNumber());
+    // This read should be skipped but obtain a new version number
+    pushVariable.read();
+    auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
+    BOOST_CHECK_EQUAL(pushVariable, 101);
     BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(versionNumberOnRuntimeError > versionNumberBeforeRuntimeError);
   }
-}
 
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_4_1_latest \ref exceptionHandling_b_2_2_4_1 "B.2.2.4.1"
- *
- * [After first skipped read operation in 2.2.4, the following] "non-blocking read operations (readNonBlocking() and
- * readLatest()) are skipped and return false (= no new data), until the device is recovered".
- *
- * This test is for readLatest().
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_4_1_latest, Fixture) {
-  std::cout << "B_2_2_4_1_latest - following skip readLatest" << std::endl;
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_3 \ref exceptionHandling_b_2_2_3 "B.2.2.3"
+   *
+   * "Read operations without AccessMode::wait_for_new_data are skipped until the device is fully recovered again (cf.
+   * 3.1). The first skipped read operation will have a new VersionNumber."
+   *
+   * Test directly inside ApplicationModule
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_3, Fixture) {
+    std::cout << "B_2_2_3 - skip poll type reads" << std::endl;
 
-  pushVariable.readLatest();
+    // initialize to known value in deviceBackend register
+    write(exceptionDummyRegister, 100);
+    pollVariable.read();
+    auto versionNumberBeforeRuntimeError = pollVariable.getVersionNumber();
 
-  // go to exception state
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 100);
-  deviceBackend->triggerInterrupt(1);
+    // modify value in register after breaking the device
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 10);
 
-  // perform first skipped operation
-  pushVariable.read();
-  auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
+    // This read should be skipped but obtain a new version number
+    pollVariable.read();
+    auto versionNumberOnRuntimeError = pollVariable.getVersionNumber();
+    BOOST_CHECK_EQUAL(pollVariable, 100);
+    BOOST_CHECK(pollVariable.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(versionNumberOnRuntimeError > versionNumberBeforeRuntimeError);
 
-  // subsequent calls to readLatest on runtime error are skipped.
-  for(size_t i = 0; i < 5; ++i) {
-    usleep(1000);
-    BOOST_CHECK_EQUAL(pushVariable.readLatest(), false);
-    BOOST_CHECK(versionNumberOnRuntimeError == pushVariable.getVersionNumber());
+    // This read should be skipped too, this time without a new version number
+    pollVariable.read();
+    BOOST_CHECK_EQUAL(pollVariable, 100);
+    BOOST_CHECK(pollVariable.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(pollVariable.getVersionNumber(), versionNumberOnRuntimeError);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_3_TrFO \ref exceptionHandling_b_2_2_3 "B.2.2.3"
+   *
+   * "Read operations without AccessMode::wait_for_new_data are skipped until the device is fully recovered again (cf.
+   * 3.1). The first skipped read operation will have a new VersionNumber."
+   *
+   * Test inside a TriggerFanOut. This is mainly necessary to make sure the ExceptionHandlingDecorator is used for
+   * variables inside the TriggerFanOut.
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_3_TriggerFanOut, Fixture) {
+    std::cout << "B_2_2_3_TriggerFanOut - skip poll type reads (in TriggerFanOut)" << std::endl;
+
+    // initialize to known value in deviceBackend register
+    triggeredInput.readLatest(); // empty queue (initial value)
+
+    write(exceptionDummy2Register, 666);
+    deviceBackend3->triggerInterrupt(1);
+    triggeredInput.read();
+    BOOST_REQUIRE_EQUAL(triggeredInput, 666);
+
+    // breaking the device and modify value
+    deviceBackend2->throwExceptionOpen = true;
+    deviceBackend2->throwExceptionRead = true;
+    write(exceptionDummy2Register, 667);
+
+    // Trigger readout of poll-type inside TriggerFanOut (should be skipped - VersionNumber is invisible in this context)
+    deviceBackend3->triggerInterrupt(1);
+    triggeredInput.read();
+    BOOST_CHECK_EQUAL(triggeredInput, 666);
+    BOOST_CHECK(triggeredInput.dataValidity() == ctk::DataValidity::faulty);
+
+    // A second read should be skipped, too
+    deviceBackend3->triggerInterrupt(1);
+    triggeredInput.read();
+    BOOST_CHECK_EQUAL(triggeredInput, 666);
+    BOOST_CHECK(triggeredInput.dataValidity() == ctk::DataValidity::faulty);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_4_blocking \ref exceptionHandling_b_2_2_4 "B.2.2.4"
+   *
+   * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
+   * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
+   * (= hasNewData), and a new VersionNumber is obtained)."
+   *
+   * This test is for blocking read().
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_4_blocking, Fixture) {
+    std::cout << "B_2_2_4_blocking - first skip of blocking read" << std::endl;
+
+    pushVariable.readLatest();
+
+    // go to exception state
+    ctk::VersionNumber version = {};
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 456);
+    deviceBackend->triggerInterrupt(1);
+
+    // as soon as the fault state has arrived, the operation is skipped
+    pushVariable.read();
+    BOOST_CHECK_NE(pushVariable, 456); // value did not come through
     BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
+    auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
+    BOOST_CHECK(versionNumberOnRuntimeError > version);
   }
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_4_2 \ref exceptionHandling_b_2_2_4_2 "B.2.2.4.2"
- *
- * [After first skipped read operation in 2.2.4, the following] "blocking read operations (read()) will be frozen until
- * the device is recovered."
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_4_2, Fixture) {
-  std::cout << "B_2_2_4_2 - freeze blocking read" << std::endl;
-
-  pushVariable.readLatest();
-
-  // go to exception state
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 100);
-  deviceBackend->triggerInterrupt(1);
-
-  // perform first skipped operation
-  pushVariable.read();
-
-  // subsequent read operations should be frozen
-  deviceBackend->triggerInterrupt(1);
-  auto f = std::async(std::launch::async, [&]() { pushVariable.read(); });
-  BOOST_CHECK(f.wait_for(std::chrono::milliseconds(100)) == std::future_status::timeout);
-
-  // FIXME: This should not be necessary. Bug in ApplicationCore's shutdown procedure!?
-  deviceBackend->throwExceptionRead = false;
-  deviceBackend->throwExceptionOpen = false;
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_4_3 \ref exceptionHandling_b_2_2_4_3 "B.2.2.4.3"
- *
- * "After the device is fully recovered (cf. 3.1), the current value is (synchronously) read from the device. This is
- * the first value received by the accessor after an exception."
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_4_3, Fixture) {
-  std::cout << "B_2_2_4_3 - value after recovery" << std::endl;
-
-  pushVariable.readLatest();
-
-  // Normal behaviour
-  write(exceptionDummyRegister, 66);
-  deviceBackend->triggerInterrupt(1);
-  pushVariable.read();
-
-  // Change value while in exception state
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  write(exceptionDummyRegister, 77);
-  deviceBackend->triggerInterrupt(1);
-
-  pushVariable.read();
-  BOOST_CHECK_EQUAL(pushVariable, 66);
-
-  // Recover from exception state
-  deviceBackend->throwExceptionRead = false;
-  deviceBackend->throwExceptionOpen = false;
-
-  // Now the value needs to be read
-  CHECK_TIMEOUT(pushVariable.readNonBlocking() == true, 10000);
-  BOOST_CHECK_EQUAL(pushVariable, 77);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_5 \ref exceptionHandling_b_2_2_5 "B.2.2.5"
- *
- * "The VersionNumbers returned in case of an exception are the same for the same exception, even across variables and
- * modules. It will be generated in the moment the exception is reported."
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_5, Fixture) {
-  std::cout << "B_2_2_5 - version numbers across PVs" << std::endl;
-
-  pushVariable.readLatest();
-
-  // Go to exception state, report it explicitly
-  ctk::VersionNumber someVersionBeforeReporting = {};
-  deviceBackend->throwExceptionOpen = true; // required to make sure device stays down
-  application.group1.device.reportException("explicit report by test");
-  deviceBackend->setException("explicit report by test"); // FIXME: should this be called by reportException()??
-  ctk::VersionNumber someVersionAfterReporting = {};
-
-  //  Check push variable
-  pushVariable.read();
-  auto exceptionVersion = pushVariable.getVersionNumber();
-  BOOST_CHECK(exceptionVersion > someVersionBeforeReporting);
-  BOOST_CHECK(exceptionVersion < someVersionAfterReporting);
-
-  // Check poll variable
-  pollVariable.read();
-  BOOST_CHECK(pollVariable.getVersionNumber() == exceptionVersion);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_2_6 \ref exceptionHandling_b_2_2_6 "B.2.2.6"
- *
- * "The data buffer is not updated. This guarantees that the data buffer stays on the last known value if the user code
- * has not modified it since the last read."
- */
-BOOST_FIXTURE_TEST_CASE(B_2_2_6, Fixture) {
-  std::cout << "B_2_2_6 - data buffer not updated" << std::endl;
-
-  pushVariable.readLatest();
-
-  // Write both variables once (without error state)
-  write(exceptionDummyRegister, 66);
-  deviceBackend->triggerInterrupt(1);
-  pushVariable.read();
-  BOOST_CHECK_EQUAL(pushVariable, 66);
-
-  write(exceptionDummyRegister, 67);
-  pollVariable.read();
-  BOOST_CHECK_EQUAL(pollVariable, 67);
-
-  // Go to exception state, report it explicitly
-  write(exceptionDummyRegister, 68);
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  pollVariable.read();
-
-  // Check push variable
-  pushVariable = 42;
-  BOOST_REQUIRE(pushVariable.dataValidity() == ctk::DataValidity::ok);
-  pushVariable.read();
-  BOOST_REQUIRE(pushVariable.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(pushVariable, 42);
-
-  // Check poll variable
-  pollVariable = 43;
-  pollVariable.read();
-  BOOST_CHECK_EQUAL(pollVariable, 43);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_3_3 \ref exceptionHandling_b_2_3_3 "B.2.3.3"
- *
- * "The return value of write() indicates whether data was lost in the transfer. If the write has to be delayed due to
- * an exception, the return value will be true (= data lost) if a previously delayed and not-yet written value is
- * discarded in the process, false (= no data lost) otherwise."
- */
-BOOST_FIXTURE_TEST_CASE(B_2_3_3, Fixture) {
-  std::cout << "B_2_3_3 - return value of write" << std::endl;
-
-  // trigger runtime error
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  pollVariable.read();
-
-  // multiple writes on faulty device.
-  outputVariable2 = 100;
-  auto testval = outputVariable2.write();
-  BOOST_CHECK_EQUAL(testval, false); // data not lost
-
-  outputVariable2 = 101;
-  BOOST_CHECK_EQUAL(outputVariable2.write(), true); // data lost
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_3_5 \ref exceptionHandling_b_2_3_5 "B.2.3.5"
- *
- * "It is guaranteed that the write takes place before the device is considered fully recovered again and other
- * transfers are allowed (cf. 3.1)."
- */
-BOOST_FIXTURE_TEST_CASE(B_2_3_5, Fixture) {
-  std::cout << "B_2_3_5 - write before deviceBecameFunctional" << std::endl;
-
-  // trigger runtime error
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  pollVariable.read();
-
-  // write on faulty device.
-  outputVariable2 = 987;
-  outputVariable2.write();
-
-  // recover device
-  deviceBackend->throwExceptionRead = false;
-  deviceBackend->throwExceptionOpen = false;
-  deviceBecameFunctional.read();
-
-  // check result (must be immediately present, so don't use CHECK_EQUAL_TIMEOUT!)
-  BOOST_CHECK_EQUAL(exceptionDummyRegister2[0], 987);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_2_5 \ref exceptionHandling_b_2_5 "B.2.5"
- *
- * "TransferElement::isReadable(), TransferElement::isWriteable() and TransferElement::isReadonly() return with values
- * as if reading and writing would be allowed."
- */
-BOOST_FIXTURE_TEST_CASE(B_2_5, Fixture) {
-  std::cout << "B_2_5 - isReadable/isWriteable/isReadOnly" << std::endl;
-
-  // trigger runtime error
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  pollVariable.read();
-
-  // Note: only test what is not anyway clear by the abstractor type. The others need to be implemented by the
-  // abstractor directly.
-  BOOST_CHECK(pollVariable.isReadable());
-
-  BOOST_CHECK(pushVariable.isReadable());
-
-  BOOST_CHECK(outputVariable2.isWriteable());
-  BOOST_CHECK(!outputVariable2.isReadOnly());
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_3_1_1 \ref exceptionHandling_b_3_1_1 "B.3.1.1"
- *
- * [The recovery procedure involves] "the execution of so-called initialisation handlers (see 3.2)."
- *
- * \anchor testExceptionHandling_b_3_2 \ref exceptionHandling_b_3_2 "B.3.2"
- *
- * "Any number of initialisation handlers can be added to the DeviceModule in the user code. Initialisation handlers are
- * callback functions which will be executed when a device is opened for the first time and after a device recovers from
- * an exception, before any application-initiated transfers are executed (including delayed write transfers).
- * See DeviceModule::addInitialisationHandler()."
- */
-BOOST_FIXTURE_TEST_CASE(B_3_1_1, Fixture_initHandlers) {
-  std::cout << "B_3_1_1 - initialisation handlers" << std::endl;
-
-  // device opened for first time
-  BOOST_CHECK(initHandler1Called);
-  BOOST_CHECK(initHandler2Called);
-  initHandler1Called = false;
-  initHandler2Called = false;
-
-  // trigger runtime error
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  pollVariable.read();
-
-  // init handlers should not yet be called
-  usleep(10000);
-  BOOST_CHECK(!initHandler1Called);
-  BOOST_CHECK(!initHandler2Called);
-
-  // trigger recovery, but let first init handler throw
-  initHandler1Throws = true;
-  deviceBackend->throwExceptionRead = false;
-  deviceBackend->throwExceptionOpen = false;
-
-  // init handler 1 must be called eventually, but not init handler 2
-  CHECK_TIMEOUT(initHandler1Called, 10000);
-  usleep(10000);
-  BOOST_CHECK(!initHandler2Called);
-
-  // let the first init handler complete, but not the second one
-  initHandler2Throws = true;
-  initHandler1Called = false;
-  initHandler1Throws = false;
-  CHECK_TIMEOUT(initHandler1Called, 10000);
-  CHECK_TIMEOUT(initHandler2Called, 10000);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_3_1_2 \ref exceptionHandling_b_3_1_2 "B.3.1.2"
- *
- * [After calling the initialisation handlers are called, the recovery procedure involves] "restoring all registers that
- * have been written since the start of the application with their latest values. The register values are restored in
- * the same order they were written. Registers of the type ChimeraTK::Void are not written."
- */
-BOOST_FIXTURE_TEST_CASE(B_3_1_2, Fixture_initHandlers) {
-  std::cout << "B_3_1_2 - delayed writes" << std::endl;
-
-  // trigger runtime error
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  pollVariable.read();
-  CHECK_TIMEOUT((status.readNonBlocking(), status == 1), 10000); // no test intended, just wait until error is reported
-
-  // get current write count for each register (as a reference)
-  auto wcReg2 = deviceBackend->getWriteCount("REG2");
-  auto wcReg3 = deviceBackend->getWriteCount("REG3");
-  auto wcRegV = deviceBackend->getWriteCount("REGV");
-
-  // multiple writes to different registers on faulty device
-  outputVariable2 = 801;
-  outputVariable2.write();
-  outputVariable3 = 802;
-  outputVariable3.write();
-  outputVariable2 = 803; // write a second time, overwriting the first value
-  outputVariable2.write();
-  outputVariableV.write(); // write the Void-typed register
-
-  // check that values are not yet written to the device
-  usleep(10000);
-  BOOST_CHECK_NE(exceptionDummyRegister2[0], 803);
-  BOOST_CHECK_NE(exceptionDummyRegister3[0], 802);
-
-  // recover device for reading/opening but not yet for writing
-  initHandler1Called = false;
-  deviceBackend->throwExceptionRead = false;
-  deviceBackend->throwExceptionWrite = true;
-  deviceBackend->throwExceptionOpen = false;
-
-  // wait until the write exception has been thrown
-  deviceBackend->throwExceptionCounter = 0;
-  CHECK_TIMEOUT(deviceBackend->throwExceptionCounter > 0, 10000);
-  BOOST_CHECK_NE(exceptionDummyRegister2[0], 803);
-  BOOST_CHECK_NE(exceptionDummyRegister3[0], 802);
-
-  // check that write attempt has happened after initialisation handlers are called
-  BOOST_CHECK(initHandler1Called);
-
-  // now let write operations complete
-  deviceBackend->throwExceptionWrite = false;
-
-  // check that values finally are written to the device
-  CHECK_EQUAL_TIMEOUT((exceptionDummyRegister2.getBufferLock(), exceptionDummyRegister2[0]), 803, 10000);
-  CHECK_EQUAL_TIMEOUT((exceptionDummyRegister3.getBufferLock(), exceptionDummyRegister3[0]), 802, 10000);
-
-  // check order of writes
-  auto woReg2 = deviceBackend->getWriteOrder("REG2");
-  auto woReg3 = deviceBackend->getWriteOrder("REG3");
-  BOOST_CHECK_GT(woReg2, woReg3);
-
-  // check each register is written only once ("only the latest written value [...] prevails"), except the Void register
-  BOOST_CHECK_EQUAL(deviceBackend->getWriteCount("REG2") - wcReg2, 1);
-  BOOST_CHECK_EQUAL(deviceBackend->getWriteCount("REG3") - wcReg3, 1);
-
-  // The Void-typed register must have not been written.
-  BOOST_CHECK_EQUAL(deviceBackend->getWriteCount("REGV"), wcRegV);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_3_1_3 \ref exceptionHandling_b_3_1_3 "B.3.1.3"
- *
- * [During recovery,] "the asynchronous read transfers of the device are (re-)activated by calling
- * Device::activateAsyncReads()" [after the delayed writes are executed.]
- */
-BOOST_FIXTURE_TEST_CASE(B_3_1_3, Fixture_initHandlers) {
-  std::cout << "B_3_1_3 - reactivate async reads" << std::endl;
-
-  // Test async read after first open
-  BOOST_CHECK(deviceBackend->asyncReadActivated());
-
-  // Cause runtime error
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  pollVariable.read();
-
-  // Write to register to latest test order of recovery procedure
-  outputVariable2.write();
-
-  // Just to make sure the test is sensitive
-  assert(deviceBackend->asyncReadActivated() == false);
-
-  auto reg2WriteCountBeforeRecovery = deviceBackend->getWriteCount("REG2");
-
-  // Recover from exception state
-  initHandler1Called = false;
-  deviceBackend->throwExceptionRead = false;
-  deviceBackend->throwExceptionOpen = false;
-
-  // Test async read after recovery
-  CHECK_TIMEOUT(deviceBackend->asyncReadActivated(), 10000);
-  BOOST_CHECK_EQUAL(deviceBackend->getWriteCount("REG2"), reg2WriteCountBeforeRecovery + 1);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_3_1_4 \ref exceptionHandling_b_3_1_4 "B.3.1.4"
- *
- * [As last part of the recovery,] "Devices/<alias>/deviceBecameFunctional is written to inform any module subscribing
- * to this variable about the finished recovery."
- */
-BOOST_FIXTURE_TEST_CASE(B_3_1_4, Fixture_initHandlers) {
-  std::cout << "B_3_1_4 - deviceBecameFunctional" << std::endl;
-
-  // (Note: deviceBecameFunctional is read inside the fixture for the first time!)
-  BOOST_CHECK(deviceBackend->asyncReadActivated());
-  BOOST_CHECK(initHandler1Called);
-
-  // Cause runtime error
-  deviceBackend->throwExceptionOpen = true;
-  deviceBackend->throwExceptionRead = true;
-  pollVariable.read();
-
-  // Make sure deviceBecameFunctional is not written at the wrong time
-  usleep(10000);
-  BOOST_CHECK(deviceBecameFunctional.readNonBlocking() == false);
-
-  // Recover from exception state
-  deviceBackend->throwExceptionRead = false;
-  deviceBackend->throwExceptionOpen = false;
-
-  // Check that deviceBecameFunctional is written after recovery
-  CHECK_TIMEOUT(deviceBecameFunctional.readNonBlocking() == true, 10000);
-
-  // Make sure deviceBecameFunctional is not written another time
-  usleep(10000);
-  BOOST_CHECK(deviceBecameFunctional.readNonBlocking() == false);
-}
-
-/**********************************************************************************************************************/
-/**
- * \anchor testExceptionHandling_b_4_1 \ref exceptionHandling_b_4_1 "B.4.1"
- *
- * "Even if some devices are initially in a persisting error state, the part of the application which does not interact
- * with the faulty devices starts and works normally."
- */
-BOOST_FIXTURE_TEST_CASE(B_4_1, Fixture_secondDeviceBroken) {
-  std::cout << "B_4_1 - broken devices don't affect unrelated modules" << std::endl;
-
-  pushVariable.readLatest();
-
-  // verify the 3 ApplicationModules work
-  write(exceptionDummyRegister, 101);
-  deviceBackend->triggerInterrupt(1);
-  pushVariable.read();
-  BOOST_CHECK_EQUAL(pushVariable, 101);
-
-  write(exceptionDummyRegister, 102);
-  pollVariable.read();
-  BOOST_CHECK_EQUAL(pollVariable, 102);
-
-  outputVariable2 = 103;
-  outputVariable2.write();
-  BOOST_CHECK_EQUAL(int(exceptionDummyRegister2), 103);
-
-  // make sure test is effective (device2 is still in error condition)
-  status2.readLatest();
-  assert(status2 == 1);
-}
-
-/**********************************************************************************************************************/
-
-BOOST_AUTO_TEST_SUITE_END()
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_4_nonBlocking \ref exceptionHandling_b_2_2_4 "B.2.2.4"
+   *
+   * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
+   * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
+   * (= hasNewData), and a new VersionNumber is obtained)."
+   *
+   * This test is for readNonBlocking().
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_4_nonBlocking, Fixture) {
+    std::cout << "B_2_2_4_nonBlocking - first skip of readNonBlocking" << std::endl;
+
+    pushVariable.readLatest();
+
+    // go to exception state
+    ctk::VersionNumber version = {};
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 123);
+    deviceBackend->triggerInterrupt(1);
+
+    // as soon as the fault state has arrived, the operation is skipped
+    CHECK_TIMEOUT(pushVariable.readNonBlocking() == true, 10000);
+    BOOST_CHECK_NE(pushVariable, 123); // value did not come through
+    BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
+    auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
+    BOOST_CHECK(versionNumberOnRuntimeError > version);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_4_any \ref exceptionHandling_b_2_2_4 "B.2.2.4"
+   *
+   * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
+   * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
+   * (= hasNewData), and a new VersionNumber is obtained)."
+   *
+   * This test is for readAny.
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_4_any, Fixture) {
+    std::cout << "B_2_2_4_any - first skip of readAny" << std::endl;
+
+    pushVariable.readLatest();
+
+    ChimeraTK::ReadAnyGroup group({pushVariable});
+
+    // go to exception state
+    ctk::VersionNumber version = {};
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 456);
+    deviceBackend->triggerInterrupt(1);
+
+    // as soon as the fault state has arrived, the operation is skipped
+    group.readAny();
+    BOOST_CHECK_NE(pushVariable, 456); // value did not come through
+    BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
+    auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
+    BOOST_CHECK(versionNumberOnRuntimeError > version);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_4_latest \ref exceptionHandling_b_2_2_4 "B.2.2.4"
+   *
+   * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
+   * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
+   * (= hasNewData), and a new VersionNumber is obtained)."
+   *
+   * This test is for readLatest().
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_4_latest, Fixture) {
+    std::cout << "B_2_2_4_latest - first skip of readLatest" << std::endl;
+
+    pushVariable.readLatest();
+
+    // go to exception state
+    ctk::VersionNumber version = {};
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 234);
+    deviceBackend->triggerInterrupt(1);
+
+    // as soon as the fault state has arrived, the operation is skipped
+    CHECK_TIMEOUT(pushVariable.readLatest() == true, 10000);
+    BOOST_CHECK_NE(pushVariable, 234); // value did not come through
+    BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
+    auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
+    BOOST_CHECK(versionNumberOnRuntimeError > version);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_4_ThFO \ref exceptionHandling_b_2_2_4 "B.2.2.4"
+   *
+   * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
+   * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
+   * (= hasNewData), and a new VersionNumber is obtained)."
+   *
+   * This test is for read() inside a ThreadedFanOut. (The ThreadedFanOut never calles the other read functions.)
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_4_ThFO, Fixture) {
+    std::cout << "B_2_2_4_ThFO - first skip read in ThreadedFanOut" << std::endl;
+
+    // remove initial value from control system
+    pushVariable3copy.readLatest();
+    pushVariable3.readLatest();
+
+    // go to exception state
+    ctk::VersionNumber version = {};
+    deviceBackend2->throwExceptionOpen = true;
+    deviceBackend2->throwExceptionRead = true;
+    write(exceptionDummy2Register, 345);
+    deviceBackend2->triggerInterrupt(1);
+
+    // as soon as the fault state has arrived, the operation is skipped
+    pushVariable3.read();
+    BOOST_CHECK_NE(pushVariable3, 345); // value did not come through
+    BOOST_CHECK(pushVariable3.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(pushVariable3.getVersionNumber() > version);
+
+    // same state is visible at control system's copy
+    pushVariable3copy.read();
+    BOOST_CHECK_NE(pushVariable3copy, 345); // value did not come through
+    BOOST_CHECK(pushVariable3copy.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(pushVariable3copy.getVersionNumber() > version);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_4_TrFO \ref exceptionHandling_b_2_2_4 "B.2.2.4"
+   *
+   * "Read operations with AccessMode::wait_for_new_data will be skipped once for each accessor to propagate the
+   * DataValidity::faulty flag (which counts as new data, i.e. readNonBlocking()/readLatest() will return true
+   * (= hasNewData), and a new VersionNumber is obtained)."
+   *
+   * This test is for read() inside a TriggerFanOut on the trigger variable.
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_4_TrFO, Fixture) {
+    std::cout << "B_2_2_4_TrFO - first skip read in TriggerFanOut on the trigger variable" << std::endl;
+
+    triggeredInput.readLatest();
+
+    // initialize to known value in deviceBackend register
+    write(exceptionDummy2Register, 668);
+    ctk::VersionNumber versionBeforeException = {};
+    deviceBackend3->triggerInterrupt(1);
+    triggeredInput.read();
+
+    // breaking the device and modify value
+    deviceBackend3->throwExceptionOpen = true;
+    deviceBackend3->throwExceptionRead = true;
+    write(exceptionDummy2Register, 669);
+    pollVariable3.read(); // make sure framework sees exception
+
+    // as soon as the fault state has arrived, the operation is skipped (inside the TriggerFanOut), so we get the
+    // updated value (remember: the updated value comes from another device which is not broken)
+    triggeredInput.read();
+    BOOST_CHECK_EQUAL(triggeredInput, 669);
+    BOOST_CHECK(triggeredInput.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(triggeredInput.getVersionNumber() > versionBeforeException);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_4_1_nonBlocking \ref exceptionHandling_b_2_2_4_1 "B.2.2.4.1"
+   *
+   * [After first skipped read operation in 2.2.4, the following] "non-blocking read operations (readNonBlocking() and
+   * readLatest()) are skipped and return false (= no new data), until the device is recovered".
+   *
+   * This test is for readNonBlocking().
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_4_1_nonBlocking, Fixture) {
+    std::cout << "B_2_2_4_1_nonBlocking - following skip readNonBlocking" << std::endl;
+
+    pushVariable.readLatest();
+
+    // go to exception state
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 100);
+    deviceBackend->triggerInterrupt(1);
+
+    // perform first skipped operation
+    pushVariable.read();
+    auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
+
+    // subsequent calls to readLatest on runtime error are skipped.
+    for(size_t i = 0; i < 5; ++i) {
+      usleep(1000);
+      BOOST_CHECK_EQUAL(pushVariable.readNonBlocking(), false);
+      BOOST_CHECK(versionNumberOnRuntimeError == pushVariable.getVersionNumber());
+      BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
+    }
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_4_1_latest \ref exceptionHandling_b_2_2_4_1 "B.2.2.4.1"
+   *
+   * [After first skipped read operation in 2.2.4, the following] "non-blocking read operations (readNonBlocking() and
+   * readLatest()) are skipped and return false (= no new data), until the device is recovered".
+   *
+   * This test is for readLatest().
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_4_1_latest, Fixture) {
+    std::cout << "B_2_2_4_1_latest - following skip readLatest" << std::endl;
+
+    pushVariable.readLatest();
+
+    // go to exception state
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 100);
+    deviceBackend->triggerInterrupt(1);
+
+    // perform first skipped operation
+    pushVariable.read();
+    auto versionNumberOnRuntimeError = pushVariable.getVersionNumber();
+
+    // subsequent calls to readLatest on runtime error are skipped.
+    for(size_t i = 0; i < 5; ++i) {
+      usleep(1000);
+      BOOST_CHECK_EQUAL(pushVariable.readLatest(), false);
+      BOOST_CHECK(versionNumberOnRuntimeError == pushVariable.getVersionNumber());
+      BOOST_CHECK(pushVariable.dataValidity() == ctk::DataValidity::faulty);
+    }
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_4_2 \ref exceptionHandling_b_2_2_4_2 "B.2.2.4.2"
+   *
+   * [After first skipped read operation in 2.2.4, the following] "blocking read operations (read()) will be frozen
+   * until the device is recovered."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_4_2, Fixture) {
+    std::cout << "B_2_2_4_2 - freeze blocking read" << std::endl;
+
+    pushVariable.readLatest();
+
+    // go to exception state
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 100);
+    deviceBackend->triggerInterrupt(1);
+
+    // perform first skipped operation
+    pushVariable.read();
+
+    // subsequent read operations should be frozen
+    deviceBackend->triggerInterrupt(1);
+    auto f = std::async(std::launch::async, [&]() { pushVariable.read(); });
+    BOOST_CHECK(f.wait_for(std::chrono::milliseconds(100)) == std::future_status::timeout);
+
+    // FIXME: This should not be necessary. Bug in ApplicationCore's shutdown procedure!?
+    deviceBackend->throwExceptionRead = false;
+    deviceBackend->throwExceptionOpen = false;
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_4_3 \ref exceptionHandling_b_2_2_4_3 "B.2.2.4.3"
+   *
+   * "After the device is fully recovered (cf. 3.1), the current value is (synchronously) read from the device. This is
+   * the first value received by the accessor after an exception."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_4_3, Fixture) {
+    std::cout << "B_2_2_4_3 - value after recovery" << std::endl;
+
+    pushVariable.readLatest();
+
+    // Normal behaviour
+    write(exceptionDummyRegister, 66);
+    deviceBackend->triggerInterrupt(1);
+    pushVariable.read();
+
+    // Change value while in exception state
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    write(exceptionDummyRegister, 77);
+    deviceBackend->triggerInterrupt(1);
+
+    pushVariable.read();
+    BOOST_CHECK_EQUAL(pushVariable, 66);
+
+    // Recover from exception state
+    deviceBackend->throwExceptionRead = false;
+    deviceBackend->throwExceptionOpen = false;
+
+    // Now the value needs to be read
+    CHECK_TIMEOUT(pushVariable.readNonBlocking() == true, 10000);
+    BOOST_CHECK_EQUAL(pushVariable, 77);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_5 \ref exceptionHandling_b_2_2_5 "B.2.2.5"
+   *
+   * "The VersionNumbers returned in case of an exception are the same for the same exception, even across variables and
+   * modules. It will be generated in the moment the exception is reported."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_5, Fixture) {
+    std::cout << "B_2_2_5 - version numbers across PVs" << std::endl;
+
+    pushVariable.readLatest();
+
+    // Go to exception state, report it explicitly
+    ctk::VersionNumber someVersionBeforeReporting = {};
+    deviceBackend->throwExceptionOpen = true; // required to make sure device stays down
+    application.group1.device.reportException("explicit report by test");
+    deviceBackend->setException("explicit report by test"); // FIXME: should this be called by reportException()??
+    ctk::VersionNumber someVersionAfterReporting = {};
+
+    //  Check push variable
+    pushVariable.read();
+    auto exceptionVersion = pushVariable.getVersionNumber();
+    BOOST_CHECK(exceptionVersion > someVersionBeforeReporting);
+    BOOST_CHECK(exceptionVersion < someVersionAfterReporting);
+
+    // Check poll variable
+    pollVariable.read();
+    BOOST_CHECK(pollVariable.getVersionNumber() == exceptionVersion);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_2_6 \ref exceptionHandling_b_2_2_6 "B.2.2.6"
+   *
+   * "The data buffer is not updated. This guarantees that the data buffer stays on the last known value if the user
+   * code has not modified it since the last read."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_2_6, Fixture) {
+    std::cout << "B_2_2_6 - data buffer not updated" << std::endl;
+
+    pushVariable.readLatest();
+
+    // Write both variables once (without error state)
+    write(exceptionDummyRegister, 66);
+    deviceBackend->triggerInterrupt(1);
+    pushVariable.read();
+    BOOST_CHECK_EQUAL(pushVariable, 66);
+
+    write(exceptionDummyRegister, 67);
+    pollVariable.read();
+    BOOST_CHECK_EQUAL(pollVariable, 67);
+
+    // Go to exception state, report it explicitly
+    write(exceptionDummyRegister, 68);
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    pollVariable.read();
+
+    // Check push variable
+    pushVariable = 42;
+    BOOST_REQUIRE(pushVariable.dataValidity() == ctk::DataValidity::ok);
+    pushVariable.read();
+    BOOST_REQUIRE(pushVariable.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(pushVariable, 42);
+
+    // Check poll variable
+    pollVariable = 43;
+    pollVariable.read();
+    BOOST_CHECK_EQUAL(pollVariable, 43);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_3_3 \ref exceptionHandling_b_2_3_3 "B.2.3.3"
+   *
+   * "The return value of write() indicates whether data was lost in the transfer. If the write has to be delayed due to
+   * an exception, the return value will be true (= data lost) if a previously delayed and not-yet written value is
+   * discarded in the process, false (= no data lost) otherwise."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_3_3, Fixture) {
+    std::cout << "B_2_3_3 - return value of write" << std::endl;
+
+    // trigger runtime error
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    pollVariable.read();
+
+    // multiple writes on faulty device.
+    outputVariable2 = 100;
+    auto testval = outputVariable2.write();
+    BOOST_CHECK_EQUAL(testval, false); // data not lost
+
+    outputVariable2 = 101;
+    BOOST_CHECK_EQUAL(outputVariable2.write(), true); // data lost
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_3_5 \ref exceptionHandling_b_2_3_5 "B.2.3.5"
+   *
+   * "It is guaranteed that the write takes place before the device is considered fully recovered again and other
+   * transfers are allowed (cf. 3.1)."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_3_5, Fixture) {
+    std::cout << "B_2_3_5 - write before deviceBecameFunctional" << std::endl;
+
+    // trigger runtime error
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    pollVariable.read();
+
+    // write on faulty device.
+    outputVariable2 = 987;
+    outputVariable2.write();
+
+    // recover device
+    deviceBackend->throwExceptionRead = false;
+    deviceBackend->throwExceptionOpen = false;
+    deviceBecameFunctional.read();
+
+    // check result (must be immediately present, so don't use CHECK_EQUAL_TIMEOUT!)
+    BOOST_CHECK_EQUAL(exceptionDummyRegister2[0], 987);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_2_5 \ref exceptionHandling_b_2_5 "B.2.5"
+   *
+   * "TransferElement::isReadable(), TransferElement::isWriteable() and TransferElement::isReadonly() return with values
+   * as if reading and writing would be allowed."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_2_5, Fixture) {
+    std::cout << "B_2_5 - isReadable/isWriteable/isReadOnly" << std::endl;
+
+    // trigger runtime error
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    pollVariable.read();
+
+    // Note: only test what is not anyway clear by the abstractor type. The others need to be implemented by the
+    // abstractor directly.
+    BOOST_CHECK(pollVariable.isReadable());
+
+    BOOST_CHECK(pushVariable.isReadable());
+
+    BOOST_CHECK(outputVariable2.isWriteable());
+    BOOST_CHECK(!outputVariable2.isReadOnly());
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_3_1_1 \ref exceptionHandling_b_3_1_1 "B.3.1.1"
+   *
+   * [The recovery procedure involves] "the execution of so-called initialisation handlers (see 3.2)."
+   *
+   * \anchor testExceptionHandling_b_3_2 \ref exceptionHandling_b_3_2 "B.3.2"
+   *
+   * "Any number of initialisation handlers can be added to the DeviceModule in the user code. Initialisation handlers
+   * are callback functions which will be executed when a device is opened for the first time and after a device
+   * recovers from an exception, before any application-initiated transfers are executed (including delayed write
+   * transfers). See DeviceModule::addInitialisationHandler()."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_3_1_1, Fixture_initHandlers) {
+    std::cout << "B_3_1_1 - initialisation handlers" << std::endl;
+
+    // device opened for first time
+    BOOST_CHECK(initHandler1Called);
+    BOOST_CHECK(initHandler2Called);
+    initHandler1Called = false;
+    initHandler2Called = false;
+
+    // trigger runtime error
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    pollVariable.read();
+
+    // init handlers should not yet be called
+    usleep(10000);
+    BOOST_CHECK(!initHandler1Called);
+    BOOST_CHECK(!initHandler2Called);
+
+    // trigger recovery, but let first init handler throw
+    initHandler1Throws = true;
+    deviceBackend->throwExceptionRead = false;
+    deviceBackend->throwExceptionOpen = false;
+
+    // init handler 1 must be called eventually, but not init handler 2
+    CHECK_TIMEOUT(initHandler1Called, 10000);
+    usleep(10000);
+    BOOST_CHECK(!initHandler2Called);
+
+    // let the first init handler complete, but not the second one
+    initHandler2Throws = true;
+    initHandler1Called = false;
+    initHandler1Throws = false;
+    CHECK_TIMEOUT(initHandler1Called, 10000);
+    CHECK_TIMEOUT(initHandler2Called, 10000);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_3_1_2 \ref exceptionHandling_b_3_1_2 "B.3.1.2"
+   *
+   * [After calling the initialisation handlers are called, the recovery procedure involves] "restoring all registers
+   * that have been written since the start of the application with their latest values. The register values are
+   * restored in the same order they were written. Registers of the type ChimeraTK::Void are not written."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_3_1_2, Fixture_initHandlers) {
+    std::cout << "B_3_1_2 - delayed writes" << std::endl;
+
+    // trigger runtime error
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    pollVariable.read();
+    CHECK_TIMEOUT(
+        (status.readNonBlocking(), status == 1), 10000); // no test intended, just wait until error is reported
+
+    // get current write count for each register (as a reference)
+    auto wcReg2 = deviceBackend->getWriteCount("REG2");
+    auto wcReg3 = deviceBackend->getWriteCount("REG3");
+    auto wcRegV = deviceBackend->getWriteCount("REGV");
+
+    // multiple writes to different registers on faulty device
+    outputVariable2 = 801;
+    outputVariable2.write();
+    outputVariable3 = 802;
+    outputVariable3.write();
+    outputVariable2 = 803; // write a second time, overwriting the first value
+    outputVariable2.write();
+    outputVariableV.write(); // write the Void-typed register
+
+    // check that values are not yet written to the device
+    usleep(10000);
+    BOOST_CHECK_NE(exceptionDummyRegister2[0], 803);
+    BOOST_CHECK_NE(exceptionDummyRegister3[0], 802);
+
+    // recover device for reading/opening but not yet for writing
+    initHandler1Called = false;
+    deviceBackend->throwExceptionRead = false;
+    deviceBackend->throwExceptionWrite = true;
+    deviceBackend->throwExceptionOpen = false;
+
+    // wait until the write exception has been thrown
+    deviceBackend->throwExceptionCounter = 0;
+    CHECK_TIMEOUT(deviceBackend->throwExceptionCounter > 0, 10000);
+    BOOST_CHECK_NE(exceptionDummyRegister2[0], 803);
+    BOOST_CHECK_NE(exceptionDummyRegister3[0], 802);
+
+    // check that write attempt has happened after initialisation handlers are called
+    BOOST_CHECK(initHandler1Called);
+
+    // now let write operations complete
+    deviceBackend->throwExceptionWrite = false;
+
+    // check that values finally are written to the device
+    CHECK_EQUAL_TIMEOUT((exceptionDummyRegister2.getBufferLock(), exceptionDummyRegister2[0]), 803, 10000);
+    CHECK_EQUAL_TIMEOUT((exceptionDummyRegister3.getBufferLock(), exceptionDummyRegister3[0]), 802, 10000);
+
+    // check order of writes
+    auto woReg2 = deviceBackend->getWriteOrder("REG2");
+    auto woReg3 = deviceBackend->getWriteOrder("REG3");
+    BOOST_CHECK_GT(woReg2, woReg3);
+
+    // check each register is written only once ("only the latest written value [...] prevails"), except the Void register
+    BOOST_CHECK_EQUAL(deviceBackend->getWriteCount("REG2") - wcReg2, 1);
+    BOOST_CHECK_EQUAL(deviceBackend->getWriteCount("REG3") - wcReg3, 1);
+
+    // The Void-typed register must have not been written.
+    BOOST_CHECK_EQUAL(deviceBackend->getWriteCount("REGV"), wcRegV);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_3_1_3 \ref exceptionHandling_b_3_1_3 "B.3.1.3"
+   *
+   * [During recovery,] "the asynchronous read transfers of the device are (re-)activated by calling
+   * Device::activateAsyncReads()" [after the delayed writes are executed.]
+   */
+  BOOST_FIXTURE_TEST_CASE(B_3_1_3, Fixture_initHandlers) {
+    std::cout << "B_3_1_3 - reactivate async reads" << std::endl;
+
+    // Test async read after first open
+    BOOST_CHECK(deviceBackend->asyncReadActivated());
+
+    // Cause runtime error
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    pollVariable.read();
+
+    // Write to register to latest test order of recovery procedure
+    outputVariable2.write();
+
+    // Just to make sure the test is sensitive
+    assert(deviceBackend->asyncReadActivated() == false);
+
+    auto reg2WriteCountBeforeRecovery = deviceBackend->getWriteCount("REG2");
+
+    // Recover from exception state
+    initHandler1Called = false;
+    deviceBackend->throwExceptionRead = false;
+    deviceBackend->throwExceptionOpen = false;
+
+    // Test async read after recovery
+    CHECK_TIMEOUT(deviceBackend->asyncReadActivated(), 10000);
+    BOOST_CHECK_EQUAL(deviceBackend->getWriteCount("REG2"), reg2WriteCountBeforeRecovery + 1);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_3_1_4 \ref exceptionHandling_b_3_1_4 "B.3.1.4"
+   *
+   * [As last part of the recovery,] "Devices/<alias>/deviceBecameFunctional is written to inform any module subscribing
+   * to this variable about the finished recovery."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_3_1_4, Fixture_initHandlers) {
+    std::cout << "B_3_1_4 - deviceBecameFunctional" << std::endl;
+
+    // (Note: deviceBecameFunctional is read inside the fixture for the first time!)
+    BOOST_CHECK(deviceBackend->asyncReadActivated());
+    BOOST_CHECK(initHandler1Called);
+
+    // Cause runtime error
+    deviceBackend->throwExceptionOpen = true;
+    deviceBackend->throwExceptionRead = true;
+    pollVariable.read();
+
+    // Make sure deviceBecameFunctional is not written at the wrong time
+    usleep(10000);
+    BOOST_CHECK(deviceBecameFunctional.readNonBlocking() == false);
+
+    // Recover from exception state
+    deviceBackend->throwExceptionRead = false;
+    deviceBackend->throwExceptionOpen = false;
+
+    // Check that deviceBecameFunctional is written after recovery
+    CHECK_TIMEOUT(deviceBecameFunctional.readNonBlocking() == true, 10000);
+
+    // Make sure deviceBecameFunctional is not written another time
+    usleep(10000);
+    BOOST_CHECK(deviceBecameFunctional.readNonBlocking() == false);
+  }
+
+  /**********************************************************************************************************************/
+  /**
+   * \anchor testExceptionHandling_b_4_1 \ref exceptionHandling_b_4_1 "B.4.1"
+   *
+   * "Even if some devices are initially in a persisting error state, the part of the application which does not
+   * interact with the faulty devices starts and works normally."
+   */
+  BOOST_FIXTURE_TEST_CASE(B_4_1, Fixture_secondDeviceBroken) {
+    std::cout << "B_4_1 - broken devices don't affect unrelated modules" << std::endl;
+
+    pushVariable.readLatest();
+
+    // verify the 3 ApplicationModules work
+    write(exceptionDummyRegister, 101);
+    deviceBackend->triggerInterrupt(1);
+    pushVariable.read();
+    BOOST_CHECK_EQUAL(pushVariable, 101);
+
+    write(exceptionDummyRegister, 102);
+    pollVariable.read();
+    BOOST_CHECK_EQUAL(pollVariable, 102);
+
+    outputVariable2 = 103;
+    outputVariable2.write();
+    BOOST_CHECK_EQUAL(int(exceptionDummyRegister2), 103);
+
+    // make sure test is effective (device2 is still in error condition)
+    status2.readLatest();
+    assert(status2 == 1);
+  }
+
+  /**********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace Tests::testExceptionHandling

--- a/tests/executables_src/testFanoutConnections.cc
+++ b/tests/executables_src/testFanoutConnections.cc
@@ -13,80 +13,84 @@
 #include <boost/mpl/list.hpp>
 #include <boost/test/included/unit_test.hpp>
 
-namespace ctk = ChimeraTK;
+namespace Tests::testFanoutConnections {
 
-struct TestModule1 : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-  ctk::ScalarPushInput<int> moduleTrigger{this, "moduleTrigger", "", ""};
+  namespace ctk = ChimeraTK;
 
-  ctk::ScalarPollInput<int> i3{this, "i3", "", ""};
+  struct TestModule1 : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+    ctk::ScalarPushInput<int> moduleTrigger{this, "moduleTrigger", "", ""};
 
-  ctk::ScalarOutput<int> moduleOutput{this, "moduleOutput", "", ""};
+    ctk::ScalarPollInput<int> i3{this, "i3", "", ""};
 
-  void mainLoop() override {
-    while(true) {
-      moduleTrigger.read();
+    ctk::ScalarOutput<int> moduleOutput{this, "moduleOutput", "", ""};
 
-      i3.readLatest();
+    void mainLoop() override {
+      while(true) {
+        moduleTrigger.read();
 
-      moduleOutput = int(i3);
+        i3.readLatest();
 
-      writeAll();
+        moduleOutput = int(i3);
+
+        writeAll();
+      }
     }
+  };
+
+  // FIXME: This test is probably already covered by one of the other test cases
+  // What it previously tested, a different connection order of device and application to CS, is
+  // no longer possible.
+  //
+  // the connection code has to create a consuming fan out because m1.i3 is a poll type consumer,
+  // and a trigger fan out because m1.i1 only has one push type consumer in the CS
+  struct TestApplication1 : ctk::Application {
+    TestApplication1() : Application("testApp") {}
+    ~TestApplication1() override { shutdown(); }
+
+    constexpr static char const* dummyCDD1 = "(dummy?map=testDataValidity1.map)";
+
+    TestModule1 m1{this, "m1", ""};
+    ctk::DeviceModule device{this, dummyCDD1, "/deviceTrigger"};
+  };
+
+  BOOST_AUTO_TEST_CASE(testConnectConsumingFanout) {
+    TestApplication1 theApp;
+    ctk::TestFacility testFacility{theApp};
+    ChimeraTK::Device dummy(TestApplication1::dummyCDD1);
+
+    // write initial values to the dummy before starting the application
+    dummy.open();
+    dummy.write("m1/i1/DUMMY_WRITEABLE", 12);
+    dummy.write("m1/i3/DUMMY_WRITEABLE", 32);
+
+    testFacility.runApplication();
+
+    BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i1"), 12);
+    BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i3"), 32);
+
+    // check that the trigger only affects i1
+    dummy.write("m1/i1/DUMMY_WRITEABLE", 13);
+    dummy.write("m1/i3/DUMMY_WRITEABLE", 33);
+
+    testFacility.getVoid("deviceTrigger").write();
+    testFacility.stepApplication();
+
+    BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i1"), 13);
+    BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i3"), 32);
+
+    // check that the module trigger updates i3
+    BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/moduleOutput"), 0);
+
+    dummy.write("m1/i1/DUMMY_WRITEABLE", 14);
+    dummy.write("m1/i3/DUMMY_WRITEABLE", 34);
+
+    testFacility.writeScalar<int>("m1/moduleTrigger", 1);
+    testFacility.stepApplication();
+
+    BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i1"), 13);
+    BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i3"), 34);
+    BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/moduleOutput"), 34);
   }
-};
 
-// FIXME: This test is probably already covered by one of the other test cases
-// What it previously tested, a different connection order of device and application to CS, is
-// no longer possible.
-//
-// the connection code has to create a consuming fan out because m1.i3 is a poll type consumer,
-// and a trigger fan out because m1.i1 only has one push type consumer in the CS
-struct TestApplication1 : ctk::Application {
-  TestApplication1() : Application("testApp") {}
-  ~TestApplication1() override { shutdown(); }
-
-  constexpr static char const* dummyCDD1 = "(dummy?map=testDataValidity1.map)";
-
-  TestModule1 m1{this, "m1", ""};
-  ctk::DeviceModule device{this, dummyCDD1, "/deviceTrigger"};
-};
-
-BOOST_AUTO_TEST_CASE(testConnectConsumingFanout) {
-  TestApplication1 theApp;
-  ctk::TestFacility testFacility{theApp};
-  ChimeraTK::Device dummy(TestApplication1::dummyCDD1);
-
-  // write initial values to the dummy before starting the application
-  dummy.open();
-  dummy.write("m1/i1/DUMMY_WRITEABLE", 12);
-  dummy.write("m1/i3/DUMMY_WRITEABLE", 32);
-
-  testFacility.runApplication();
-
-  BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i1"), 12);
-  BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i3"), 32);
-
-  // check that the trigger only affects i1
-  dummy.write("m1/i1/DUMMY_WRITEABLE", 13);
-  dummy.write("m1/i3/DUMMY_WRITEABLE", 33);
-
-  testFacility.getVoid("deviceTrigger").write();
-  testFacility.stepApplication();
-
-  BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i1"), 13);
-  BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i3"), 32);
-
-  // check that the module trigger updates i3
-  BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/moduleOutput"), 0);
-
-  dummy.write("m1/i1/DUMMY_WRITEABLE", 14);
-  dummy.write("m1/i3/DUMMY_WRITEABLE", 34);
-
-  testFacility.writeScalar<int>("m1/moduleTrigger", 1);
-  testFacility.stepApplication();
-
-  BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i1"), 13);
-  BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/i3"), 34);
-  BOOST_CHECK_EQUAL(testFacility.readScalar<int>("m1/moduleOutput"), 34);
-}
+} // namespace Tests::testFanoutConnections

--- a/tests/executables_src/testHierarchyModifyingGroup.cc
+++ b/tests/executables_src/testHierarchyModifyingGroup.cc
@@ -17,244 +17,248 @@
 #include <boost/test/included/unit_test.hpp>
 #include <boost/thread.hpp>
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testHierarchyModifyingGroup {
 
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
-/**
- * This test checks use of relative paths in modules at the example of a VariableGroup.
- *
- * TODO
- * - Rename this test source file
- * - Add checks for relative paths in ModuleGroups and ApplicationModules
- * - Add checks for relative paths in accessors
- */
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
+  /**
+   * This test checks use of relative paths in modules at the example of a VariableGroup.
+   *
+   * TODO
+   * - Rename this test source file
+   * - Add checks for relative paths in ModuleGroups and ApplicationModules
+   * - Add checks for relative paths in accessors
+   */
 
-struct TestGroup : public ctk::VariableGroup {
-  using ctk::VariableGroup::VariableGroup;
-  ctk::ScalarPushInput<int> myVar{this, "myVar", "MV/m", "Descrption"};
-};
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-struct TestApplication : public ctk::Application {
-  TestApplication() : Application("testSuite") {}
-  ~TestApplication() override { shutdown(); }
+  struct TestGroup : public ctk::VariableGroup {
+    using ctk::VariableGroup::VariableGroup;
+    ctk::ScalarPushInput<int> myVar{this, "myVar", "MV/m", "Descrption"};
+  };
 
-  struct TestModule : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
+  struct TestApplication : public ctk::Application {
+    TestApplication() : Application("testSuite") {}
+    ~TestApplication() override { shutdown(); }
 
-    TestGroup g;
+    struct TestModule : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
 
-    struct ExtraHierarchy : public ctk::VariableGroup {
-      using ctk::VariableGroup::VariableGroup;
       TestGroup g;
-    } extraHierarchy{this, "ExtraHierarchy", "Extra depth"};
 
-    void mainLoop() override {
-      if(getAccessorListRecursive().empty()) {
-        return;
+      struct ExtraHierarchy : public ctk::VariableGroup {
+        using ctk::VariableGroup::VariableGroup;
+        TestGroup g;
+      } extraHierarchy{this, "ExtraHierarchy", "Extra depth"};
+
+      void mainLoop() override {
+        if(getAccessorListRecursive().empty()) {
+          return;
+        }
+        assert(getAccessorListRecursive().size() == 1);
+        while(true) {
+          readAll();
+        }
       }
-      assert(getAccessorListRecursive().size() == 1);
-      while(true) {
-        readAll();
-      }
-    }
-  } testModule{this, "mod", "The test module"};
-};
+    } testModule{this, "mod", "The test module"};
+  };
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-void check(TestApplication& app, TestGroup& group, const std::string& name) {
-  static int myCounter = 42;
+  void check(TestApplication& app, TestGroup& group, const std::string& name) {
+    static int myCounter = 42;
 
-  ChimeraTK::TestFacility test{app};
-  auto acc = test.getScalar<int>(name + "/myVar");
-  test.runApplication();
+    ChimeraTK::TestFacility test{app};
+    auto acc = test.getScalar<int>(name + "/myVar");
+    test.runApplication();
 
-  acc = myCounter;
-  acc.write();
+    acc = myCounter;
+    acc.write();
 
-  test.stepApplication();
+    test.stepApplication();
 
-  BOOST_TEST(int(group.myVar) == myCounter);
+    BOOST_TEST(int(group.myVar) == myCounter);
 
-  ++myCounter;
-}
+    ++myCounter;
+  }
 
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(VariableGroupLike) {
-  std::cout << "*** VariableGroupLike" << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "VariableGroupLike", "Use like normal VariableGroup"};
-  check(app, app.testModule.g, "/mod/VariableGroupLike");
-}
+  BOOST_AUTO_TEST_CASE(VariableGroupLike) {
+    std::cout << "*** VariableGroupLike" << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "VariableGroupLike", "Use like normal VariableGroup"};
+    check(app, app.testModule.g, "/mod/VariableGroupLike");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(MoveToRoot) {
-  std::cout << "*** MoveToRoot" << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "/MoveToRoot", "Use like normal VariableGroup with MoveToRoot"};
-  check(app, app.testModule.g, "/MoveToRoot");
-}
+  BOOST_AUTO_TEST_CASE(MoveToRoot) {
+    std::cout << "*** MoveToRoot" << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "/MoveToRoot", "Use like normal VariableGroup with MoveToRoot"};
+    check(app, app.testModule.g, "/MoveToRoot");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(oneUp) {
-  std::cout << "*** ../oneUp" << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "../oneUp", "Use like normal VariableGroup with oneUp"};
-  check(app, app.testModule.g, "/oneUp");
-}
+  BOOST_AUTO_TEST_CASE(oneUp) {
+    std::cout << "*** ../oneUp" << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "../oneUp", "Use like normal VariableGroup with oneUp"};
+    check(app, app.testModule.g, "/oneUp");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(dotdot) {
-  std::cout << "*** .." << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "..", "Use like normal VariableGroup with oneUpAndHide"};
-  check(app, app.testModule.g, "");
-}
+  BOOST_AUTO_TEST_CASE(dotdot) {
+    std::cout << "*** .." << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "..", "Use like normal VariableGroup with oneUpAndHide"};
+    check(app, app.testModule.g, "");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(local_hierarchy) {
-  std::cout << "*** local/hierarchy" << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "local/hierarchy", "Create hierarchy locally"};
-  check(app, app.testModule.g, "/mod/local/hierarchy");
-}
+  BOOST_AUTO_TEST_CASE(local_hierarchy) {
+    std::cout << "*** local/hierarchy" << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "local/hierarchy", "Create hierarchy locally"};
+    check(app, app.testModule.g, "/mod/local/hierarchy");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(AtRoot_hierarchy) {
-  std::cout << "*** /AtRoot/hierarchy" << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "/AtRoot/hierarchy", "Create hierarchy at root"};
-  check(app, app.testModule.g, "/AtRoot/hierarchy");
-}
+  BOOST_AUTO_TEST_CASE(AtRoot_hierarchy) {
+    std::cout << "*** /AtRoot/hierarchy" << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "/AtRoot/hierarchy", "Create hierarchy at root"};
+    check(app, app.testModule.g, "/AtRoot/hierarchy");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(oneUp_hierarchy) {
-  std::cout << "*** ../oneUp/hierarchy" << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "../oneUp/hierarchy", "Create hierarchy one level up"};
-  check(app, app.testModule.g, "/oneUp/hierarchy");
-}
+  BOOST_AUTO_TEST_CASE(oneUp_hierarchy) {
+    std::cout << "*** ../oneUp/hierarchy" << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "../oneUp/hierarchy", "Create hierarchy one level up"};
+    check(app, app.testModule.g, "/oneUp/hierarchy");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(local_very_deep_hierarchy) {
-  std::cout << "*** local/very/deep/hierarchy" << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "local/very/deep/hierarchy", "Create deep hierarchy locally"};
-  check(app, app.testModule.g, "/mod/local/very/deep/hierarchy");
-}
+  BOOST_AUTO_TEST_CASE(local_very_deep_hierarchy) {
+    std::cout << "*** local/very/deep/hierarchy" << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "local/very/deep/hierarchy", "Create deep hierarchy locally"};
+    check(app, app.testModule.g, "/mod/local/very/deep/hierarchy");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(root_very_deep_hierarchy) {
-  std::cout << "*** /root/very/deep/hierarchy" << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "/root/very/deep/hierarchy", "Create deep hierarchy at root"};
-  check(app, app.testModule.g, "/root/very/deep/hierarchy");
-}
+  BOOST_AUTO_TEST_CASE(root_very_deep_hierarchy) {
+    std::cout << "*** /root/very/deep/hierarchy" << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "/root/very/deep/hierarchy", "Create deep hierarchy at root"};
+    check(app, app.testModule.g, "/root/very/deep/hierarchy");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(oneUp_very_deep_hierarchy) {
-  std::cout << "*** ../oneUp/very/deep/hierarchy" << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "../oneUp/very/deep/hierarchy", "Create deep hierarchy one level up"};
-  check(app, app.testModule.g, "/oneUp/very/deep/hierarchy");
-}
+  BOOST_AUTO_TEST_CASE(oneUp_very_deep_hierarchy) {
+    std::cout << "*** ../oneUp/very/deep/hierarchy" << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "../oneUp/very/deep/hierarchy", "Create deep hierarchy one level up"};
+    check(app, app.testModule.g, "/oneUp/very/deep/hierarchy");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(extra_slashes_everywhere) {
-  std::cout << "*** //extra//slashes////everywhere///" << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "//extra//slashes////everywhere///", "Extra slashes"};
-  check(app, app.testModule.g, "");
-}
+  BOOST_AUTO_TEST_CASE(extra_slashes_everywhere) {
+    std::cout << "*** //extra//slashes////everywhere///" << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "//extra//slashes////everywhere///", "Extra slashes"};
+    check(app, app.testModule.g, "");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(twoUp) {
-  std::cout << "*** twoUp" << std::endl;
-  TestApplication app;
-  app.testModule.extraHierarchy.g = {&app.testModule.extraHierarchy, "../../twoUp", "Two levels up"};
-  check(app, app.testModule.extraHierarchy.g, "/twoUp");
-}
+  BOOST_AUTO_TEST_CASE(twoUp) {
+    std::cout << "*** twoUp" << std::endl;
+    TestApplication app;
+    app.testModule.extraHierarchy.g = {&app.testModule.extraHierarchy, "../../twoUp", "Two levels up"};
+    check(app, app.testModule.extraHierarchy.g, "/twoUp");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(hierarchy_with_dots_anywhere_also_single_dots) {
-  std::cout << "*** hierarchy/with/../dots/../../anywhere/./also/./single/./dots/.." << std::endl;
-  TestApplication app;
-  app.testModule.g = {
-      &app.testModule, "hierarchy/with/../dots/../../anywhere/./also/./single/./dots/..", "Dots everywhere "};
-  app.getModel().writeGraphViz("vg_test.dot");
-  check(app, app.testModule.g, "/mod/anywhere/also/single");
-}
+  BOOST_AUTO_TEST_CASE(hierarchy_with_dots_anywhere_also_single_dots) {
+    std::cout << "*** hierarchy/with/../dots/../../anywhere/./also/./single/./dots/.." << std::endl;
+    TestApplication app;
+    app.testModule.g = {
+        &app.testModule, "hierarchy/with/../dots/../../anywhere/./also/./single/./dots/..", "Dots everywhere "};
+    app.getModel().writeGraphViz("vg_test.dot");
+    check(app, app.testModule.g, "/mod/anywhere/also/single");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(dot) {
-  std::cout << "*** ." << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, ".", "This is like hideThis"};
-  check(app, app.testModule.g, "/mod");
-}
+  BOOST_AUTO_TEST_CASE(dot) {
+    std::cout << "*** ." << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, ".", "This is like hideThis"};
+    check(app, app.testModule.g, "/mod");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(dot_at_end) {
-  std::cout << "*** dot/at/end/." << std::endl;
-  TestApplication app;
-  app.testModule.g = {&app.testModule, "dot/at/end/.", "Gets effectively ignored..."};
-  check(app, app.testModule.g, "/mod/dot/at/end");
-}
+  BOOST_AUTO_TEST_CASE(dot_at_end) {
+    std::cout << "*** dot/at/end/." << std::endl;
+    TestApplication app;
+    app.testModule.g = {&app.testModule, "dot/at/end/.", "Gets effectively ignored..."};
+    check(app, app.testModule.g, "/mod/dot/at/end");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(MoveToRootFromHidden) {
-  std::cout << "*** MoveToRootFromHidden" << std::endl;
-  TestApplication app;
-  app.testModule = {&app, ".", "The test module is hidden now"};
-  app.testModule.g = {&app.testModule, "/MoveToRootFromHidden",
-      "Use like normal VariableGroup with MoveToRoot, and place inside a hidden to-level module"};
-  check(app, app.testModule.g, "/MoveToRootFromHidden");
-}
+  BOOST_AUTO_TEST_CASE(MoveToRootFromHidden) {
+    std::cout << "*** MoveToRootFromHidden" << std::endl;
+    TestApplication app;
+    app.testModule = {&app, ".", "The test module is hidden now"};
+    app.testModule.g = {&app.testModule, "/MoveToRootFromHidden",
+        "Use like normal VariableGroup with MoveToRoot, and place inside a hidden to-level module"};
+    check(app, app.testModule.g, "/MoveToRootFromHidden");
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-struct TestApplicationEmpty : public ctk::Application {
-  TestApplicationEmpty() : Application("testSuite") {}
-  ~TestApplicationEmpty() override { shutdown(); }
+  struct TestApplicationEmpty : public ctk::Application {
+    TestApplicationEmpty() : Application("testSuite") {}
+    ~TestApplicationEmpty() override { shutdown(); }
 
-  struct TestModule : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
-    void mainLoop() override {}
-  } testModule{this, "TestModule", "The test module"};
-};
+    struct TestModule : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
+      void mainLoop() override {}
+    } testModule{this, "TestModule", "The test module"};
+  };
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(bad_path_exception) {
-  std::cout << "*** bad_path_exception" << std::endl;
-  TestApplicationEmpty app;
-  BOOST_CHECK_THROW(TestGroup tg(&app.testModule, "/../cannot/work", "This is not allowed"), ctk::logic_error);
-  BOOST_CHECK_THROW(TestGroup tg(&app.testModule, "/..", "This is not allowed either"), ctk::logic_error);
-  BOOST_CHECK_THROW(
-      TestGroup tg(&app.testModule, "/somthing/less/../../../obvious", "This is also not allowed"), ctk::logic_error);
-}
+  BOOST_AUTO_TEST_CASE(bad_path_exception) {
+    std::cout << "*** bad_path_exception" << std::endl;
+    TestApplicationEmpty app;
+    BOOST_CHECK_THROW(TestGroup tg(&app.testModule, "/../cannot/work", "This is not allowed"), ctk::logic_error);
+    BOOST_CHECK_THROW(TestGroup tg(&app.testModule, "/..", "This is not allowed either"), ctk::logic_error);
+    BOOST_CHECK_THROW(
+        TestGroup tg(&app.testModule, "/somthing/less/../../../obvious", "This is also not allowed"), ctk::logic_error);
+  }
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
+
+} // namespace Tests::testHierarchyModifyingGroup

--- a/tests/executables_src/testIllegalNetworks.cc
+++ b/tests/executables_src/testIllegalNetworks.cc
@@ -17,166 +17,171 @@
 #include <boost/mpl/list.hpp>
 #include <boost/test/included/unit_test.hpp>
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testIllegalNetworks {
 
-// list of user types the accessors are tested with
-using TestTypes = boost::mpl::list<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, float, double, ctk::Boolean>;
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
-/*********************************************************************************************************************/
-/* test case for two scalar accessors, feeder in poll mode and consumer in push
- * mode (without trigger) */
+  // list of user types the accessors are tested with
+  using TestTypes =
+      boost::mpl::list<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, float, double, ctk::Boolean>;
 
-struct TestApplication1 : public ctk::Application {
-  TestApplication1() : Application("testSuite") {}
-  ~TestApplication1() override { shutdown(); }
+  /*********************************************************************************************************************/
+  /* test case for two scalar accessors, feeder in poll mode and consumer in push
+   * mode (without trigger) */
 
-  ctk::SetDMapFilePath dmap{"test.dmap"};
+  struct TestApplication1 : public ctk::Application {
+    TestApplication1() : Application("testSuite") {}
+    ~TestApplication1() override { shutdown(); }
 
-  struct : ctk::ApplicationModule {
-    using ApplicationModule::ApplicationModule;
+    ctk::SetDMapFilePath dmap{"test.dmap"};
 
-    ctk::ScalarPushInput<int> consumingPush{this, "/MyModule/readBack", "", ""};
+    struct : ctk::ApplicationModule {
+      using ApplicationModule::ApplicationModule;
 
-    void mainLoop() override {}
-  } testModule{(this), ".", ""}; // extra parentheses are for doxygen...
+      ctk::ScalarPushInput<int> consumingPush{this, "/MyModule/readBack", "", ""};
 
-  ctk::DeviceModule dev{this, "Dummy0"};
-};
+      void mainLoop() override {}
+    } testModule{(this), ".", ""}; // extra parentheses are for doxygen...
 
-BOOST_AUTO_TEST_CASE(testTwoScalarPollPushAccessors) {
-  TestApplication1 app;
-  app.debugMakeConnections();
+    ctk::DeviceModule dev{this, "Dummy0"};
+  };
 
-  BOOST_CHECK_THROW(
-      {
-        app.initialise();
-        app.run();
-      },
-      ctk::logic_error);
-}
+  BOOST_AUTO_TEST_CASE(testTwoScalarPollPushAccessors) {
+    TestApplication1 app;
+    app.debugMakeConnections();
 
-/*********************************************************************************************************************/
-/* test case for two feeders */
+    BOOST_CHECK_THROW(
+        {
+          app.initialise();
+          app.run();
+        },
+        ctk::logic_error);
+  }
 
-template<typename T>
-struct TestApplication3 : public ctk::Application {
-  TestApplication3() : Application("testSuite") { debugMakeConnections(); }
-  ~TestApplication3() override { shutdown(); }
+  /*********************************************************************************************************************/
+  /* test case for two feeders */
 
-  struct : ctk::ApplicationModule {
-    using ApplicationModule::ApplicationModule;
+  template<typename T>
+  struct TestApplication3 : public ctk::Application {
+    TestApplication3() : Application("testSuite") { debugMakeConnections(); }
+    ~TestApplication3() override { shutdown(); }
 
-    ctk::ScalarOutput<T> consumingPush{this, "/MyModule/readBack", "", ""};
+    struct : ctk::ApplicationModule {
+      using ApplicationModule::ApplicationModule;
 
-    void mainLoop() override {}
-  } testModule{this, ".", ""};
+      ctk::ScalarOutput<T> consumingPush{this, "/MyModule/readBack", "", ""};
 
-  struct : ctk::ApplicationModule {
-    using ApplicationModule::ApplicationModule;
+      void mainLoop() override {}
+    } testModule{this, ".", ""};
 
-    ctk::ScalarOutput<T> consumingPush2{this, "/MyModule/readBack", "", ""};
+    struct : ctk::ApplicationModule {
+      using ApplicationModule::ApplicationModule;
 
-    void mainLoop() override {}
-  } testModule2{this, ".", ""};
-};
+      ctk::ScalarOutput<T> consumingPush2{this, "/MyModule/readBack", "", ""};
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(testTwoFeeders, T, TestTypes) {
-  TestApplication3<T> app;
+      void mainLoop() override {}
+    } testModule2{this, ".", ""};
+  };
 
-  BOOST_CHECK_THROW(ctk::TestFacility tf(app, false), ctk::logic_error);
-}
+  BOOST_AUTO_TEST_CASE_TEMPLATE(testTwoFeeders, T, TestTypes) {
+    TestApplication3<T> app;
 
-/*********************************************************************************************************************/
-/* test case for too many polling consumers */
+    BOOST_CHECK_THROW(ctk::TestFacility tf(app, false), ctk::logic_error);
+  }
 
-struct TestApplication4 : public ctk::Application {
-  TestApplication4() : Application("testSuite") { debugMakeConnections(); }
-  ~TestApplication4() override { shutdown(); }
+  /*********************************************************************************************************************/
+  /* test case for too many polling consumers */
 
-  ctk::SetDMapFilePath dmap{"test.dmap"};
+  struct TestApplication4 : public ctk::Application {
+    TestApplication4() : Application("testSuite") { debugMakeConnections(); }
+    ~TestApplication4() override { shutdown(); }
 
-  struct : ctk::ApplicationModule {
-    using ApplicationModule::ApplicationModule;
+    ctk::SetDMapFilePath dmap{"test.dmap"};
 
-    ctk::ScalarPollInput<int> consumingPush{this, "/MyModule/readBack", "", ""};
+    struct : ctk::ApplicationModule {
+      using ApplicationModule::ApplicationModule;
 
-    void mainLoop() override {}
-  } testModule{this, ".", ""};
+      ctk::ScalarPollInput<int> consumingPush{this, "/MyModule/readBack", "", ""};
 
-  struct : ctk::ApplicationModule {
-    using ApplicationModule::ApplicationModule;
+      void mainLoop() override {}
+    } testModule{this, ".", ""};
 
-    ctk::ScalarPollInput<int> consumingPush2{this, "/MyModule/readBack", "", ""};
+    struct : ctk::ApplicationModule {
+      using ApplicationModule::ApplicationModule;
 
-    void mainLoop() override {}
-  } testModule2{this, ".", ""};
+      ctk::ScalarPollInput<int> consumingPush2{this, "/MyModule/readBack", "", ""};
 
-  ctk::DeviceModule dev{this, "Dummy0"};
-};
+      void mainLoop() override {}
+    } testModule2{this, ".", ""};
 
-BOOST_AUTO_TEST_CASE(testTooManyPollingConsumers) {
-  TestApplication4 app;
+    ctk::DeviceModule dev{this, "Dummy0"};
+  };
 
-  BOOST_CHECK_THROW(
-      {
-        app.initialise();
-        app.run();
-      },
-      ctk::logic_error);
-}
+  BOOST_AUTO_TEST_CASE(testTooManyPollingConsumers) {
+    TestApplication4 app;
 
-/*********************************************************************************************************************/
-/* test case for different number of elements */
+    BOOST_CHECK_THROW(
+        {
+          app.initialise();
+          app.run();
+        },
+        ctk::logic_error);
+  }
 
-template<typename T>
-struct TestApplication5 : public ctk::Application {
-  TestApplication5() : Application("testSuite") { debugMakeConnections(); }
-  ~TestApplication5() override { shutdown(); }
+  /*********************************************************************************************************************/
+  /* test case for different number of elements */
 
-  struct : ctk::ApplicationModule {
-    using ApplicationModule::ApplicationModule;
+  template<typename T>
+  struct TestApplication5 : public ctk::Application {
+    TestApplication5() : Application("testSuite") { debugMakeConnections(); }
+    ~TestApplication5() override { shutdown(); }
 
-    ctk::ArrayOutput<T> feed{this, "/MyModule/readBack", "", 10, ""};
+    struct : ctk::ApplicationModule {
+      using ApplicationModule::ApplicationModule;
 
-    void mainLoop() override {}
-  } testModule{this, ".", ""};
+      ctk::ArrayOutput<T> feed{this, "/MyModule/readBack", "", 10, ""};
 
-  struct : ctk::ApplicationModule {
-    using ApplicationModule::ApplicationModule;
+      void mainLoop() override {}
+    } testModule{this, ".", ""};
 
-    ctk::ArrayPollInput<T> consume{this, "/MyModule/readBack", "", 20, ""};
+    struct : ctk::ApplicationModule {
+      using ApplicationModule::ApplicationModule;
 
-    void mainLoop() override {}
-  } testModule2{this, ".", ""};
-};
+      ctk::ArrayPollInput<T> consume{this, "/MyModule/readBack", "", 20, ""};
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(testDifferentNrElements, T, TestTypes) {
-  TestApplication5<T> app;
-  BOOST_CHECK_THROW(ctk::TestFacility tf(app, false), ctk::logic_error);
-}
+      void mainLoop() override {}
+    } testModule2{this, ".", ""};
+  };
 
-/*********************************************************************************************************************/
-/* test case for zero-length elements that are not void */
+  BOOST_AUTO_TEST_CASE_TEMPLATE(testDifferentNrElements, T, TestTypes) {
+    TestApplication5<T> app;
+    BOOST_CHECK_THROW(ctk::TestFacility tf(app, false), ctk::logic_error);
+  }
 
-template<typename T>
-struct TestApplication6 : public ctk::Application {
-  TestApplication6() : Application("testSuite") { debugMakeConnections(); }
-  ~TestApplication6() override { shutdown(); }
+  /*********************************************************************************************************************/
+  /* test case for zero-length elements that are not void */
 
-  struct : ctk::ApplicationModule {
-    using ApplicationModule::ApplicationModule;
+  template<typename T>
+  struct TestApplication6 : public ctk::Application {
+    TestApplication6() : Application("testSuite") { debugMakeConnections(); }
+    ~TestApplication6() override { shutdown(); }
 
-    ctk::ArrayOutput<T> feed{this, "/MyModule/readBack", "", 0, ""};
+    struct : ctk::ApplicationModule {
+      using ApplicationModule::ApplicationModule;
 
-    void mainLoop() override {}
-  } testModule{this, ".", ""};
+      ctk::ArrayOutput<T> feed{this, "/MyModule/readBack", "", 0, ""};
 
-  struct : ctk::ApplicationModule {
-    using ApplicationModule::ApplicationModule;
+      void mainLoop() override {}
+    } testModule{this, ".", ""};
 
-    ctk::ArrayPollInput<T> consume{this, "/MyModule/readBack", "", 0, ""};
+    struct : ctk::ApplicationModule {
+      using ApplicationModule::ApplicationModule;
 
-    void mainLoop() override {}
-  } testModule2{this, ".", ""};
-};
+      ctk::ArrayPollInput<T> consume{this, "/MyModule/readBack", "", 0, ""};
+
+      void mainLoop() override {}
+    } testModule2{this, ".", ""};
+  };
+
+} // namespace Tests::testIllegalNetworks

--- a/tests/executables_src/testInitialValueSpecD8.cc
+++ b/tests/executables_src/testInitialValueSpecD8.cc
@@ -22,870 +22,876 @@
 #include <future>
 #include <VoidAccessor.h>
 
-/*********************************************************************************************************************/
+namespace Tests::testInitialValues {
 
-// Base Application module that provides flags for the various phases
-// of module lifetime and full-fills a promise when the main loop has been reached
-struct NotifyingModule : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
+  /*********************************************************************************************************************/
 
-  std::promise<void> p;
-  std::atomic_bool enteredTheMainLoop{false};
-  std::atomic_bool enteredThePrepareLoop{false};
-  void mainLoop() override {
-    enteredTheMainLoop = true;
-    p.set_value();
+  // Base Application module that provides flags for the various phases
+  // of module lifetime and full-fills a promise when the main loop has been reached
+  struct NotifyingModule : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
+
+    std::promise<void> p;
+    std::atomic_bool enteredTheMainLoop{false};
+    std::atomic_bool enteredThePrepareLoop{false};
+    void mainLoop() override {
+      enteredTheMainLoop = true;
+      p.set_value();
+    }
+    void prepare() override { enteredThePrepareLoop = true; }
+  };
+
+  /*********************************************************************************************************************/
+
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
+  // A generic module with just one input. It is connected manually, so we just call the register "REG1" so we easily
+  // connect to that register in the device It has a flag and a promise to check whether the module has entered the main
+  // loop, and to wait for it.
+  template<class INPUT_TYPE>
+  struct InputModule : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
+    INPUT_TYPE input{this, "/REG1", "", ""};
+    std::promise<void> p;
+    std::atomic_bool enteredTheMainLoop{false};
+    void mainLoop() override {
+      enteredTheMainLoop = true;
+      p.set_value();
+    }
+  };
+
+  struct PollDummyApplication : ChimeraTK::Application {
+    constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test-ro.map)";
+    PollDummyApplication() : Application("DummyApplication") {}
+    ~PollDummyApplication() override { shutdown(); }
+
+    InputModule<ctk::ScalarPollInput<int>> inputModule{this, "PollModule", ""};
+    ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
+  };
+
+  // for the push type we need different connection code
+  struct PushDummyApplication : ChimeraTK::Application {
+    constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:2?map=test-async.map)";
+    PushDummyApplication() : Application("DummyApplication") {}
+    ~PushDummyApplication() override { shutdown(); }
+
+    InputModule<ctk::ScalarPushInput<int>> inputModule{this, "PushModule", ""};
+    ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
+  };
+
+  template<class APPLICATION_TYPE>
+  struct TestFixtureWithEceptionDummy {
+    TestFixtureWithEceptionDummy()
+    : deviceBackend(boost::dynamic_pointer_cast<ChimeraTK::ExceptionDummy>(
+          ChimeraTK::BackendFactory::getInstance().createBackend(APPLICATION_TYPE::ExceptionDummyCDD1))) {}
+    ~TestFixtureWithEceptionDummy() { deviceBackend->throwExceptionRead = false; }
+
+    boost::shared_ptr<ChimeraTK::ExceptionDummy> deviceBackend;
+    APPLICATION_TYPE application;
+    ChimeraTK::TestFacility testFacility{application, false};
+    ChimeraTK::ScalarRegisterAccessor<int> exceptionDummyRegister;
+  };
+  /**
+   *  Test Initial Values - Inputs of `ApplicationModule`s
+   *  InitialValuesInputsOfApplicationCore_D_8 "D.8"
+   */
+  BOOST_AUTO_TEST_SUITE(testInitialValuesInputsOfApplicationCore_D_8)
+  using DeviceTestApplicationTypes = boost::mpl::list<PushDummyApplication, PollDummyApplication>;
+
+  /**
+   *  For device variables the ExceptionHandlingDecorator freezes the variable until the device is available
+   * \anchor testInitialValue_D_8_b_i \ref initialValue_D_8_b_i
+   */
+  BOOST_AUTO_TEST_CASE_TEMPLATE(testInitValueAtDevice8bi, APPLICATION_TYPE, DeviceTestApplicationTypes) {
+    std::cout << "===   testInitValueAtDevice8bi " << typeid(APPLICATION_TYPE).name() << "  ===" << std::endl;
+    std::chrono::time_point<std::chrono::steady_clock> start, end;
+    { // Here the time is stopped until you reach the mainloop.
+      TestFixtureWithEceptionDummy<APPLICATION_TYPE> dummyToStopTimeUntilOpen;
+      start = std::chrono::steady_clock::now();
+      dummyToStopTimeUntilOpen.application.run();
+      dummyToStopTimeUntilOpen.application.inputModule.p.get_future().wait();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      end = std::chrono::steady_clock::now();
+    }
+    { // waiting 2 x the time stopped above, in the assumption that it is then frozen,
+      // as it is described in the spec.
+      TestFixtureWithEceptionDummy<APPLICATION_TYPE> d;
+      d.deviceBackend->throwExceptionOpen = true;
+      BOOST_CHECK_THROW(d.deviceBackend->open(), std::exception);
+      d.deviceBackend->throwExceptionOpen = true;
+      d.application.run();
+      auto elapsed_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+      BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == false);
+      std::this_thread::sleep_for(std::chrono::milliseconds(2 * elapsed_milliseconds));
+      BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == false);
+      BOOST_CHECK(d.application.inputModule.input.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
+      d.deviceBackend->throwExceptionOpen = false;
+      d.application.inputModule.p.get_future().wait();
+      BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == true);
+      BOOST_CHECK(d.application.inputModule.input.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+    }
   }
-  void prepare() override { enteredThePrepareLoop = true; }
-};
 
-/*********************************************************************************************************************/
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
-// A generic module with just one input. It is connected manually, so we just call the register "REG1" so we easily
-// connect to that register in the device It has a flag and a promise to check whether the module has entered the main
-// loop, and to wait for it.
-template<class INPUT_TYPE>
-struct InputModule : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
-  INPUT_TYPE input{this, "/REG1", "", ""};
-  std::promise<void> p;
-  std::atomic_bool enteredTheMainLoop{false};
-  void mainLoop() override {
-    enteredTheMainLoop = true;
-    p.set_value();
+  struct ScalarOutputModule : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
+    ChimeraTK::ScalarOutput<int> output{this, "REG1", "", ""};
+    std::promise<void> p;
+    std::atomic_bool enteredTheMainLoop{false};
+    void mainLoop() override {
+      enteredTheMainLoop = true;
+      p.set_value();
+    }
+  };
+
+  template<class INPUT_TYPE>
+  struct ProcessArryDummyApplication : ChimeraTK::Application {
+    constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test.map)";
+    ProcessArryDummyApplication() : Application("DummyApplication") {}
+    ~ProcessArryDummyApplication() override { shutdown(); }
+
+    InputModule<INPUT_TYPE> inputModule{this, ".", ""};
+    ScalarOutputModule scalarOutputModule{this, ".", ""};
+  };
+
+  using TestInputTypes = boost::mpl::list<ctk::ScalarPollInput<int>, ctk::ScalarPushInput<int>>;
+
+  /**
+   *  ProcessArray freeze in their implementation until the initial value is received
+   * \anchor testInitialValue_D_8_b_ii \ref initialValue_D_8_b_ii
+   */
+  BOOST_AUTO_TEST_CASE_TEMPLATE(testProcessArrayInitValueAtDevice8bii, INPUT_TYPE, TestInputTypes) {
+    std::cout << "===   testPollProcessArrayInitValueAtDevice8bii " << typeid(INPUT_TYPE).name()
+              << "  === " << std::endl;
+    std::chrono::time_point<std::chrono::steady_clock> start, end;
+    {
+      // we don't need the exception dummy in this test. But no need to write a new fixture for it.
+      TestFixtureWithEceptionDummy<ProcessArryDummyApplication<INPUT_TYPE>> dummyToStopTimeForApplicationStart;
+      start = std::chrono::steady_clock::now();
+      dummyToStopTimeForApplicationStart.application.run();
+      dummyToStopTimeForApplicationStart.application.scalarOutputModule.output.write();
+      dummyToStopTimeForApplicationStart.application.inputModule.p.get_future().wait();
+      end = std::chrono::steady_clock::now();
+    }
+    {
+      TestFixtureWithEceptionDummy<ProcessArryDummyApplication<INPUT_TYPE>> d;
+      d.application.run();
+      BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == false);
+      std::this_thread::sleep_for(end - start);
+      BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == false);
+      BOOST_CHECK(d.application.inputModule.input.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
+      d.application.scalarOutputModule.output.write();
+      d.application.inputModule.p.get_future().wait();
+      BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == true);
+      BOOST_CHECK(d.application.inputModule.input.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+    }
   }
-};
 
-struct PollDummyApplication : ChimeraTK::Application {
-  constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test-ro.map)";
-  PollDummyApplication() : Application("DummyApplication") {}
-  ~PollDummyApplication() override { shutdown(); }
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  InputModule<ctk::ScalarPollInput<int>> inputModule{this, "PollModule", ""};
-  ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
-};
+  template<class INPUT_TYPE>
+  struct ConstantTestApplication : ChimeraTK::Application {
+    constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test.map)";
+    ConstantTestApplication() : Application("DummyApplication") {}
+    ~ConstantTestApplication() override { shutdown(); }
 
-// for the push type we need different connection code
-struct PushDummyApplication : ChimeraTK::Application {
-  constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:2?map=test-async.map)";
-  PushDummyApplication() : Application("DummyApplication") {}
-  ~PushDummyApplication() override { shutdown(); }
+    InputModule<INPUT_TYPE> inputModule{this, "constantPollModule", ""};
+  };
 
-  InputModule<ctk::ScalarPushInput<int>> inputModule{this, "PushModule", ""};
-  ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
-};
+  /**
+   * Constants can be read exactly once in case of `AccessMode::wait_for_new_data`, so the initial value can be
+   * received. \anchor testInitialValue_D_8_b_iii \ref initialValue_D_8_b_iii
+   *
+   * Note: "Constants" here refer to the ConstantAccessor, which is nowadays only used for unconnected inputs when the
+   * control system connection has been optimised out (cf. Application::optimiseUnmappedVariables()).
+   *
+   */
+  BOOST_AUTO_TEST_CASE_TEMPLATE(testConstantInitValueAtDevice8biii, INPUT_TYPE, TestInputTypes) {
+    std::cout << "===   testConstantInitValueAtDevice8biii " << typeid(INPUT_TYPE).name() << "  === " << std::endl;
+    TestFixtureWithEceptionDummy<ConstantTestApplication<INPUT_TYPE>> d;
 
-template<class APPLICATION_TYPE>
-struct TestFixtureWithEceptionDummy {
-  TestFixtureWithEceptionDummy()
-  : deviceBackend(boost::dynamic_pointer_cast<ChimeraTK::ExceptionDummy>(
-        ChimeraTK::BackendFactory::getInstance().createBackend(APPLICATION_TYPE::ExceptionDummyCDD1))) {}
-  ~TestFixtureWithEceptionDummy() { deviceBackend->throwExceptionRead = false; }
+    // make sure, inputModule.input is not connected to anything, not even the control system.
+    d.application.optimiseUnmappedVariables({"/REG1"});
 
-  boost::shared_ptr<ChimeraTK::ExceptionDummy> deviceBackend;
-  APPLICATION_TYPE application;
-  ChimeraTK::TestFacility testFacility{application, false};
-  ChimeraTK::ScalarRegisterAccessor<int> exceptionDummyRegister;
-};
-/**
- *  Test Initial Values - Inputs of `ApplicationModule`s
- *  InitialValuesInputsOfApplicationCore_D_8 "D.8"
- */
-BOOST_AUTO_TEST_SUITE(testInitialValuesInputsOfApplicationCore_D_8)
-using DeviceTestApplicationTypes = boost::mpl::list<PushDummyApplication, PollDummyApplication>;
-
-/**
- *  For device variables the ExceptionHandlingDecorator freezes the variable until the device is available
- * \anchor testInitialValue_D_8_b_i \ref initialValue_D_8_b_i
- */
-BOOST_AUTO_TEST_CASE_TEMPLATE(testInitValueAtDevice8bi, APPLICATION_TYPE, DeviceTestApplicationTypes) {
-  std::cout << "===   testInitValueAtDevice8bi " << typeid(APPLICATION_TYPE).name() << "  ===" << std::endl;
-  std::chrono::time_point<std::chrono::steady_clock> start, end;
-  { // Here the time is stopped until you reach the mainloop.
-    TestFixtureWithEceptionDummy<APPLICATION_TYPE> dummyToStopTimeUntilOpen;
-    start = std::chrono::steady_clock::now();
-    dummyToStopTimeUntilOpen.application.run();
-    dummyToStopTimeUntilOpen.application.inputModule.p.get_future().wait();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    end = std::chrono::steady_clock::now();
-  }
-  { // waiting 2 x the time stopped above, in the assumption that it is then frozen,
-    // as it is described in the spec.
-    TestFixtureWithEceptionDummy<APPLICATION_TYPE> d;
-    d.deviceBackend->throwExceptionOpen = true;
-    BOOST_CHECK_THROW(d.deviceBackend->open(), std::exception);
-    d.deviceBackend->throwExceptionOpen = true;
     d.application.run();
-    auto elapsed_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-    BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == false);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * elapsed_milliseconds));
-    BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == false);
-    BOOST_CHECK(d.application.inputModule.input.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
-    d.deviceBackend->throwExceptionOpen = false;
     d.application.inputModule.p.get_future().wait();
-    BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == true);
+
     BOOST_CHECK(d.application.inputModule.input.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+    if(d.application.inputModule.input.getAccessModeFlags().has(ctk::AccessMode::wait_for_new_data)) {
+      BOOST_CHECK(d.application.inputModule.input.readNonBlocking() ==
+          false); // no new data. Calling read() would block infinitely
+    }
+    else {
+      BOOST_CHECK(d.application.inputModule.input.readNonBlocking() == true);
+    }
   }
-}
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-struct ScalarOutputModule : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
-  ChimeraTK::ScalarOutput<int> output{this, "REG1", "", ""};
-  std::promise<void> p;
-  std::atomic_bool enteredTheMainLoop{false};
-  void mainLoop() override {
-    enteredTheMainLoop = true;
-    p.set_value();
+  struct PushModuleD91 : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
+    ChimeraTK::ScalarPushInput<int> pushInput{this, "/REG1", "", ""};
+    std::promise<void> p;
+    std::atomic_bool enteredTheMainLoop{false};
+    void mainLoop() override {
+      enteredTheMainLoop = true;
+      p.set_value();
+    }
+  };
+  struct PushModuleD92 : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
+    ChimeraTK::ScalarPushInput<int> pushInput{this, "/REG2", "", ""};
+    std::promise<void> p;
+    std::atomic_bool enteredTheMainLoop{false};
+    void mainLoop() override {
+      enteredTheMainLoop = true;
+      p.set_value();
+    }
+  };
+
+  struct PushD9DummyApplication : ChimeraTK::Application {
+    constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test-async.map)";
+    PushD9DummyApplication() : Application("DummyApplication") {}
+    ~PushD9DummyApplication() override { shutdown(); }
+
+    PushModuleD91 pushModuleD91{this, "PushModule1", ""};
+    PushModuleD92 pushModuleD92{this, "PushModule2", ""};
+
+    ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
+  };
+
+  struct D9InitialValueEceptionDummy {
+    D9InitialValueEceptionDummy()
+    : deviceBackend(boost::dynamic_pointer_cast<ChimeraTK::ExceptionDummy>(
+          ChimeraTK::BackendFactory::getInstance().createBackend(PushD9DummyApplication::ExceptionDummyCDD1))) {}
+    ~D9InitialValueEceptionDummy() { deviceBackend->throwExceptionRead = false; }
+
+    boost::shared_ptr<ChimeraTK::ExceptionDummy> deviceBackend;
+    PushD9DummyApplication application;
+    ChimeraTK::TestFacility testFacitiy{application, false};
+    ChimeraTK::ScalarRegisterAccessor<int> exceptionDummyRegister;
+    ChimeraTK::ScalarPushInput<int>& pushVariable1{application.pushModuleD91.pushInput};
+    ChimeraTK::ScalarPushInput<int>& pushVariable2{application.pushModuleD92.pushInput};
+  };
+
+  /**
+   *  D 9 b for ThreadedFanOut
+   * \anchor testInitialValueThreadedFanOut_D_9_b_ThreadedFanOut \ref initialValueThreadedFanOut_D_9_b
+   */
+  BOOST_AUTO_TEST_CASE(testPushInitValueAtDeviceD9) {
+    std::cout << "===   testPushInitValueAtDeviceD9   === " << std::endl;
+    std::chrono::time_point<std::chrono::steady_clock> start, end;
+    {
+      D9InitialValueEceptionDummy dummyToStopTimeUntilOpen;
+      start = std::chrono::steady_clock::now();
+      dummyToStopTimeUntilOpen.application.run();
+      dummyToStopTimeUntilOpen.application.pushModuleD91.p.get_future().wait();
+      dummyToStopTimeUntilOpen.application.pushModuleD92.p.get_future().wait();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      end = std::chrono::steady_clock::now();
+    }
+    {
+      D9InitialValueEceptionDummy d;
+      d.deviceBackend->throwExceptionOpen = true;
+      BOOST_CHECK_THROW(d.deviceBackend->open(), std::exception);
+      d.application.run();
+      BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == false);
+      std::this_thread::sleep_for(2 * (end - start));
+      BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == false);
+      BOOST_CHECK(d.pushVariable1.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
+      d.deviceBackend->throwExceptionOpen = false;
+      d.application.pushModuleD91.p.get_future().wait();
+      BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == true);
+      BOOST_CHECK(d.pushVariable1.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+    }
   }
-};
 
-template<class INPUT_TYPE>
-struct ProcessArryDummyApplication : ChimeraTK::Application {
-  constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test.map)";
-  ProcessArryDummyApplication() : Application("DummyApplication") {}
-  ~ProcessArryDummyApplication() override { shutdown(); }
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  InputModule<INPUT_TYPE> inputModule{this, ".", ""};
-  ScalarOutputModule scalarOutputModule{this, ".", ""};
-};
+  struct TriggerModule : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
+    ChimeraTK::VoidOutput trigger{this, "/TRIG1/PUSH_OUT", ""};
+    std::promise<void> p;
+    std::atomic_bool enteredTheMainLoop{false};
+    void mainLoop() override {
+      enteredTheMainLoop = true;
+      p.set_value();
+    }
+  };
 
-using TestInputTypes = boost::mpl::list<ctk::ScalarPollInput<int>, ctk::ScalarPushInput<int>>;
+  struct TriggerFanOutD9DummyApplication : ChimeraTK::Application {
+    constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test-trigger-fanout-iv.map)";
+    TriggerFanOutD9DummyApplication() : Application("DummyApplication") {}
+    ~TriggerFanOutD9DummyApplication() override { shutdown(); }
 
-/**
- *  ProcessArray freeze in their implementation until the initial value is received
- * \anchor testInitialValue_D_8_b_ii \ref initialValue_D_8_b_ii
- */
-BOOST_AUTO_TEST_CASE_TEMPLATE(testProcessArrayInitValueAtDevice8bii, INPUT_TYPE, TestInputTypes) {
-  std::cout << "===   testPollProcessArrayInitValueAtDevice8bii " << typeid(INPUT_TYPE).name() << "  === " << std::endl;
-  std::chrono::time_point<std::chrono::steady_clock> start, end;
-  {
-    // we don't need the exception dummy in this test. But no need to write a new fixture for it.
-    TestFixtureWithEceptionDummy<ProcessArryDummyApplication<INPUT_TYPE>> dummyToStopTimeForApplicationStart;
-    start = std::chrono::steady_clock::now();
-    dummyToStopTimeForApplicationStart.application.run();
-    dummyToStopTimeForApplicationStart.application.scalarOutputModule.output.write();
-    dummyToStopTimeForApplicationStart.application.inputModule.p.get_future().wait();
-    end = std::chrono::steady_clock::now();
+    PushModuleD91 pushModuleD91{this, "PushModule1", ""};
+    PushModuleD92 pushModuleD92{this, "PushModule2", ""};
+    TriggerModule triggerModule{this, "TriggerModule", ""};
+
+    ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1, "/TRIG1/PUSH_OUT"};
+  };
+
+  struct TriggerFanOutInitialValueEceptionDummy {
+    TriggerFanOutInitialValueEceptionDummy()
+    : deviceBackend(
+          boost::dynamic_pointer_cast<ChimeraTK::ExceptionDummy>(ChimeraTK::BackendFactory::getInstance().createBackend(
+              TriggerFanOutD9DummyApplication::ExceptionDummyCDD1))) {}
+    ~TriggerFanOutInitialValueEceptionDummy() { deviceBackend->throwExceptionRead = false; }
+
+    boost::shared_ptr<ChimeraTK::ExceptionDummy> deviceBackend;
+    TriggerFanOutD9DummyApplication application;
+    ChimeraTK::TestFacility testFacitiy{application, false};
+    ChimeraTK::ScalarRegisterAccessor<int> exceptionDummyRegister;
+    ChimeraTK::ScalarPushInput<int>& pushVariable1{application.pushModuleD91.pushInput};
+    ChimeraTK::ScalarPushInput<int>& pushVariable2{application.pushModuleD92.pushInput};
+  };
+
+  /**
+   *  D 9 b for TriggerFanOut
+   * \anchor testInitialValueThreadedFanOut_D_9_b_TriggerFanOut \ref initialValueThreadedFanOut_D_9_b
+   */
+  BOOST_AUTO_TEST_CASE(testTriggerFanOutInitValueAtDeviceD9) {
+    std::cout << "===   testTriggerFanOutInitValueAtDeviceD9   === " << std::endl;
+    std::chrono::time_point<std::chrono::steady_clock> start, end;
+    {
+      TriggerFanOutInitialValueEceptionDummy dummyToStopTimeUntilOpen;
+      start = std::chrono::steady_clock::now();
+      dummyToStopTimeUntilOpen.application.run();
+      dummyToStopTimeUntilOpen.application.triggerModule.trigger.write();
+      dummyToStopTimeUntilOpen.application.pushModuleD91.p.get_future().wait();
+      dummyToStopTimeUntilOpen.application.pushModuleD92.p.get_future().wait();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      end = std::chrono::steady_clock::now();
+    }
+    {
+      TriggerFanOutInitialValueEceptionDummy d;
+      d.deviceBackend->throwExceptionOpen = true;
+      BOOST_CHECK_THROW(d.deviceBackend->open(), std::exception);
+      d.application.run();
+      BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == false);
+      std::this_thread::sleep_for(2 * (end - start));
+      BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == false);
+      BOOST_CHECK(d.pushVariable1.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
+      d.deviceBackend->throwExceptionOpen = false;
+      d.application.triggerModule.trigger.write();
+      d.application.pushModuleD91.p.get_future().wait();
+      BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == true);
+      BOOST_CHECK(d.pushVariable1.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+    }
   }
-  {
-    TestFixtureWithEceptionDummy<ProcessArryDummyApplication<INPUT_TYPE>> d;
-    d.application.run();
-    BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == false);
-    std::this_thread::sleep_for(end - start);
-    BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == false);
-    BOOST_CHECK(d.application.inputModule.input.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
-    d.application.scalarOutputModule.output.write();
-    d.application.inputModule.p.get_future().wait();
-    BOOST_CHECK(d.application.inputModule.enteredTheMainLoop == true);
-    BOOST_CHECK(d.application.inputModule.input.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-  }
-}
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template<class INPUT_TYPE>
-struct ConstantTestApplication : ChimeraTK::Application {
-  constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test.map)";
-  ConstantTestApplication() : Application("DummyApplication") {}
-  ~ConstantTestApplication() override { shutdown(); }
+  struct ConstantModule : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
 
-  InputModule<INPUT_TYPE> inputModule{this, "constantPollModule", ""};
-};
+    struct : ChimeraTK::VariableGroup {
+      using ChimeraTK::VariableGroup::VariableGroup;
+      ChimeraTK::ScalarPushInput<int> constant{this, "/REG1", "", ""};
+    } reg1{this, ".", ""};
 
-/**
- * Constants can be read exactly once in case of `AccessMode::wait_for_new_data`, so the initial value can be received.
- * \anchor testInitialValue_D_8_b_iii \ref initialValue_D_8_b_iii
- *
- * Note: "Constants" here refer to the ConstantAccessor, which is nowadays only used for unconnected inputs when the
- * control system connection has been optimised out (cf. Application::optimiseUnmappedVariables()).
- *
- */
-BOOST_AUTO_TEST_CASE_TEMPLATE(testConstantInitValueAtDevice8biii, INPUT_TYPE, TestInputTypes) {
-  std::cout << "===   testConstantInitValueAtDevice8biii " << typeid(INPUT_TYPE).name() << "  === " << std::endl;
-  TestFixtureWithEceptionDummy<ConstantTestApplication<INPUT_TYPE>> d;
+    std::promise<void> p;
+    std::atomic_bool enteredTheMainLoop{false};
 
-  // make sure, inputModule.input is not connected to anything, not even the control system.
-  d.application.optimiseUnmappedVariables({"/REG1"});
+    void prepare() override {
+      reg1.constant = 543; // some non-zero value to detect if the 0 constant is written later
+    }
 
-  d.application.run();
-  d.application.inputModule.p.get_future().wait();
+    void mainLoop() override {
+      enteredTheMainLoop = true;
+      p.set_value();
+    }
+  };
 
-  BOOST_CHECK(d.application.inputModule.input.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-  if(d.application.inputModule.input.getAccessModeFlags().has(ctk::AccessMode::wait_for_new_data)) {
-    BOOST_CHECK(d.application.inputModule.input.readNonBlocking() ==
-        false); // no new data. Calling read() would block infinitely
-  }
-  else {
-    BOOST_CHECK(d.application.inputModule.input.readNonBlocking() == true);
-  }
-}
+  struct ConstantD10DummyApplication : ChimeraTK::Application {
+    constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test.map)";
+    ConstantD10DummyApplication() : Application("DummyApplication") {}
+    ~ConstantD10DummyApplication() override { shutdown(); }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+    ConstantModule constantModule{this, "ConstantModule", ""};
 
-struct PushModuleD91 : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
-  ChimeraTK::ScalarPushInput<int> pushInput{this, "/REG1", "", ""};
-  std::promise<void> p;
-  std::atomic_bool enteredTheMainLoop{false};
-  void mainLoop() override {
-    enteredTheMainLoop = true;
-    p.set_value();
-  }
-};
-struct PushModuleD92 : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
-  ChimeraTK::ScalarPushInput<int> pushInput{this, "/REG2", "", ""};
-  std::promise<void> p;
-  std::atomic_bool enteredTheMainLoop{false};
-  void mainLoop() override {
-    enteredTheMainLoop = true;
-    p.set_value();
-  }
-};
+    ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
+  };
 
-struct PushD9DummyApplication : ChimeraTK::Application {
-  constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test-async.map)";
-  PushD9DummyApplication() : Application("DummyApplication") {}
-  ~PushD9DummyApplication() override { shutdown(); }
+  struct ConstantD10InitialValueEceptionDummy {
+    ConstantD10InitialValueEceptionDummy()
+    : deviceBackend(boost::dynamic_pointer_cast<ChimeraTK::ExceptionDummy>(
+          ChimeraTK::BackendFactory::getInstance().createBackend("(ExceptionDummy:1?map=test.map)"))) {}
+    ~ConstantD10InitialValueEceptionDummy() { deviceBackend->throwExceptionRead = false; }
 
-  PushModuleD91 pushModuleD91{this, "PushModule1", ""};
-  PushModuleD92 pushModuleD92{this, "PushModule2", ""};
+    boost::shared_ptr<ChimeraTK::ExceptionDummy> deviceBackend;
+    ConstantD10DummyApplication application;
+    ChimeraTK::TestFacility testFacitiy{application, false};
+  };
 
-  ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
-};
+  /**
+   *  D 10 for Constant
+   * \anchor testConstantD10InitialValue_D_10 \ref initialValue_d_10
+   */
+  BOOST_AUTO_TEST_CASE(testConstantD10InitialValue) {
+    std::cout << "===   testConstantD10InitialValue   === " << std::endl;
+    ConstantD10InitialValueEceptionDummy d;
+    d.application.optimiseUnmappedVariables({"/REG1"});
 
-struct D9InitialValueEceptionDummy {
-  D9InitialValueEceptionDummy()
-  : deviceBackend(boost::dynamic_pointer_cast<ChimeraTK::ExceptionDummy>(
-        ChimeraTK::BackendFactory::getInstance().createBackend(PushD9DummyApplication::ExceptionDummyCDD1))) {}
-  ~D9InitialValueEceptionDummy() { deviceBackend->throwExceptionRead = false; }
+    ChimeraTK::Device dev("(ExceptionDummy:1?map=test.map)");
+    dev.open();
+    dev.write<int>("REG1", 1234); // place some value, we expect it to be overwritten with 0
 
-  boost::shared_ptr<ChimeraTK::ExceptionDummy> deviceBackend;
-  PushD9DummyApplication application;
-  ChimeraTK::TestFacility testFacitiy{application, false};
-  ChimeraTK::ScalarRegisterAccessor<int> exceptionDummyRegister;
-  ChimeraTK::ScalarPushInput<int>& pushVariable1{application.pushModuleD91.pushInput};
-  ChimeraTK::ScalarPushInput<int>& pushVariable2{application.pushModuleD92.pushInput};
-};
-
-/**
- *  D 9 b for ThreadedFanOut
- * \anchor testInitialValueThreadedFanOut_D_9_b_ThreadedFanOut \ref initialValueThreadedFanOut_D_9_b
- */
-BOOST_AUTO_TEST_CASE(testPushInitValueAtDeviceD9) {
-  std::cout << "===   testPushInitValueAtDeviceD9   === " << std::endl;
-  std::chrono::time_point<std::chrono::steady_clock> start, end;
-  {
-    D9InitialValueEceptionDummy dummyToStopTimeUntilOpen;
-    start = std::chrono::steady_clock::now();
-    dummyToStopTimeUntilOpen.application.run();
-    dummyToStopTimeUntilOpen.application.pushModuleD91.p.get_future().wait();
-    dummyToStopTimeUntilOpen.application.pushModuleD92.p.get_future().wait();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    end = std::chrono::steady_clock::now();
-  }
-  {
-    D9InitialValueEceptionDummy d;
     d.deviceBackend->throwExceptionOpen = true;
     BOOST_CHECK_THROW(d.deviceBackend->open(), std::exception);
+
     d.application.run();
-    BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == false);
-    std::this_thread::sleep_for(2 * (end - start));
-    BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == false);
-    BOOST_CHECK(d.pushVariable1.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
+    d.application.constantModule.p.get_future().wait();
+
+    BOOST_CHECK(d.application.constantModule.enteredTheMainLoop == true);
+    BOOST_CHECK(d.application.constantModule.reg1.constant == 0); // no longer at the value set in prepare()
+    BOOST_CHECK(d.application.constantModule.reg1.constant.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+
+    ChimeraTK::DummyRegisterAccessor<int> reg1(
+        boost::dynamic_pointer_cast<ChimeraTK::DummyBackend>(dev.getBackend()).get(), "", "REG1");
+    {
+      auto lk = reg1.getBufferLock();
+      BOOST_CHECK(reg1 == 1234);
+    }
     d.deviceBackend->throwExceptionOpen = false;
-    d.application.pushModuleD91.p.get_future().wait();
-    BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == true);
-    BOOST_CHECK(d.pushVariable1.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+    CHECK_TIMEOUT((reg1.getBufferLock(), reg1 == 0), 1000000);
   }
-}
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-struct TriggerModule : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
-  ChimeraTK::VoidOutput trigger{this, "/TRIG1/PUSH_OUT", ""};
-  std::promise<void> p;
-  std::atomic_bool enteredTheMainLoop{false};
-  void mainLoop() override {
-    enteredTheMainLoop = true;
-    p.set_value();
-  }
-};
+  struct TestModule : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
+    ChimeraTK::ScalarPushInput<int> pushInput{this, "/REG1", "", ""};
+    ChimeraTK::ScalarOutput<int> output{this, "SomeOutput", "", ""};
+    std::promise<void> p;
+    std::atomic_bool enteredTheMainLoop{false};
+    void mainLoop() override {
+      enteredTheMainLoop = true;
+      p.set_value();
+    }
+  };
 
-struct TriggerFanOutD9DummyApplication : ChimeraTK::Application {
-  constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test-trigger-fanout-iv.map)";
-  TriggerFanOutD9DummyApplication() : Application("DummyApplication") {}
-  ~TriggerFanOutD9DummyApplication() override { shutdown(); }
+  struct TestDummyApplication : ChimeraTK::Application {
+    constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test-async.map)";
+    TestDummyApplication() : Application("DummyApplication") {}
+    ~TestDummyApplication() override { shutdown(); }
 
-  PushModuleD91 pushModuleD91{this, "PushModule1", ""};
-  PushModuleD92 pushModuleD92{this, "PushModule2", ""};
-  TriggerModule triggerModule{this, "TriggerModule", ""};
+    TestModule testModule{this, "TestModule", ""};
+    ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
+  };
 
-  ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1, "/TRIG1/PUSH_OUT"};
-};
+  struct TestInitialValueExceptionDummy {
+    explicit TestInitialValueExceptionDummy()
+    : deviceBackend(boost::dynamic_pointer_cast<ChimeraTK::ExceptionDummy>(
+          ChimeraTK::BackendFactory::getInstance().createBackend(TestDummyApplication::ExceptionDummyCDD1))) {}
+    ~TestInitialValueExceptionDummy() { deviceBackend->throwExceptionRead = false; }
 
-struct TriggerFanOutInitialValueEceptionDummy {
-  TriggerFanOutInitialValueEceptionDummy()
-  : deviceBackend(boost::dynamic_pointer_cast<ChimeraTK::ExceptionDummy>(
-        ChimeraTK::BackendFactory::getInstance().createBackend(TriggerFanOutD9DummyApplication::ExceptionDummyCDD1))) {}
-  ~TriggerFanOutInitialValueEceptionDummy() { deviceBackend->throwExceptionRead = false; }
+    boost::shared_ptr<ChimeraTK::ExceptionDummy> deviceBackend;
+    TestDummyApplication application;
+    ChimeraTK::TestFacility testFacitiy{application, false};
+    ChimeraTK::ScalarPushInput<int>& pushVariable{application.testModule.pushInput};
+    ChimeraTK::ScalarOutput<int>& outputVariable{application.testModule.output};
+  };
 
-  boost::shared_ptr<ChimeraTK::ExceptionDummy> deviceBackend;
-  TriggerFanOutD9DummyApplication application;
-  ChimeraTK::TestFacility testFacitiy{application, false};
-  ChimeraTK::ScalarRegisterAccessor<int> exceptionDummyRegister;
-  ChimeraTK::ScalarPushInput<int>& pushVariable1{application.pushModuleD91.pushInput};
-  ChimeraTK::ScalarPushInput<int>& pushVariable2{application.pushModuleD92.pushInput};
-};
+  /**
+   *  D 1 for DataValidity::faulty
+   * \anchor testD1InitialValue_D_1 \ref testD1InitialValue_D_1
+   */
+  // Todo add missing tests for bi-directional variables
+  BOOST_AUTO_TEST_CASE(testD1InitialValue) {
+    std::cout << "===   testD1InitialValue   === " << std::endl;
 
-/**
- *  D 9 b for TriggerFanOut
- * \anchor testInitialValueThreadedFanOut_D_9_b_TriggerFanOut \ref initialValueThreadedFanOut_D_9_b
- */
-BOOST_AUTO_TEST_CASE(testTriggerFanOutInitValueAtDeviceD9) {
-  std::cout << "===   testTriggerFanOutInitValueAtDeviceD9   === " << std::endl;
-  std::chrono::time_point<std::chrono::steady_clock> start, end;
-  {
-    TriggerFanOutInitialValueEceptionDummy dummyToStopTimeUntilOpen;
-    start = std::chrono::steady_clock::now();
-    dummyToStopTimeUntilOpen.application.run();
-    dummyToStopTimeUntilOpen.application.triggerModule.trigger.write();
-    dummyToStopTimeUntilOpen.application.pushModuleD91.p.get_future().wait();
-    dummyToStopTimeUntilOpen.application.pushModuleD92.p.get_future().wait();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    end = std::chrono::steady_clock::now();
-  }
-  {
-    TriggerFanOutInitialValueEceptionDummy d;
-    d.deviceBackend->throwExceptionOpen = true;
-    BOOST_CHECK_THROW(d.deviceBackend->open(), std::exception);
+    TestInitialValueExceptionDummy d;
+
     d.application.run();
-    BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == false);
-    std::this_thread::sleep_for(2 * (end - start));
-    BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == false);
-    BOOST_CHECK(d.pushVariable1.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
-    d.deviceBackend->throwExceptionOpen = false;
+    d.application.testModule.p.get_future().wait();
+    BOOST_CHECK(d.application.testModule.enteredTheMainLoop == true);
+    BOOST_CHECK(d.pushVariable.dataValidity() == ctk::DataValidity::ok);
+    d.application.testModule.output.write();
+    BOOST_CHECK(d.outputVariable.dataValidity() == ctk::DataValidity::ok);
+  }
+
+  /**
+   *  D 2 for DataValidity::faulty
+   * \anchor testD1InitialValue_D_2 \ref testD1InitialValue_D_2
+   */
+  BOOST_AUTO_TEST_CASE(testD2InitialValue) {
+    std::cout << "===   testD2InitialValue   === " << std::endl;
+
+    TestInitialValueExceptionDummy d;
+    d.application.run();
+    d.application.testModule.p.get_future().wait();
+    d.application.testModule.output.write();
+    BOOST_CHECK(d.application.testModule.enteredTheMainLoop == true);
+    BOOST_CHECK(d.pushVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+    BOOST_CHECK(d.outputVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+  }
+
+  /**
+   *  D 3 for DataValidity::faulty
+   * \anchor testD1InitialValue_D_3 \ref testD1InitialValue_D_3
+   */
+  BOOST_AUTO_TEST_CASE(testD3InitialValue) {
+    std::cout << "===   testD3InitialValue   === " << std::endl;
+
+    TestInitialValueExceptionDummy d;
+    d.application.run();
+    d.application.testModule.p.get_future().wait();
+    BOOST_CHECK(d.application.testModule.enteredTheMainLoop == true);
+    BOOST_CHECK(d.pushVariable.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(d.outputVariable.dataValidity() == ctk::DataValidity::ok);
+    // Todo. The initial value can also be faulty. Change backend so that it allows to override the data validity
+    // without going to an exception state.
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  struct WriterModule : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
+    ChimeraTK::ScalarOutput<int> output1{this, "/REG1", "", ""};
+    ChimeraTK::ScalarOutput<int> output2{this, "/REG2", "", ""};
+    std::atomic_bool enteredTheMainLoop{false};
+    std::atomic_bool enteredThePrepareLoop{false};
+    void mainLoop() override {
+      enteredTheMainLoop = true;
+      output2 = 555;
+      output2.write();
+    }
+    void prepare() override {
+      enteredThePrepareLoop = true;
+      output1 = 777;
+      output1.write();
+    }
+  };
+
+  struct ReaderModule : NotifyingModule {
+    using NotifyingModule::NotifyingModule;
+
+    ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
+    ChimeraTK::ScalarPushInput<int> reg2{this, "/REG2", "", ""};
+  };
+
+  struct Test7DummyApplication : ChimeraTK::Application {
+    Test7DummyApplication() : Application("DummyApplication") {}
+    ~Test7DummyApplication() override { shutdown(); }
+
+    WriterModule writerModule{this, "WriterModule", ""};
+    ReaderModule readerModule{this, "ReaderModule", ""};
+  };
+
+  /**
+   *  D 7_1
+   * \anchor testD7_1_InitialValue \ref testD7_1_InitialValue
+   */
+
+  BOOST_AUTO_TEST_CASE(testD7_1_InitialValue) {
+    std::cout << "===   testD7_1_InitialValue   === " << std::endl;
+
+    Test7DummyApplication application;
+    ChimeraTK::TestFacility testFacitiy{application, false};
+    application.run();
+    BOOST_CHECK(application.writerModule.enteredThePrepareLoop == true);
+    application.readerModule.p.get_future().wait();
+    CHECK_TIMEOUT(application.readerModule.reg1 == 777, 500);
+  }
+
+  /**
+   *  D 7_2
+   * \anchor testD7_2_InitialValue \ref testD7_2_InitialValue
+   */
+  BOOST_AUTO_TEST_CASE(testD7_2_InitialValue) {
+    std::cout << "===   testD7_2_InitialValue   === " << std::endl;
+
+    Test7DummyApplication application;
+    ChimeraTK::TestFacility testFacitiy{application, false};
+    application.run();
+    application.readerModule.p.get_future().wait();
+    BOOST_CHECK(application.readerModule.enteredTheMainLoop == true);
+    CHECK_TIMEOUT(application.readerModule.reg2 == 555, 500);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  struct Test6A1DummyApplication : ChimeraTK::Application {
+    // This application connects the CS to the device and and the input of the readerModule
+    constexpr static const char* CDD = "(dummy:1?map=test.map)";
+    Test6A1DummyApplication() : Application("DummyApplication") {}
+    ~Test6A1DummyApplication() override { shutdown(); }
+
+    struct : NotifyingModule {
+      using NotifyingModule::NotifyingModule;
+
+      ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
+    } readerModule{this, ".", ""};
+
+    ChimeraTK::DeviceModule device{this, CDD};
+  };
+
+  struct Test6A1InitialValueEceptionDummy {
+    Test6A1InitialValueEceptionDummy() = default;
+    ~Test6A1InitialValueEceptionDummy() = default;
+
+    Test6A1DummyApplication application;
+    ChimeraTK::TestFacility testFacitiy{application, false};
+    ChimeraTK::ScalarPushInput<int>& pushVariable{application.readerModule.reg1};
+  };
+
+  /**
+   *  D 6_a1 initial value from control system variable
+   * \anchor testD6_a1_InitialValue \ref testD6_a1_InitialValue
+   */
+
+  BOOST_AUTO_TEST_CASE(testD6_a1_InitialValue) {
+    std::cout << "===   testD6_a1_InitialValue   === " << std::endl;
+    Test6A1InitialValueEceptionDummy d;
+    d.application.run();
+    BOOST_CHECK(d.pushVariable.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
+    d.testFacitiy.writeScalar<int>("REG1", 27);
+    ChimeraTK::Device dev;
+    dev.open(Test6A1DummyApplication::CDD);
+    CHECK_TIMEOUT(dev.read<int>("REG1") == 27, 1000000);
+    // wait until the main loop has been entered. then we know the version number of the inputs must not be 0.
+    // FIXME: I think this does not belong into this test....
+    d.application.readerModule.p.get_future().wait(); // synchronisation point for the thread sanitizer
+    BOOST_CHECK(d.pushVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
+  struct Test6A2DummyApplication : ChimeraTK::Application {
+    constexpr static const char* CDD1 = "(dummy:1?map=one-register.map)";
+    constexpr static const char* CDD2 = "(dummy:2?map=test-ro.map)";
+    Test6A2DummyApplication() : Application("DummyApplication") {}
+    ~Test6A2DummyApplication() override { shutdown(); }
+
+    struct : NotifyingModule {
+      using NotifyingModule::NotifyingModule;
+      ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
+    } readerModule{this, "ReaderModule", ""};
+
+    TriggerModule triggerModule{this, "ReaderModule", ""};
+    ChimeraTK::DeviceModule device{this, CDD1};
+    ChimeraTK::DeviceModule device2{this, CDD2, "/TRIG1/PUSH_OUT"};
+  };
+
+  struct Test6A2InitialValueEceptionDummy {
+    Test6A2InitialValueEceptionDummy() = default;
+    ~Test6A2InitialValueEceptionDummy() = default;
+
+    Test6A2DummyApplication application;
+    ChimeraTK::TestFacility testFacility{application, false};
+    ChimeraTK::ScalarPushInput<int>& pushVariable{application.readerModule.reg1};
+  };
+
+  /**
+   *  D 6_a2 initial value from device in poll mode
+   * \anchor testD6_a2_InitialValue \ref testD6_a2_InitialValue
+   *
+   *  The push type variable dev2/REG1 is "directly" connected to dev1/REG2 through a trigger.
+   *  Test that it is written as soon as the initial value is available, i.e. there has been a trigger.
+   */
+
+  BOOST_AUTO_TEST_CASE(testD6_a2_InitialValue) {
+    std::cout << "===   testD6_a2_InitialValue   === " << std::endl;
+
+    Test6A2InitialValueEceptionDummy d;
+
+    ChimeraTK::Device dev2;
+    dev2.open(Test6A2DummyApplication::CDD2);
+    dev2.write<int>("REG1/DUMMY_WRITEABLE", 99); // value now in in dev2
+
+    d.application.run();
+    // no trigger yet and the value is not on dev1 yet
+    BOOST_CHECK(d.pushVariable.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
+    ChimeraTK::Device dev;
+    dev.open(Test6A2DummyApplication::CDD1);
+    BOOST_CHECK(dev.read<int>("REG1") != 99);
+
+    // send the trigger and check that the data arrives on the device
     d.application.triggerModule.trigger.write();
-    d.application.pushModuleD91.p.get_future().wait();
-    BOOST_CHECK(d.application.pushModuleD91.enteredTheMainLoop == true);
-    BOOST_CHECK(d.pushVariable1.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-  }
-}
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-struct ConstantModule : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
-
-  struct : ChimeraTK::VariableGroup {
-    using ChimeraTK::VariableGroup::VariableGroup;
-    ChimeraTK::ScalarPushInput<int> constant{this, "/REG1", "", ""};
-  } reg1{this, ".", ""};
-
-  std::promise<void> p;
-  std::atomic_bool enteredTheMainLoop{false};
-
-  void prepare() override {
-    reg1.constant = 543; // some non-zero value to detect if the 0 constant is written later
+    CHECK_TIMEOUT(dev.read<int>("REG1") == 99, 1000000);
   }
 
-  void mainLoop() override {
-    enteredTheMainLoop = true;
-    p.set_value();
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  struct Test6A3DummyApplication : ChimeraTK::Application {
+    constexpr static const char* CDD1 = "(dummy:1?map=one-register.map)";
+    constexpr static const char* CDD2 = "(dummy:2?map=test-async.map)";
+    Test6A3DummyApplication() : Application("DummyApplication") {}
+    ~Test6A3DummyApplication() override { shutdown(); }
+
+    struct : NotifyingModule {
+      using NotifyingModule::NotifyingModule;
+      ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
+    } readerModule{this, "ReaderModule", ""};
+
+    ChimeraTK::DeviceModule device{this, CDD1};
+    ChimeraTK::DeviceModule device2{this, CDD2};
+  };
+
+  struct Test6A3InitialValueEceptionDummy {
+    Test6A3InitialValueEceptionDummy() = default;
+    ~Test6A3InitialValueEceptionDummy() = default;
+
+    Test6A3DummyApplication application;
+    ChimeraTK::TestFacility testFacility{application, false};
+    ChimeraTK::ScalarPushInput<int>& pushVariable{application.readerModule.reg1};
+  };
+
+  /**
+   *  D 6_a3 initial value from device in push mode
+   * \anchor testD6_a3_InitialValue \ref testD6_a3_InitialValue
+   */
+  BOOST_AUTO_TEST_CASE(testD6_a3_InitialValue) {
+    std::cout << "===   testD6_a3_InitialValue   === " << std::endl;
+
+    Test6A3InitialValueEceptionDummy d;
+
+    ChimeraTK::Device dev2;
+    dev2.open(Test6A3DummyApplication::CDD2);
+    dev2.write<int>("REG1/DUMMY_WRITEABLE", 99);
+
+    d.application.run();
+
+    ChimeraTK::Device dev;
+    dev.open(Test6A3DummyApplication::CDD1);
+    CHECK_TIMEOUT(dev.read<int>("REG1") == 99, 1000000);
+    d.application.readerModule.p.get_future().wait();
+    BOOST_CHECK(d.pushVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
   }
-};
 
-struct ConstantD10DummyApplication : ChimeraTK::Application {
-  constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test.map)";
-  ConstantD10DummyApplication() : Application("DummyApplication") {}
-  ~ConstantD10DummyApplication() override { shutdown(); }
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  ConstantModule constantModule{this, "ConstantModule", ""};
+  struct Test6A4DummyApplication : ChimeraTK::Application {
+    Test6A4DummyApplication() : Application("DummyApplication") {}
+    ~Test6A4DummyApplication() override { shutdown(); }
 
-  ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
-};
+    struct : NotifyingModule {
+      using NotifyingModule::NotifyingModule;
+      ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
+    } readerModule{this, "ReaderModule", ""};
 
-struct ConstantD10InitialValueEceptionDummy {
-  ConstantD10InitialValueEceptionDummy()
-  : deviceBackend(boost::dynamic_pointer_cast<ChimeraTK::ExceptionDummy>(
-        ChimeraTK::BackendFactory::getInstance().createBackend("(ExceptionDummy:1?map=test.map)"))) {}
-  ~ConstantD10InitialValueEceptionDummy() { deviceBackend->throwExceptionRead = false; }
+    WriterModule writerModule{this, "WriterModule", ""};
+  };
 
-  boost::shared_ptr<ChimeraTK::ExceptionDummy> deviceBackend;
-  ConstantD10DummyApplication application;
-  ChimeraTK::TestFacility testFacitiy{application, false};
-};
+  struct Test6A4InitialValueEceptionDummy {
+    Test6A4InitialValueEceptionDummy() = default;
+    ~Test6A4InitialValueEceptionDummy() = default;
 
-/**
- *  D 10 for Constant
- * \anchor testConstantD10InitialValue_D_10 \ref initialValue_d_10
- */
-BOOST_AUTO_TEST_CASE(testConstantD10InitialValue) {
-  std::cout << "===   testConstantD10InitialValue   === " << std::endl;
-  ConstantD10InitialValueEceptionDummy d;
-  d.application.optimiseUnmappedVariables({"/REG1"});
+    Test6A4DummyApplication application;
+    ChimeraTK::TestFacility testFacitiy{application, false};
+    ChimeraTK::ScalarPushInput<int>& pushVariable{application.readerModule.reg1};
+  };
 
-  ChimeraTK::Device dev("(ExceptionDummy:1?map=test.map)");
-  dev.open();
-  dev.write<int>("REG1", 1234); // place some value, we expect it to be overwritten with 0
+  /**
+   *  D 6_a4 initial value from output
+   * \anchor testD6_a4_InitialValue \ref testD6_a4_InitialValue
+   */
+  BOOST_AUTO_TEST_CASE(testD6_a4_InitialValue) {
+    std::cout << "===   testD6_a4_InitialValue   === " << std::endl;
 
-  d.deviceBackend->throwExceptionOpen = true;
-  BOOST_CHECK_THROW(d.deviceBackend->open(), std::exception);
+    Test6A4InitialValueEceptionDummy d;
 
-  d.application.run();
-  d.application.constantModule.p.get_future().wait();
-
-  BOOST_CHECK(d.application.constantModule.enteredTheMainLoop == true);
-  BOOST_CHECK(d.application.constantModule.reg1.constant == 0); // no longer at the value set in prepare()
-  BOOST_CHECK(d.application.constantModule.reg1.constant.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-
-  ChimeraTK::DummyRegisterAccessor<int> reg1(
-      boost::dynamic_pointer_cast<ChimeraTK::DummyBackend>(dev.getBackend()).get(), "", "REG1");
-  {
-    auto lk = reg1.getBufferLock();
-    BOOST_CHECK(reg1 == 1234);
+    d.application.run();
+    d.application.readerModule.p.get_future().wait();
+    BOOST_CHECK(d.application.readerModule.enteredTheMainLoop == true);
+    CHECK_TIMEOUT(d.pushVariable == 777, 100000);
+    BOOST_CHECK(d.pushVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
   }
-  d.deviceBackend->throwExceptionOpen = false;
-  CHECK_TIMEOUT((reg1.getBufferLock(), reg1 == 0), 1000000);
-}
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-struct TestModule : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
-  ChimeraTK::ScalarPushInput<int> pushInput{this, "/REG1", "", ""};
-  ChimeraTK::ScalarOutput<int> output{this, "SomeOutput", "", ""};
-  std::promise<void> p;
-  std::atomic_bool enteredTheMainLoop{false};
-  void mainLoop() override {
-    enteredTheMainLoop = true;
-    p.set_value();
-  }
-};
-
-struct TestDummyApplication : ChimeraTK::Application {
-  constexpr static const char* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=test-async.map)";
-  TestDummyApplication() : Application("DummyApplication") {}
-  ~TestDummyApplication() override { shutdown(); }
-
-  TestModule testModule{this, "TestModule", ""};
-  ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
-};
-
-struct TestInitialValueExceptionDummy {
-  explicit TestInitialValueExceptionDummy()
-  : deviceBackend(boost::dynamic_pointer_cast<ChimeraTK::ExceptionDummy>(
-        ChimeraTK::BackendFactory::getInstance().createBackend(TestDummyApplication::ExceptionDummyCDD1))) {}
-  ~TestInitialValueExceptionDummy() { deviceBackend->throwExceptionRead = false; }
-
-  boost::shared_ptr<ChimeraTK::ExceptionDummy> deviceBackend;
-  TestDummyApplication application;
-  ChimeraTK::TestFacility testFacitiy{application, false};
-  ChimeraTK::ScalarPushInput<int>& pushVariable{application.testModule.pushInput};
-  ChimeraTK::ScalarOutput<int>& outputVariable{application.testModule.output};
-};
-
-/**
- *  D 1 for DataValidity::faulty
- * \anchor testD1InitialValue_D_1 \ref testD1InitialValue_D_1
- */
-// Todo add missing tests for bi-directional variables
-BOOST_AUTO_TEST_CASE(testD1InitialValue) {
-  std::cout << "===   testD1InitialValue   === " << std::endl;
-
-  TestInitialValueExceptionDummy d;
-
-  d.application.run();
-  d.application.testModule.p.get_future().wait();
-  BOOST_CHECK(d.application.testModule.enteredTheMainLoop == true);
-  BOOST_CHECK(d.pushVariable.dataValidity() == ctk::DataValidity::ok);
-  d.application.testModule.output.write();
-  BOOST_CHECK(d.outputVariable.dataValidity() == ctk::DataValidity::ok);
-}
-
-/**
- *  D 2 for DataValidity::faulty
- * \anchor testD1InitialValue_D_2 \ref testD1InitialValue_D_2
- */
-BOOST_AUTO_TEST_CASE(testD2InitialValue) {
-  std::cout << "===   testD2InitialValue   === " << std::endl;
-
-  TestInitialValueExceptionDummy d;
-  d.application.run();
-  d.application.testModule.p.get_future().wait();
-  d.application.testModule.output.write();
-  BOOST_CHECK(d.application.testModule.enteredTheMainLoop == true);
-  BOOST_CHECK(d.pushVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-  BOOST_CHECK(d.outputVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-}
-
-/**
- *  D 3 for DataValidity::faulty
- * \anchor testD1InitialValue_D_3 \ref testD1InitialValue_D_3
- */
-BOOST_AUTO_TEST_CASE(testD3InitialValue) {
-  std::cout << "===   testD3InitialValue   === " << std::endl;
-
-  TestInitialValueExceptionDummy d;
-  d.application.run();
-  d.application.testModule.p.get_future().wait();
-  BOOST_CHECK(d.application.testModule.enteredTheMainLoop == true);
-  BOOST_CHECK(d.pushVariable.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(d.outputVariable.dataValidity() == ctk::DataValidity::ok);
-  // Todo. The initial value can also be faulty. Change backend so that it allows to override the data validity without
-  // going to an exception state.
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-struct WriterModule : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
-  ChimeraTK::ScalarOutput<int> output1{this, "/REG1", "", ""};
-  ChimeraTK::ScalarOutput<int> output2{this, "/REG2", "", ""};
-  std::atomic_bool enteredTheMainLoop{false};
-  std::atomic_bool enteredThePrepareLoop{false};
-  void mainLoop() override {
-    enteredTheMainLoop = true;
-    output2 = 555;
-    output2.write();
-  }
-  void prepare() override {
-    enteredThePrepareLoop = true;
-    output1 = 777;
-    output1.write();
-  }
-};
-
-struct ReaderModule : NotifyingModule {
-  using NotifyingModule::NotifyingModule;
-
-  ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
-  ChimeraTK::ScalarPushInput<int> reg2{this, "/REG2", "", ""};
-};
-
-struct Test7DummyApplication : ChimeraTK::Application {
-  Test7DummyApplication() : Application("DummyApplication") {}
-  ~Test7DummyApplication() override { shutdown(); }
-
-  WriterModule writerModule{this, "WriterModule", ""};
-  ReaderModule readerModule{this, "ReaderModule", ""};
-};
-
-/**
- *  D 7_1
- * \anchor testD7_1_InitialValue \ref testD7_1_InitialValue
- */
-
-BOOST_AUTO_TEST_CASE(testD7_1_InitialValue) {
-  std::cout << "===   testD7_1_InitialValue   === " << std::endl;
-
-  Test7DummyApplication application;
-  ChimeraTK::TestFacility testFacitiy{application, false};
-  application.run();
-  BOOST_CHECK(application.writerModule.enteredThePrepareLoop == true);
-  application.readerModule.p.get_future().wait();
-  CHECK_TIMEOUT(application.readerModule.reg1 == 777, 500);
-}
-
-/**
- *  D 7_2
- * \anchor testD7_2_InitialValue \ref testD7_2_InitialValue
- */
-BOOST_AUTO_TEST_CASE(testD7_2_InitialValue) {
-  std::cout << "===   testD7_2_InitialValue   === " << std::endl;
-
-  Test7DummyApplication application;
-  ChimeraTK::TestFacility testFacitiy{application, false};
-  application.run();
-  application.readerModule.p.get_future().wait();
-  BOOST_CHECK(application.readerModule.enteredTheMainLoop == true);
-  CHECK_TIMEOUT(application.readerModule.reg2 == 555, 500);
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-struct Test6A1DummyApplication : ChimeraTK::Application {
-  // This application connects the CS to the device and and the input of the readerModule
-  constexpr static const char* CDD = "(dummy:1?map=test.map)";
-  Test6A1DummyApplication() : Application("DummyApplication") {}
-  ~Test6A1DummyApplication() override { shutdown(); }
-
-  struct : NotifyingModule {
+  struct PollModule : NotifyingModule {
     using NotifyingModule::NotifyingModule;
 
-    ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
-  } readerModule{this, ".", ""};
+    ChimeraTK::ScalarPollInput<int> pollInput{this, "/REG1", "", ""};
+  };
 
-  ChimeraTK::DeviceModule device{this, CDD};
-};
+  struct Test6BDummyApplication : ChimeraTK::Application {
+    constexpr static const char* CDD = "(dummy?map=test-ro.map)";
+    Test6BDummyApplication() : Application("DummyApplication") {}
+    ~Test6BDummyApplication() override { shutdown(); }
 
-struct Test6A1InitialValueEceptionDummy {
-  Test6A1InitialValueEceptionDummy() = default;
-  ~Test6A1InitialValueEceptionDummy() = default;
+    PollModule pollModule{this, "PollModule", ""};
+    ChimeraTK::DeviceModule device{this, CDD};
+  };
 
-  Test6A1DummyApplication application;
-  ChimeraTK::TestFacility testFacitiy{application, false};
-  ChimeraTK::ScalarPushInput<int>& pushVariable{application.readerModule.reg1};
-};
+  struct Test6BInitialValueEceptionDummy {
+    Test6BInitialValueEceptionDummy() = default;
+    ~Test6BInitialValueEceptionDummy() = default;
 
-/**
- *  D 6_a1 initial value from control system variable
- * \anchor testD6_a1_InitialValue \ref testD6_a1_InitialValue
- */
+    Test6BDummyApplication application;
+    ChimeraTK::TestFacility testFacitiy{application, false};
+    ChimeraTK::ScalarPollInput<int>& pollVariable{application.pollModule.pollInput};
+  };
 
-BOOST_AUTO_TEST_CASE(testD6_a1_InitialValue) {
-  std::cout << "===   testD6_a1_InitialValue   === " << std::endl;
-  Test6A1InitialValueEceptionDummy d;
-  d.application.run();
-  BOOST_CHECK(d.pushVariable.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
-  d.testFacitiy.writeScalar<int>("REG1", 27);
-  ChimeraTK::Device dev;
-  dev.open(Test6A1DummyApplication::CDD);
-  CHECK_TIMEOUT(dev.read<int>("REG1") == 27, 1000000);
-  // wait until the main loop has been entered. then we know the version number of the inputs must not be 0.
-  // FIXME: I think this does not belong into this test....
-  d.application.readerModule.p.get_future().wait(); // synchronisation point for the thread sanitizer
-  BOOST_CHECK(d.pushVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-}
+  /**
+   *  D 6_b initial value from device in poll mode
+   * \anchor testD6_b_InitialValue \ref testD6_b_InitialValue
+   * FIXME: Is this supposed to test push variables in poll mode or poll variables?
+   */
+  BOOST_AUTO_TEST_CASE(testD6_b_InitialValue) {
+    std::cout << "===   testD6_b_InitialValue   === " << std::endl;
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-struct Test6A2DummyApplication : ChimeraTK::Application {
-  constexpr static const char* CDD1 = "(dummy:1?map=one-register.map)";
-  constexpr static const char* CDD2 = "(dummy:2?map=test-ro.map)";
-  Test6A2DummyApplication() : Application("DummyApplication") {}
-  ~Test6A2DummyApplication() override { shutdown(); }
+    Test6BInitialValueEceptionDummy d;
 
-  struct : NotifyingModule {
-    using NotifyingModule::NotifyingModule;
-    ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
-  } readerModule{this, "ReaderModule", ""};
+    d.application.run();
 
-  TriggerModule triggerModule{this, "ReaderModule", ""};
-  ChimeraTK::DeviceModule device{this, CDD1};
-  ChimeraTK::DeviceModule device2{this, CDD2, "/TRIG1/PUSH_OUT"};
-};
+    ChimeraTK::Device dev;
+    dev.open(Test6BDummyApplication::CDD);
+    dev.write<int>("REG1/DUMMY_WRITEABLE", 99);
+    d.application.pollModule.p.get_future().wait();
+    BOOST_CHECK(d.application.pollModule.enteredTheMainLoop == true);
+    BOOST_CHECK(d.pollVariable == 99);
+    BOOST_CHECK(d.pollVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+  }
 
-struct Test6A2InitialValueEceptionDummy {
-  Test6A2InitialValueEceptionDummy() = default;
-  ~Test6A2InitialValueEceptionDummy() = default;
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  Test6A2DummyApplication application;
-  ChimeraTK::TestFacility testFacility{application, false};
-  ChimeraTK::ScalarPushInput<int>& pushVariable{application.readerModule.reg1};
-};
+  struct Test6CDummyApplication : ChimeraTK::Application {
+    constexpr static const char* ExceptionDummyCDD1 = "(dummy:1?map=test-async.map)";
+    Test6CDummyApplication() : Application("DummyApplication") {}
+    ~Test6CDummyApplication() override { shutdown(); }
 
-/**
- *  D 6_a2 initial value from device in poll mode
- * \anchor testD6_a2_InitialValue \ref testD6_a2_InitialValue
- *
- *  The push type variable dev2/REG1 is "directly" connected to dev1/REG2 through a trigger.
- *  Test that it is written as soon as the initial value is available, i.e. there has been a trigger.
- */
+    struct : NotifyingModule {
+      using NotifyingModule::NotifyingModule;
+      ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
+    } readerModule{this, "ReaderModule", ""};
 
-BOOST_AUTO_TEST_CASE(testD6_a2_InitialValue) {
-  std::cout << "===   testD6_a2_InitialValue   === " << std::endl;
+    ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
+  };
 
-  Test6A2InitialValueEceptionDummy d;
+  struct Test6CInitialValueEceptionDummy {
+    Test6CInitialValueEceptionDummy() = default;
+    ~Test6CInitialValueEceptionDummy() = default;
 
-  ChimeraTK::Device dev2;
-  dev2.open(Test6A2DummyApplication::CDD2);
-  dev2.write<int>("REG1/DUMMY_WRITEABLE", 99); // value now in in dev2
+    Test6CDummyApplication application;
+    ChimeraTK::TestFacility testFacitiy{application, false};
+    ChimeraTK::ScalarRegisterAccessor<int> exceptionDummyRegister;
+    ChimeraTK::ScalarPushInput<int>& pushVariable{application.readerModule.reg1};
+  };
+  /**
+   *  D 6_c initial value from device in push mode
+   * \anchor testD6_c_InitialValue \ref testD6_c_InitialValue
+   */
+  BOOST_AUTO_TEST_CASE(testD6_c_InitialValue) {
+    std::cout << "===   testD6_c_InitialValue   === " << std::endl;
 
-  d.application.run();
-  // no trigger yet and the value is not on dev1 yet
-  BOOST_CHECK(d.pushVariable.getVersionNumber() == ctk::VersionNumber(std::nullptr_t()));
-  ChimeraTK::Device dev;
-  dev.open(Test6A2DummyApplication::CDD1);
-  BOOST_CHECK(dev.read<int>("REG1") != 99);
+    Test6CInitialValueEceptionDummy d;
 
-  // send the trigger and check that the data arrives on the device
-  d.application.triggerModule.trigger.write();
+    d.application.run();
 
-  CHECK_TIMEOUT(dev.read<int>("REG1") == 99, 1000000);
-}
+    ChimeraTK::Device dev;
+    dev.open(Test6CDummyApplication::ExceptionDummyCDD1);
+    dev.write<int>("REG1/DUMMY_WRITEABLE", 99);
+    dev.getVoidRegisterAccessor("/DUMMY_INTERRUPT_3").write();
+    d.application.readerModule.p.get_future().wait();
+    BOOST_CHECK(d.application.readerModule.enteredTheMainLoop == true);
+    BOOST_TEST(d.pushVariable == 99);
+    BOOST_CHECK(d.pushVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
+  }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+  BOOST_AUTO_TEST_SUITE_END()
 
-struct Test6A3DummyApplication : ChimeraTK::Application {
-  constexpr static const char* CDD1 = "(dummy:1?map=one-register.map)";
-  constexpr static const char* CDD2 = "(dummy:2?map=test-async.map)";
-  Test6A3DummyApplication() : Application("DummyApplication") {}
-  ~Test6A3DummyApplication() override { shutdown(); }
-
-  struct : NotifyingModule {
-    using NotifyingModule::NotifyingModule;
-    ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
-  } readerModule{this, "ReaderModule", ""};
-
-  ChimeraTK::DeviceModule device{this, CDD1};
-  ChimeraTK::DeviceModule device2{this, CDD2};
-};
-
-struct Test6A3InitialValueEceptionDummy {
-  Test6A3InitialValueEceptionDummy() = default;
-  ~Test6A3InitialValueEceptionDummy() = default;
-
-  Test6A3DummyApplication application;
-  ChimeraTK::TestFacility testFacility{application, false};
-  ChimeraTK::ScalarPushInput<int>& pushVariable{application.readerModule.reg1};
-};
-
-/**
- *  D 6_a3 initial value from device in push mode
- * \anchor testD6_a3_InitialValue \ref testD6_a3_InitialValue
- */
-BOOST_AUTO_TEST_CASE(testD6_a3_InitialValue) {
-  std::cout << "===   testD6_a3_InitialValue   === " << std::endl;
-
-  Test6A3InitialValueEceptionDummy d;
-
-  ChimeraTK::Device dev2;
-  dev2.open(Test6A3DummyApplication::CDD2);
-  dev2.write<int>("REG1/DUMMY_WRITEABLE", 99);
-
-  d.application.run();
-
-  ChimeraTK::Device dev;
-  dev.open(Test6A3DummyApplication::CDD1);
-  CHECK_TIMEOUT(dev.read<int>("REG1") == 99, 1000000);
-  d.application.readerModule.p.get_future().wait();
-  BOOST_CHECK(d.pushVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-struct Test6A4DummyApplication : ChimeraTK::Application {
-  Test6A4DummyApplication() : Application("DummyApplication") {}
-  ~Test6A4DummyApplication() override { shutdown(); }
-
-  struct : NotifyingModule {
-    using NotifyingModule::NotifyingModule;
-    ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
-  } readerModule{this, "ReaderModule", ""};
-
-  WriterModule writerModule{this, "WriterModule", ""};
-};
-
-struct Test6A4InitialValueEceptionDummy {
-  Test6A4InitialValueEceptionDummy() = default;
-  ~Test6A4InitialValueEceptionDummy() = default;
-
-  Test6A4DummyApplication application;
-  ChimeraTK::TestFacility testFacitiy{application, false};
-  ChimeraTK::ScalarPushInput<int>& pushVariable{application.readerModule.reg1};
-};
-
-/**
- *  D 6_a4 initial value from output
- * \anchor testD6_a4_InitialValue \ref testD6_a4_InitialValue
- */
-BOOST_AUTO_TEST_CASE(testD6_a4_InitialValue) {
-  std::cout << "===   testD6_a4_InitialValue   === " << std::endl;
-
-  Test6A4InitialValueEceptionDummy d;
-
-  d.application.run();
-  d.application.readerModule.p.get_future().wait();
-  BOOST_CHECK(d.application.readerModule.enteredTheMainLoop == true);
-  CHECK_TIMEOUT(d.pushVariable == 777, 100000);
-  BOOST_CHECK(d.pushVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-struct PollModule : NotifyingModule {
-  using NotifyingModule::NotifyingModule;
-
-  ChimeraTK::ScalarPollInput<int> pollInput{this, "/REG1", "", ""};
-};
-
-struct Test6BDummyApplication : ChimeraTK::Application {
-  constexpr static const char* CDD = "(dummy?map=test-ro.map)";
-  Test6BDummyApplication() : Application("DummyApplication") {}
-  ~Test6BDummyApplication() override { shutdown(); }
-
-  PollModule pollModule{this, "PollModule", ""};
-  ChimeraTK::DeviceModule device{this, CDD};
-};
-
-struct Test6BInitialValueEceptionDummy {
-  Test6BInitialValueEceptionDummy() = default;
-  ~Test6BInitialValueEceptionDummy() = default;
-
-  Test6BDummyApplication application;
-  ChimeraTK::TestFacility testFacitiy{application, false};
-  ChimeraTK::ScalarPollInput<int>& pollVariable{application.pollModule.pollInput};
-};
-
-/**
- *  D 6_b initial value from device in poll mode
- * \anchor testD6_b_InitialValue \ref testD6_b_InitialValue
- * FIXME: Is this supposed to test push variables in poll mode or poll variables?
- */
-BOOST_AUTO_TEST_CASE(testD6_b_InitialValue) {
-  std::cout << "===   testD6_b_InitialValue   === " << std::endl;
-
-  Test6BInitialValueEceptionDummy d;
-
-  d.application.run();
-
-  ChimeraTK::Device dev;
-  dev.open(Test6BDummyApplication::CDD);
-  dev.write<int>("REG1/DUMMY_WRITEABLE", 99);
-  d.application.pollModule.p.get_future().wait();
-  BOOST_CHECK(d.application.pollModule.enteredTheMainLoop == true);
-  BOOST_CHECK(d.pollVariable == 99);
-  BOOST_CHECK(d.pollVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-struct Test6CDummyApplication : ChimeraTK::Application {
-  constexpr static const char* ExceptionDummyCDD1 = "(dummy:1?map=test-async.map)";
-  Test6CDummyApplication() : Application("DummyApplication") {}
-  ~Test6CDummyApplication() override { shutdown(); }
-
-  struct : NotifyingModule {
-    using NotifyingModule::NotifyingModule;
-    ChimeraTK::ScalarPushInput<int> reg1{this, "/REG1", "", ""};
-  } readerModule{this, "ReaderModule", ""};
-
-  ChimeraTK::DeviceModule device{this, ExceptionDummyCDD1};
-};
-
-struct Test6CInitialValueEceptionDummy {
-  Test6CInitialValueEceptionDummy() = default;
-  ~Test6CInitialValueEceptionDummy() = default;
-
-  Test6CDummyApplication application;
-  ChimeraTK::TestFacility testFacitiy{application, false};
-  ChimeraTK::ScalarRegisterAccessor<int> exceptionDummyRegister;
-  ChimeraTK::ScalarPushInput<int>& pushVariable{application.readerModule.reg1};
-};
-/**
- *  D 6_c initial value from device in push mode
- * \anchor testD6_c_InitialValue \ref testD6_c_InitialValue
- */
-BOOST_AUTO_TEST_CASE(testD6_c_InitialValue) {
-  std::cout << "===   testD6_c_InitialValue   === " << std::endl;
-
-  Test6CInitialValueEceptionDummy d;
-
-  d.application.run();
-
-  ChimeraTK::Device dev;
-  dev.open(Test6CDummyApplication::ExceptionDummyCDD1);
-  dev.write<int>("REG1/DUMMY_WRITEABLE", 99);
-  dev.getVoidRegisterAccessor("/DUMMY_INTERRUPT_3").write();
-  d.application.readerModule.p.get_future().wait();
-  BOOST_CHECK(d.application.readerModule.enteredTheMainLoop == true);
-  BOOST_TEST(d.pushVariable == 99);
-  BOOST_CHECK(d.pushVariable.getVersionNumber() != ctk::VersionNumber(std::nullptr_t()));
-}
-
-BOOST_AUTO_TEST_SUITE_END()
+} // namespace Tests::testInitialValues

--- a/tests/executables_src/testModel.cc
+++ b/tests/executables_src/testModel.cc
@@ -11,732 +11,1275 @@
 #define BOOST_TEST_MODULE testApplicationPVModel
 #include <boost/test/included/unit_test.hpp>
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testApplicationPVModel {
 
-/*********************************************************************************************************************/
-/* Simple TestApplication */
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
-struct MyModule : ctk::ApplicationModule {
-  MyModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
-      const std::unordered_set<std::string>& tags = {})
-  : ApplicationModule(owner, name, description, tags) {
-    actuator.addTag("B");
+  /*********************************************************************************************************************/
+  /* Simple TestApplication */
+
+  struct MyModule : ctk::ApplicationModule {
+    MyModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
+        const std::unordered_set<std::string>& tags = {})
+    : ApplicationModule(owner, name, description, tags) {
+      actuator.addTag("B");
+    }
+
+    using ctk::ApplicationModule::ApplicationModule;
+
+    ctk::ScalarOutput<int> actuator{this, "actuator", "unit", "Some output scalar"};
+
+    struct PointlessVariableGroup : ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarPollInput<int> readBack{this, "../readBack", "unit", "Some input scalar"};
+    } pointlessVariableGroup{this, "pointlessVariableGroup", ""};
+
+    void mainLoop() override {}
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TestModule : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+
+    ctk::ScalarPushInput<int> also{this, "also", "unit", "Some push input"};
+
+    struct Need : ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarPollInput<int> tests{this, "tests", "unit", "Some poll input", {"B"}};
+    } need{this, "need", ""};
+
+    void mainLoop() override {}
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TestModuleGroup : ctk::ModuleGroup {
+    using ctk::ModuleGroup::ModuleGroup;
+
+    TestModule testModule{this, ".", "The test module"};
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TestApplication : ctk::Application {
+    TestApplication() : Application("testSuite") {}
+    ctk::SetDMapFilePath dmap{"test.dmap"};
+
+    ~TestApplication() override { shutdown(); }
+
+    TestModuleGroup deeperHierarchies{this, "Deeper/hierarchies", "The test module group", {"A"}};
+    MyModule myModule{this, "MyModule", "ApplicationModule directly owned by app"};
+    MyModule myModule2{this, "Deeper/MyModule", "Additional "};
+    ctk::DeviceModule dev{this, "Dummy0", "/somepath/dummyTrigger"}; // test2.map
+  };
+
+  /*********************************************************************************************************************/
+  /* Generic tests */
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testGraphViz) {
+    // this is no real test, just a smoke test, since there might be too much variance in the dot graph output
+    TestApplication app;
+    app.getModel().writeGraphViz("test.dot");
+    app.getModel().writeGraphViz("test-parenthood.dot", ChimeraTK::Model::keepParenthood);
   }
 
-  using ctk::ApplicationModule::ApplicationModule;
+  /*********************************************************************************************************************/
 
-  ctk::ScalarOutput<int> actuator{this, "actuator", "unit", "Some output scalar"};
+  BOOST_AUTO_TEST_CASE(testGetFullyQualifiedPath) {
+    TestApplication app;
 
-  struct PointlessVariableGroup : ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarPollInput<int> readBack{this, "../readBack", "unit", "Some input scalar"};
-  } pointlessVariableGroup{this, "pointlessVariableGroup", ""};
+    BOOST_TEST(app.getModel().getFullyQualifiedPath() == "/");
+    BOOST_TEST(app.deeperHierarchies.getModel().getFullyQualifiedPath() == "/Deeper/hierarchies");
+    BOOST_TEST(app.deeperHierarchies.testModule.getModel().getFullyQualifiedPath() == "/Deeper/hierarchies");
+    BOOST_TEST(app.deeperHierarchies.testModule.need.getModel().getFullyQualifiedPath() == "/Deeper/hierarchies/need");
+    BOOST_TEST(app.deeperHierarchies.testModule.need.tests.getModel().getFullyQualifiedPath() ==
+        "/Deeper/hierarchies/need/tests");
+    BOOST_TEST(app.myModule.pointlessVariableGroup.readBack.getModel().getFullyQualifiedPath() == "/MyModule/readBack");
+  }
 
-  void mainLoop() override {}
-};
+  /*********************************************************************************************************************/
 
-/*********************************************************************************************************************/
+  BOOST_AUTO_TEST_CASE(testIsValid) {
+    TestApplication app;
 
-struct TestModule : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
+    ChimeraTK::Model::RootProxy invalid;
 
-  ctk::ScalarPushInput<int> also{this, "also", "unit", "Some push input"};
+    BOOST_TEST(invalid.isValid() == false);
+    BOOST_TEST(app.getModel().isValid() == true);
+  }
 
-  struct Need : ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarPollInput<int> tests{this, "tests", "unit", "Some poll input", {"B"}};
-  } need{this, "need", ""};
+  /*********************************************************************************************************************/
 
-  void mainLoop() override {}
-};
+  BOOST_AUTO_TEST_CASE(testVisitByPath) {
+    TestApplication app;
+    bool found;
 
-/*********************************************************************************************************************/
-
-struct TestModuleGroup : ctk::ModuleGroup {
-  using ctk::ModuleGroup::ModuleGroup;
-
-  TestModule testModule{this, ".", "The test module"};
-};
-
-/*********************************************************************************************************************/
-
-struct TestApplication : ctk::Application {
-  TestApplication() : Application("testSuite") {}
-  ctk::SetDMapFilePath dmap{"test.dmap"};
-
-  ~TestApplication() override { shutdown(); }
-
-  TestModuleGroup deeperHierarchies{this, "Deeper/hierarchies", "The test module group", {"A"}};
-  MyModule myModule{this, "MyModule", "ApplicationModule directly owned by app"};
-  MyModule myModule2{this, "Deeper/MyModule", "Additional "};
-  ctk::DeviceModule dev{this, "Dummy0", "/somepath/dummyTrigger"}; // test2.map
-};
-
-/*********************************************************************************************************************/
-/* Generic tests */
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testGraphViz) {
-  // this is no real test, just a smoke test, since there might be too much variance in the dot graph output
-  TestApplication app;
-  app.getModel().writeGraphViz("test.dot");
-  app.getModel().writeGraphViz("test-parenthood.dot", ChimeraTK::Model::keepParenthood);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testGetFullyQualifiedPath) {
-  TestApplication app;
-
-  BOOST_TEST(app.getModel().getFullyQualifiedPath() == "/");
-  BOOST_TEST(app.deeperHierarchies.getModel().getFullyQualifiedPath() == "/Deeper/hierarchies");
-  BOOST_TEST(app.deeperHierarchies.testModule.getModel().getFullyQualifiedPath() == "/Deeper/hierarchies");
-  BOOST_TEST(app.deeperHierarchies.testModule.need.getModel().getFullyQualifiedPath() == "/Deeper/hierarchies/need");
-  BOOST_TEST(app.deeperHierarchies.testModule.need.tests.getModel().getFullyQualifiedPath() ==
-      "/Deeper/hierarchies/need/tests");
-  BOOST_TEST(app.myModule.pointlessVariableGroup.readBack.getModel().getFullyQualifiedPath() == "/MyModule/readBack");
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testIsValid) {
-  TestApplication app;
-
-  ChimeraTK::Model::RootProxy invalid;
-
-  BOOST_TEST(invalid.isValid() == false);
-  BOOST_TEST(app.getModel().isValid() == true);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testVisitByPath) {
-  TestApplication app;
-  bool found;
-
-  ChimeraTK::Model::DirectoryProxy dir;
-  found = app.getModel().visitByPath("/Deeper/hierarchies", [&](auto proxy) {
-    if constexpr(isDirectory(proxy)) {
-      dir = proxy;
-    }
-    else {
-      BOOST_FAIL("Wrong proxy type found.");
-    }
-  });
-  BOOST_TEST(found == true);
-  BOOST_TEST(dir.isValid());
-  BOOST_TEST(dir.getName() == "hierarchies");
-
-  found = app.getModel().visitByPath(
-      "/Deeper/hierarchies/notExisting", [&](auto) { BOOST_FAIL("Visitor must not be called."); });
-  BOOST_TEST(found == false);
-
-  ChimeraTK::Model::ProcessVariableProxy var;
-  found = app.getModel().visitByPath("/Deeper/hierarchies/also", [&](auto proxy) {
-    if constexpr(isVariable(proxy)) {
-      var = proxy;
-    }
-    else {
-      BOOST_FAIL("Wrong proxy type found.");
-    }
-  });
-  BOOST_TEST(found == true);
-  BOOST_TEST(var.isValid());
-  BOOST_TEST(var.getName() == "also");
-}
-
-/*********************************************************************************************************************/
-/* Test functionality specific to the individual Proxy implementations */
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testModuleGroupProxy) {
-  TestApplication app;
-
-  ChimeraTK::Model::ModuleGroupProxy proxy = app.deeperHierarchies.getModel();
-  BOOST_CHECK(&proxy.getModuleGroup() == &app.deeperHierarchies);
-  BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testApplicationModuleProxy) {
-  TestApplication app;
-
-  ChimeraTK::Model::ApplicationModuleProxy proxy = app.deeperHierarchies.testModule.getModel();
-  BOOST_CHECK(&proxy.getApplicationModule() == &app.deeperHierarchies.testModule);
-  BOOST_CHECK(proxy.getName() == ".");
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testVariableGroupProxy) {
-  TestApplication app;
-
-  ChimeraTK::Model::VariableGroupProxy proxy = app.deeperHierarchies.testModule.need.getModel();
-  BOOST_CHECK(&proxy.getVariableGroup() == &app.deeperHierarchies.testModule.need);
-  BOOST_CHECK(proxy.getName() == "need");
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testDeviceModuleProxy) {
-  TestApplication app;
-
-  ChimeraTK::Model::DeviceModuleProxy proxy = app.dev.getModel();
-  BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
-  BOOST_REQUIRE(proxy.getTrigger().isValid());
-  BOOST_CHECK(proxy.getTrigger().getName() == "dummyTrigger");
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testProcessVariableProxy) {
-  TestApplication app;
-
-  ChimeraTK::Model::ProcessVariableProxy pv = app.myModule.actuator.getModel();
-  BOOST_TEST(pv.getName() == "actuator");
-  auto nodes = pv.getNodes();
-  BOOST_TEST(nodes.size() == 2);
-  BOOST_CHECK(nodes[0].getType() == ChimeraTK::NodeType::Device || nodes[1].getType() == ChimeraTK::NodeType::Device);
-  BOOST_CHECK(
-      nodes[0].getType() == ChimeraTK::NodeType::Application || nodes[1].getType() == ChimeraTK::NodeType::Application);
-
-  auto checker = [](auto proxy) {
-    if constexpr(isVariable(proxy)) {
-      BOOST_TEST(proxy.getName() == "readBack");
-    }
-    else {
-      BOOST_FAIL("Wrong vertex type found");
-    }
-  };
-  bool found = pv.visitByPath("../readBack", checker);
-  BOOST_TEST(found == true);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testDirectoryProxy) {
-  TestApplication app;
-
-  // get the directory. this relies on some other features...
-  auto dir = app.myModule.getModel().visit(ChimeraTK::Model::returnDirectory, ChimeraTK::Model::getNeighbourDirectory,
-      ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::DirectoryProxy{}));
-  assert(dir.isValid());
-
-  BOOST_TEST(dir.getName() == "MyModule");
-
-  auto checker = [](auto proxy) {
-    if constexpr(isVariable(proxy)) {
-      BOOST_TEST(proxy.getName() == "readBack");
-    }
-    else {
-      BOOST_FAIL("Wrong vertex type found");
-    }
-  };
-  bool found = dir.visitByPath("./readBack", checker);
-  BOOST_TEST(found == true);
-}
-
-/*********************************************************************************************************************/
-/* Test predicates */
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testPredicatesWithProxy) {
-  ChimeraTK::Model::RootProxy rp;
-  BOOST_TEST(isRoot(rp) == true);
-  BOOST_TEST(isModuleGroup(rp) == false);
-  BOOST_TEST(isApplicationModule(rp) == false);
-  BOOST_TEST(isVariableGroup(rp) == false);
-  BOOST_TEST(isDeviceModule(rp) == false);
-  BOOST_TEST(isVariable(rp) == false);
-  BOOST_TEST(isDirectory(rp) == false);
-  BOOST_TEST(hasName(rp) == false);
-
-  ChimeraTK::Model::ModuleGroupProxy mgp;
-  BOOST_TEST(isRoot(mgp) == false);
-  BOOST_TEST(isModuleGroup(mgp) == true);
-  BOOST_TEST(isApplicationModule(mgp) == false);
-  BOOST_TEST(isVariableGroup(mgp) == false);
-  BOOST_TEST(isDeviceModule(mgp) == false);
-  BOOST_TEST(isVariable(mgp) == false);
-  BOOST_TEST(isDirectory(mgp) == false);
-  BOOST_TEST(hasName(mgp) == true);
-
-  ChimeraTK::Model::ApplicationModuleProxy amp;
-  BOOST_TEST(isRoot(amp) == false);
-  BOOST_TEST(isModuleGroup(amp) == false);
-  BOOST_TEST(isApplicationModule(amp) == true);
-  BOOST_TEST(isVariableGroup(amp) == false);
-  BOOST_TEST(isDeviceModule(amp) == false);
-  BOOST_TEST(isVariable(amp) == false);
-  BOOST_TEST(isDirectory(amp) == false);
-  BOOST_TEST(hasName(amp) == true);
-
-  ChimeraTK::Model::VariableGroupProxy vgp;
-  BOOST_TEST(isRoot(vgp) == false);
-  BOOST_TEST(isModuleGroup(vgp) == false);
-  BOOST_TEST(isApplicationModule(vgp) == false);
-  BOOST_TEST(isVariableGroup(vgp) == true);
-  BOOST_TEST(isDeviceModule(vgp) == false);
-  BOOST_TEST(isVariable(vgp) == false);
-  BOOST_TEST(isDirectory(vgp) == false);
-  BOOST_TEST(hasName(vgp) == true);
-
-  ChimeraTK::Model::DeviceModuleProxy dmp;
-  BOOST_TEST(isRoot(dmp) == false);
-  BOOST_TEST(isModuleGroup(dmp) == false);
-  BOOST_TEST(isApplicationModule(dmp) == false);
-  BOOST_TEST(isVariableGroup(dmp) == false);
-  BOOST_TEST(isDeviceModule(dmp) == true);
-  BOOST_TEST(isVariable(dmp) == false);
-  BOOST_TEST(isDirectory(dmp) == false);
-  BOOST_TEST(hasName(dmp) == false);
-
-  ChimeraTK::Model::ProcessVariableProxy pvp;
-  BOOST_TEST(isRoot(pvp) == false);
-  BOOST_TEST(isModuleGroup(pvp) == false);
-  BOOST_TEST(isApplicationModule(pvp) == false);
-  BOOST_TEST(isVariableGroup(pvp) == false);
-  BOOST_TEST(isDeviceModule(pvp) == false);
-  BOOST_TEST(isVariable(pvp) == true);
-  BOOST_TEST(isDirectory(pvp) == false);
-  BOOST_TEST(hasName(pvp) == true);
-
-  ChimeraTK::Model::DirectoryProxy dp;
-  BOOST_TEST(isRoot(dp) == false);
-  BOOST_TEST(isModuleGroup(dp) == false);
-  BOOST_TEST(isApplicationModule(dp) == false);
-  BOOST_TEST(isVariableGroup(dp) == false);
-  BOOST_TEST(isDeviceModule(dp) == false);
-  BOOST_TEST(isVariable(dp) == false);
-  BOOST_TEST(isDirectory(dp) == true);
-  BOOST_TEST(hasName(dp) == true);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testPredicatesWithProperties) {
-  TestApplication app;
-
-  ChimeraTK::Model::VertexProperties::RootProperties rp{app};
-  BOOST_TEST(isRoot(rp) == true);
-  BOOST_TEST(isModuleGroup(rp) == false);
-  BOOST_TEST(isApplicationModule(rp) == false);
-  BOOST_TEST(isVariableGroup(rp) == false);
-  BOOST_TEST(isDeviceModule(rp) == false);
-  BOOST_TEST(isVariable(rp) == false);
-  BOOST_TEST(isDirectory(rp) == false);
-  BOOST_TEST(hasName(rp) == false);
-
-  ChimeraTK::Model::VertexProperties::ModuleGroupProperties mgp{"xxx", app.deeperHierarchies};
-  BOOST_TEST(isRoot(mgp) == false);
-  BOOST_TEST(isModuleGroup(mgp) == true);
-  BOOST_TEST(isApplicationModule(mgp) == false);
-  BOOST_TEST(isVariableGroup(mgp) == false);
-  BOOST_TEST(isDeviceModule(mgp) == false);
-  BOOST_TEST(isVariable(mgp) == false);
-  BOOST_TEST(isDirectory(mgp) == false);
-  BOOST_TEST(hasName(mgp) == true);
-
-  ChimeraTK::Model::VertexProperties::ApplicationModuleProperties amp{"xxx", app.myModule};
-  BOOST_TEST(isRoot(amp) == false);
-  BOOST_TEST(isModuleGroup(amp) == false);
-  BOOST_TEST(isApplicationModule(amp) == true);
-  BOOST_TEST(isVariableGroup(amp) == false);
-  BOOST_TEST(isDeviceModule(amp) == false);
-  BOOST_TEST(isVariable(amp) == false);
-  BOOST_TEST(isDirectory(amp) == false);
-  BOOST_TEST(hasName(amp) == true);
-
-  ChimeraTK::Model::VertexProperties::VariableGroupProperties vgp{"xxx", app.myModule.pointlessVariableGroup};
-  BOOST_TEST(isRoot(vgp) == false);
-  BOOST_TEST(isModuleGroup(vgp) == false);
-  BOOST_TEST(isApplicationModule(vgp) == false);
-  BOOST_TEST(isVariableGroup(vgp) == true);
-  BOOST_TEST(isDeviceModule(vgp) == false);
-  BOOST_TEST(isVariable(vgp) == false);
-  BOOST_TEST(isDirectory(vgp) == false);
-  BOOST_TEST(hasName(vgp) == true);
-
-  ChimeraTK::Model::VertexProperties::DeviceModuleProperties dmp{"xxx", {}, app.dev};
-  BOOST_TEST(isRoot(dmp) == false);
-  BOOST_TEST(isModuleGroup(dmp) == false);
-  BOOST_TEST(isApplicationModule(dmp) == false);
-  BOOST_TEST(isVariableGroup(dmp) == false);
-  BOOST_TEST(isDeviceModule(dmp) == true);
-  BOOST_TEST(isVariable(dmp) == false);
-  BOOST_TEST(isDirectory(dmp) == false);
-  BOOST_TEST(hasName(dmp) == false);
-
-  ChimeraTK::Model::VertexProperties::ProcessVariableProperties pvp{"xxx", {}, {}};
-  BOOST_TEST(isRoot(pvp) == false);
-  BOOST_TEST(isModuleGroup(pvp) == false);
-  BOOST_TEST(isApplicationModule(pvp) == false);
-  BOOST_TEST(isVariableGroup(pvp) == false);
-  BOOST_TEST(isDeviceModule(pvp) == false);
-  BOOST_TEST(isVariable(pvp) == true);
-  BOOST_TEST(isDirectory(pvp) == false);
-  BOOST_TEST(hasName(pvp) == true);
-
-  ChimeraTK::Model::VertexProperties::DirectoryProperties dp{"xxx"};
-  BOOST_TEST(isRoot(dp) == false);
-  BOOST_TEST(isModuleGroup(dp) == false);
-  BOOST_TEST(isApplicationModule(dp) == false);
-  BOOST_TEST(isVariableGroup(dp) == false);
-  BOOST_TEST(isDeviceModule(dp) == false);
-  BOOST_TEST(isVariable(dp) == false);
-  BOOST_TEST(isDirectory(dp) == true);
-  BOOST_TEST(hasName(dp) == true);
-}
-
-/*********************************************************************************************************************/
-/* Test search types */
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testAdjacentIn) {
-  TestApplication app;
-
-  // Check on root
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
-        // Root is the neighbouring directory of the device module
-        BOOST_TEST(proxy.getAliasOrCdd() == "Dummy0");
-      }
-      else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
-        // Root is its own neighbouring directory
+    ChimeraTK::Model::DirectoryProxy dir;
+    found = app.getModel().visitByPath("/Deeper/hierarchies", [&](auto proxy) {
+      if constexpr(isDirectory(proxy)) {
+        dir = proxy;
       }
       else {
-        BOOST_FAIL("Wrong vertex type found");
+        BOOST_FAIL("Wrong proxy type found.");
       }
-    };
+    });
+    BOOST_TEST(found == true);
+    BOOST_TEST(dir.isValid());
+    BOOST_TEST(dir.getName() == "hierarchies");
 
-    app.getModel().visit(checker, ChimeraTK::Model::adjacentInSearch);
+    found = app.getModel().visitByPath(
+        "/Deeper/hierarchies/notExisting", [&](auto) { BOOST_FAIL("Visitor must not be called."); });
+    BOOST_TEST(found == false);
 
-    BOOST_TEST(foundElements == 2);
+    ChimeraTK::Model::ProcessVariableProxy var;
+    found = app.getModel().visitByPath("/Deeper/hierarchies/also", [&](auto proxy) {
+      if constexpr(isVariable(proxy)) {
+        var = proxy;
+      }
+      else {
+        BOOST_FAIL("Wrong proxy type found.");
+      }
+    });
+    BOOST_TEST(found == true);
+    BOOST_TEST(var.isValid());
+    BOOST_TEST(var.getName() == "also");
   }
 
-  // Check on MyModule application module
-  {
-    size_t foundElements = 0;
+  /*********************************************************************************************************************/
+  /* Test functionality specific to the individual Proxy implementations */
+  /*********************************************************************************************************************/
 
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariable(proxy)) {
-        // this PV is an input
+  BOOST_AUTO_TEST_CASE(testModuleGroupProxy) {
+    TestApplication app;
+
+    ChimeraTK::Model::ModuleGroupProxy proxy = app.deeperHierarchies.getModel();
+    BOOST_CHECK(&proxy.getModuleGroup() == &app.deeperHierarchies);
+    BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testApplicationModuleProxy) {
+    TestApplication app;
+
+    ChimeraTK::Model::ApplicationModuleProxy proxy = app.deeperHierarchies.testModule.getModel();
+    BOOST_CHECK(&proxy.getApplicationModule() == &app.deeperHierarchies.testModule);
+    BOOST_CHECK(proxy.getName() == ".");
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testVariableGroupProxy) {
+    TestApplication app;
+
+    ChimeraTK::Model::VariableGroupProxy proxy = app.deeperHierarchies.testModule.need.getModel();
+    BOOST_CHECK(&proxy.getVariableGroup() == &app.deeperHierarchies.testModule.need);
+    BOOST_CHECK(proxy.getName() == "need");
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDeviceModuleProxy) {
+    TestApplication app;
+
+    ChimeraTK::Model::DeviceModuleProxy proxy = app.dev.getModel();
+    BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
+    BOOST_REQUIRE(proxy.getTrigger().isValid());
+    BOOST_CHECK(proxy.getTrigger().getName() == "dummyTrigger");
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testProcessVariableProxy) {
+    TestApplication app;
+
+    ChimeraTK::Model::ProcessVariableProxy pv = app.myModule.actuator.getModel();
+    BOOST_TEST(pv.getName() == "actuator");
+    auto nodes = pv.getNodes();
+    BOOST_TEST(nodes.size() == 2);
+    BOOST_CHECK(nodes[0].getType() == ChimeraTK::NodeType::Device || nodes[1].getType() == ChimeraTK::NodeType::Device);
+    BOOST_CHECK(nodes[0].getType() == ChimeraTK::NodeType::Application ||
+        nodes[1].getType() == ChimeraTK::NodeType::Application);
+
+    auto checker = [](auto proxy) {
+      if constexpr(isVariable(proxy)) {
         BOOST_TEST(proxy.getName() == "readBack");
       }
-      else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
-        // module is owned by root
+      else {
+        BOOST_FAIL("Wrong vertex type found");
+      }
+    };
+    bool found = pv.visitByPath("../readBack", checker);
+    BOOST_TEST(found == true);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDirectoryProxy) {
+    TestApplication app;
+
+    // get the directory. this relies on some other features...
+    auto dir = app.myModule.getModel().visit(ChimeraTK::Model::returnDirectory, ChimeraTK::Model::getNeighbourDirectory,
+        ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::DirectoryProxy{}));
+    assert(dir.isValid());
+
+    BOOST_TEST(dir.getName() == "MyModule");
+
+    auto checker = [](auto proxy) {
+      if constexpr(isVariable(proxy)) {
+        BOOST_TEST(proxy.getName() == "readBack");
       }
       else {
         BOOST_FAIL("Wrong vertex type found");
       }
     };
-
-    app.myModule.getModel().visit(checker, ChimeraTK::Model::adjacentInSearch);
-
-    BOOST_TEST(foundElements == 2);
+    bool found = dir.visitByPath("./readBack", checker);
+    BOOST_TEST(found == true);
   }
-}
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
+  /* Test predicates */
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(testAdjacentOut) {
-  TestApplication app;
+  BOOST_AUTO_TEST_CASE(testPredicatesWithProxy) {
+    ChimeraTK::Model::RootProxy rp;
+    BOOST_TEST(isRoot(rp) == true);
+    BOOST_TEST(isModuleGroup(rp) == false);
+    BOOST_TEST(isApplicationModule(rp) == false);
+    BOOST_TEST(isVariableGroup(rp) == false);
+    BOOST_TEST(isDeviceModule(rp) == false);
+    BOOST_TEST(isVariable(rp) == false);
+    BOOST_TEST(isDirectory(rp) == false);
+    BOOST_TEST(hasName(rp) == false);
 
-  // Check on root
-  {
-    size_t foundElements = 0;
+    ChimeraTK::Model::ModuleGroupProxy mgp;
+    BOOST_TEST(isRoot(mgp) == false);
+    BOOST_TEST(isModuleGroup(mgp) == true);
+    BOOST_TEST(isApplicationModule(mgp) == false);
+    BOOST_TEST(isVariableGroup(mgp) == false);
+    BOOST_TEST(isDeviceModule(mgp) == false);
+    BOOST_TEST(isVariable(mgp) == false);
+    BOOST_TEST(isDirectory(mgp) == false);
+    BOOST_TEST(hasName(mgp) == true);
 
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
-        // Root owns the DeviceModule
-        BOOST_TEST(proxy.getAliasOrCdd() == "Dummy0");
+    ChimeraTK::Model::ApplicationModuleProxy amp;
+    BOOST_TEST(isRoot(amp) == false);
+    BOOST_TEST(isModuleGroup(amp) == false);
+    BOOST_TEST(isApplicationModule(amp) == true);
+    BOOST_TEST(isVariableGroup(amp) == false);
+    BOOST_TEST(isDeviceModule(amp) == false);
+    BOOST_TEST(isVariable(amp) == false);
+    BOOST_TEST(isDirectory(amp) == false);
+    BOOST_TEST(hasName(amp) == true);
+
+    ChimeraTK::Model::VariableGroupProxy vgp;
+    BOOST_TEST(isRoot(vgp) == false);
+    BOOST_TEST(isModuleGroup(vgp) == false);
+    BOOST_TEST(isApplicationModule(vgp) == false);
+    BOOST_TEST(isVariableGroup(vgp) == true);
+    BOOST_TEST(isDeviceModule(vgp) == false);
+    BOOST_TEST(isVariable(vgp) == false);
+    BOOST_TEST(isDirectory(vgp) == false);
+    BOOST_TEST(hasName(vgp) == true);
+
+    ChimeraTK::Model::DeviceModuleProxy dmp;
+    BOOST_TEST(isRoot(dmp) == false);
+    BOOST_TEST(isModuleGroup(dmp) == false);
+    BOOST_TEST(isApplicationModule(dmp) == false);
+    BOOST_TEST(isVariableGroup(dmp) == false);
+    BOOST_TEST(isDeviceModule(dmp) == true);
+    BOOST_TEST(isVariable(dmp) == false);
+    BOOST_TEST(isDirectory(dmp) == false);
+    BOOST_TEST(hasName(dmp) == false);
+
+    ChimeraTK::Model::ProcessVariableProxy pvp;
+    BOOST_TEST(isRoot(pvp) == false);
+    BOOST_TEST(isModuleGroup(pvp) == false);
+    BOOST_TEST(isApplicationModule(pvp) == false);
+    BOOST_TEST(isVariableGroup(pvp) == false);
+    BOOST_TEST(isDeviceModule(pvp) == false);
+    BOOST_TEST(isVariable(pvp) == true);
+    BOOST_TEST(isDirectory(pvp) == false);
+    BOOST_TEST(hasName(pvp) == true);
+
+    ChimeraTK::Model::DirectoryProxy dp;
+    BOOST_TEST(isRoot(dp) == false);
+    BOOST_TEST(isModuleGroup(dp) == false);
+    BOOST_TEST(isApplicationModule(dp) == false);
+    BOOST_TEST(isVariableGroup(dp) == false);
+    BOOST_TEST(isDeviceModule(dp) == false);
+    BOOST_TEST(isVariable(dp) == false);
+    BOOST_TEST(isDirectory(dp) == true);
+    BOOST_TEST(hasName(dp) == true);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testPredicatesWithProperties) {
+    TestApplication app;
+
+    ChimeraTK::Model::VertexProperties::RootProperties rp{app};
+    BOOST_TEST(isRoot(rp) == true);
+    BOOST_TEST(isModuleGroup(rp) == false);
+    BOOST_TEST(isApplicationModule(rp) == false);
+    BOOST_TEST(isVariableGroup(rp) == false);
+    BOOST_TEST(isDeviceModule(rp) == false);
+    BOOST_TEST(isVariable(rp) == false);
+    BOOST_TEST(isDirectory(rp) == false);
+    BOOST_TEST(hasName(rp) == false);
+
+    ChimeraTK::Model::VertexProperties::ModuleGroupProperties mgp{"xxx", app.deeperHierarchies};
+    BOOST_TEST(isRoot(mgp) == false);
+    BOOST_TEST(isModuleGroup(mgp) == true);
+    BOOST_TEST(isApplicationModule(mgp) == false);
+    BOOST_TEST(isVariableGroup(mgp) == false);
+    BOOST_TEST(isDeviceModule(mgp) == false);
+    BOOST_TEST(isVariable(mgp) == false);
+    BOOST_TEST(isDirectory(mgp) == false);
+    BOOST_TEST(hasName(mgp) == true);
+
+    ChimeraTK::Model::VertexProperties::ApplicationModuleProperties amp{"xxx", app.myModule};
+    BOOST_TEST(isRoot(amp) == false);
+    BOOST_TEST(isModuleGroup(amp) == false);
+    BOOST_TEST(isApplicationModule(amp) == true);
+    BOOST_TEST(isVariableGroup(amp) == false);
+    BOOST_TEST(isDeviceModule(amp) == false);
+    BOOST_TEST(isVariable(amp) == false);
+    BOOST_TEST(isDirectory(amp) == false);
+    BOOST_TEST(hasName(amp) == true);
+
+    ChimeraTK::Model::VertexProperties::VariableGroupProperties vgp{"xxx", app.myModule.pointlessVariableGroup};
+    BOOST_TEST(isRoot(vgp) == false);
+    BOOST_TEST(isModuleGroup(vgp) == false);
+    BOOST_TEST(isApplicationModule(vgp) == false);
+    BOOST_TEST(isVariableGroup(vgp) == true);
+    BOOST_TEST(isDeviceModule(vgp) == false);
+    BOOST_TEST(isVariable(vgp) == false);
+    BOOST_TEST(isDirectory(vgp) == false);
+    BOOST_TEST(hasName(vgp) == true);
+
+    ChimeraTK::Model::VertexProperties::DeviceModuleProperties dmp{"xxx", {}, app.dev};
+    BOOST_TEST(isRoot(dmp) == false);
+    BOOST_TEST(isModuleGroup(dmp) == false);
+    BOOST_TEST(isApplicationModule(dmp) == false);
+    BOOST_TEST(isVariableGroup(dmp) == false);
+    BOOST_TEST(isDeviceModule(dmp) == true);
+    BOOST_TEST(isVariable(dmp) == false);
+    BOOST_TEST(isDirectory(dmp) == false);
+    BOOST_TEST(hasName(dmp) == false);
+
+    ChimeraTK::Model::VertexProperties::ProcessVariableProperties pvp{"xxx", {}, {}};
+    BOOST_TEST(isRoot(pvp) == false);
+    BOOST_TEST(isModuleGroup(pvp) == false);
+    BOOST_TEST(isApplicationModule(pvp) == false);
+    BOOST_TEST(isVariableGroup(pvp) == false);
+    BOOST_TEST(isDeviceModule(pvp) == false);
+    BOOST_TEST(isVariable(pvp) == true);
+    BOOST_TEST(isDirectory(pvp) == false);
+    BOOST_TEST(hasName(pvp) == true);
+
+    ChimeraTK::Model::VertexProperties::DirectoryProperties dp{"xxx"};
+    BOOST_TEST(isRoot(dp) == false);
+    BOOST_TEST(isModuleGroup(dp) == false);
+    BOOST_TEST(isApplicationModule(dp) == false);
+    BOOST_TEST(isVariableGroup(dp) == false);
+    BOOST_TEST(isDeviceModule(dp) == false);
+    BOOST_TEST(isVariable(dp) == false);
+    BOOST_TEST(isDirectory(dp) == true);
+    BOOST_TEST(hasName(dp) == true);
+  }
+
+  /*********************************************************************************************************************/
+  /* Test search types */
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testAdjacentIn) {
+    TestApplication app;
+
+    // Check on root
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
+          // Root is the neighbouring directory of the device module
+          BOOST_TEST(proxy.getAliasOrCdd() == "Dummy0");
+        }
+        else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
+          // Root is its own neighbouring directory
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.getModel().visit(checker, ChimeraTK::Model::adjacentInSearch);
+
+      BOOST_TEST(foundElements == 2);
+    }
+
+    // Check on MyModule application module
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariable(proxy)) {
+          // this PV is an input
+          BOOST_TEST(proxy.getName() == "readBack");
+        }
+        else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
+          // module is owned by root
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.getModel().visit(checker, ChimeraTK::Model::adjacentInSearch);
+
+      BOOST_TEST(foundElements == 2);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testAdjacentOut) {
+    TestApplication app;
+
+    // Check on root
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
+          // Root owns the DeviceModule
+          BOOST_TEST(proxy.getAliasOrCdd() == "Dummy0");
+        }
+        else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          // Root owns several directories
+          const auto& name = proxy.getName();
+          BOOST_CHECK(name == "Deeper" || name == "MyModule" || name == "somepath" || name == "Devices");
+        }
+        else if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
+          // Root owns the ModuleGroup
+          const auto& name = proxy.getName();
+          BOOST_CHECK(name == "Deeper/hierarchies");
+        }
+        else if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
+          const auto& name = proxy.getName();
+          BOOST_CHECK(name == "MyModule" || name == "Deeper/MyModule" || name == "/Devices/Dummy0");
+        }
+        else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
+          // Root is its own neighbouring directory
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.getModel().visit(checker, ChimeraTK::Model::adjacentOutSearch);
+
+      BOOST_TEST(foundElements == 10);
+    }
+
+    // Check on MyModule application module
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariable(proxy)) {
+          // this variable is an output
+          BOOST_CHECK(proxy.getName() == "actuator");
+        }
+        else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          // The neightbouring directory
+          BOOST_CHECK(proxy.getName() == "MyModule");
+        }
+        else if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
+          // VariableGroup owned by the module
+          BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.getModel().visit(checker, ChimeraTK::Model::adjacentOutSearch);
+
+      BOOST_TEST(foundElements == 4); // actuator is found twice because of pvAccess and ownership relationships
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  // helper class for testAdjacent
+  struct Item {
+    template<typename PROXY>
+    explicit Item(PROXY proxy) : type(typeid(proxy)) {
+      if constexpr(ChimeraTK::Model::hasName(proxy)) {
+        nameOrAlias = proxy.getName();
       }
-      else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        // Root owns several directories
-        const auto& name = proxy.getName();
-        BOOST_CHECK(name == "Deeper" || name == "MyModule" || name == "somepath" || name == "Devices");
-      }
-      else if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
-        // Root owns the ModuleGroup
-        const auto& name = proxy.getName();
-        BOOST_CHECK(name == "Deeper/hierarchies");
-      }
-      else if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
-        const auto& name = proxy.getName();
-        BOOST_CHECK(name == "MyModule" || name == "Deeper/MyModule" || name == "/Devices/Dummy0");
-      }
-      else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
-        // Root is its own neighbouring directory
+      else if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
+        nameOrAlias = proxy.getAliasOrCdd();
       }
       else {
-        BOOST_FAIL("Wrong vertex type found");
+        nameOrAlias = "(unnamed)";
       }
-    };
-
-    app.getModel().visit(checker, ChimeraTK::Model::adjacentOutSearch);
-
-    BOOST_TEST(foundElements == 10);
-  }
-
-  // Check on MyModule application module
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariable(proxy)) {
-        // this variable is an output
-        BOOST_CHECK(proxy.getName() == "actuator");
-      }
-      else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        // The neightbouring directory
-        BOOST_CHECK(proxy.getName() == "MyModule");
-      }
-      else if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
-        // VariableGroup owned by the module
-        BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.myModule.getModel().visit(checker, ChimeraTK::Model::adjacentOutSearch);
-
-    BOOST_TEST(foundElements == 4); // actuator is found twice because of pvAccess and ownership relationships
-  }
-}
-
-/*********************************************************************************************************************/
-
-// helper class for testAdjacent
-struct Item {
-  template<typename PROXY>
-  explicit Item(PROXY proxy) : type(typeid(proxy)) {
-    if constexpr(ChimeraTK::Model::hasName(proxy)) {
-      nameOrAlias = proxy.getName();
     }
-    else if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
-      nameOrAlias = proxy.getAliasOrCdd();
+    const std::type_info& type;
+    std::string nameOrAlias;
+
+    bool operator<(const Item& rhs) const {
+      return &type < &rhs.type || (&type == &rhs.type && nameOrAlias < rhs.nameOrAlias);
     }
-    else {
-      nameOrAlias = "(unnamed)";
-    }
-  }
-  const std::type_info& type;
-  std::string nameOrAlias;
-
-  bool operator<(const Item& rhs) const {
-    return &type < &rhs.type || (&type == &rhs.type && nameOrAlias < rhs.nameOrAlias);
-  }
-};
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testAdjacent) {
-  // adjacent is the sum of adjacentIn and adjacentOut
-  TestApplication app;
-
-  // First collect information about search results of adjacentOut and adjacentIn.
-  std::set<Item> items;
-  size_t itemsToFind = 0; // count also duplicates
-  auto collector = [&](auto proxy) {
-    Item itemToInsert(proxy);
-    items.insert(itemToInsert);
-    ++itemsToFind;
   };
 
-  app.getModel().visit(collector, ChimeraTK::Model::adjacentOutSearch);
-  app.getModel().visit(collector, ChimeraTK::Model::adjacentInSearch);
+  /*********************************************************************************************************************/
 
-  // Now compare the result of the adjacent search (without implying a certain ordering)
-  size_t itemsFound = 0;
-  auto finder = [&](auto proxy) {
-    Item itemToFind(proxy);
-    // adjacent search result item must be among items previously found in either adjacentOut or adjacentIn
-    BOOST_CHECK(items.find(itemToFind) != items.end());
-    ++itemsFound;
-  };
-  app.getModel().visit(finder, ChimeraTK::Model::adjacentSearch);
-  // check that all items have been found
-  BOOST_TEST(itemsFound == itemsToFind);
-}
+  BOOST_AUTO_TEST_CASE(testAdjacent) {
+    // adjacent is the sum of adjacentIn and adjacentOut
+    TestApplication app;
 
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testDepthFirstSearch) {
-  TestApplication app;
-
-  std::vector<std::string> pvNames;
-
-  auto pvNamesFiller = [&](auto proxy) { pvNames.push_back(proxy.getFullyQualifiedPath()); };
-
-  app.getModel().visit(pvNamesFiller, ChimeraTK::Model::depthFirstSearch, ChimeraTK::Model::keepDirectories,
-      ChimeraTK::Model::keepParenthood);
-
-  BOOST_TEST(pvNames.size() == 10);
-
-  // All directories have been found
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies/need") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule/pointlessVariableGroup") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/somepath") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/MyModule") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/MyModule/pointlessVariableGroup") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Devices") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Devices/Dummy0") != pvNames.end());
-
-  // Check ordering: depth first, not breadth first
-  // Note: The ordering on a single hierarchy is not strictly defined, hence we need to make the test insensitive
-  // to allowed reordering. Hence we have two allowed cases:
-  //  1) /Deeper/hierarchies is found before /Deeper/MyModule
-  //  2) /Deeper/MyModule is found before /Deeper/hierarchies
-  // In case 1), /Deeper/hierarchies/need needs to be found before /Deeper/MyModule
-  // In case 2), /Deeper/MyModule/pointlessVariableGroup needs to be found before /Deeper/hierarchies
-  auto deeperHierarchies = std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies");
-  auto deeperHierarchiesNeed = std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies/need");
-  auto deeperMyModule = std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule");
-  auto deeperMyModulePVG = std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule/pointlessVariableGroup");
-
-  BOOST_CHECK((deeperHierarchies < deeperMyModule && deeperHierarchiesNeed < deeperMyModule) ||
-      (deeperMyModule < deeperHierarchies && deeperMyModulePVG < deeperHierarchies));
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testBreadthFirstSearch) {
-  TestApplication app;
-
-  std::vector<std::string> pvNames;
-
-  auto pvNamesFiller = [&](auto proxy) { pvNames.push_back(proxy.getFullyQualifiedPath()); };
-
-  app.getModel().visit(pvNamesFiller, ChimeraTK::Model::breadthFirstSearch, ChimeraTK::Model::keepDirectories,
-      ChimeraTK::Model::keepParenthood);
-
-  BOOST_TEST(pvNames.size() == 10);
-
-  // All directories have been found
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies/need") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule/pointlessVariableGroup") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/somepath") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/MyModule") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/MyModule/pointlessVariableGroup") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Devices") != pvNames.end());
-  BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Devices/Dummy0") != pvNames.end());
-
-  // Check ordering: breadth first, not depth first
-  auto deeperHierarchies = std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies");
-  auto deeperHierarchiesNeed = std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies/need");
-  auto deeperMyModule = std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule");
-  auto deeperMyModulePVG = std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule/pointlessVariableGroup");
-
-  BOOST_CHECK(deeperHierarchies < deeperHierarchiesNeed);
-  BOOST_CHECK(deeperMyModule < deeperHierarchiesNeed);
-  BOOST_CHECK(deeperHierarchies < deeperMyModulePVG);
-  BOOST_CHECK(deeperMyModule < deeperMyModulePVG);
-}
-
-/*********************************************************************************************************************/
-/* Test edge/relationship filters */
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testKeepPvAccess) {
-  TestApplication app;
-
-  // Run check on ApplicationModule MyModule
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariable(proxy)) {
-        BOOST_CHECK(proxy.getName() == "readBack" || proxy.getName() == "actuator");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
+    // First collect information about search results of adjacentOut and adjacentIn.
+    std::set<Item> items;
+    size_t itemsToFind = 0; // count also duplicates
+    auto collector = [&](auto proxy) {
+      Item itemToInsert(proxy);
+      items.insert(itemToInsert);
+      ++itemsToFind;
     };
 
-    app.myModule.getModel().visit(checker, ChimeraTK::Model::keepPvAccess, ChimeraTK::Model::adjacentSearch);
+    app.getModel().visit(collector, ChimeraTK::Model::adjacentOutSearch);
+    app.getModel().visit(collector, ChimeraTK::Model::adjacentInSearch);
 
-    BOOST_TEST(foundElements == 2);
-  }
-
-  // Run check on the PV readBack
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
-        BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
-      }
-      else if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
-        BOOST_CHECK(proxy.getName() == "MyModule");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
+    // Now compare the result of the adjacent search (without implying a certain ordering)
+    size_t itemsFound = 0;
+    auto finder = [&](auto proxy) {
+      Item itemToFind(proxy);
+      // adjacent search result item must be among items previously found in either adjacentOut or adjacentIn
+      BOOST_CHECK(items.find(itemToFind) != items.end());
+      ++itemsFound;
     };
-
-    app.myModule.pointlessVariableGroup.readBack.getModel().visit(
-        checker, ChimeraTK::Model::keepPvAccess, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 2);
+    app.getModel().visit(finder, ChimeraTK::Model::adjacentSearch);
+    // check that all items have been found
+    BOOST_TEST(itemsFound == itemsToFind);
   }
-}
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(testKeepOwnership) {
-  TestApplication app;
+  BOOST_AUTO_TEST_CASE(testDepthFirstSearch) {
+    TestApplication app;
 
-  // Run check on ApplicationModule MyModule
-  {
+    std::vector<std::string> pvNames;
+
+    auto pvNamesFiller = [&](auto proxy) { pvNames.push_back(proxy.getFullyQualifiedPath()); };
+
+    app.getModel().visit(pvNamesFiller, ChimeraTK::Model::depthFirstSearch, ChimeraTK::Model::keepDirectories,
+        ChimeraTK::Model::keepParenthood);
+
+    BOOST_TEST(pvNames.size() == 10);
+
+    // All directories have been found
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies/need") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule/pointlessVariableGroup") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/somepath") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/MyModule") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/MyModule/pointlessVariableGroup") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Devices") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Devices/Dummy0") != pvNames.end());
+
+    // Check ordering: depth first, not breadth first
+    // Note: The ordering on a single hierarchy is not strictly defined, hence we need to make the test insensitive
+    // to allowed reordering. Hence we have two allowed cases:
+    //  1) /Deeper/hierarchies is found before /Deeper/MyModule
+    //  2) /Deeper/MyModule is found before /Deeper/hierarchies
+    // In case 1), /Deeper/hierarchies/need needs to be found before /Deeper/MyModule
+    // In case 2), /Deeper/MyModule/pointlessVariableGroup needs to be found before /Deeper/hierarchies
+    auto deeperHierarchies = std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies");
+    auto deeperHierarchiesNeed = std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies/need");
+    auto deeperMyModule = std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule");
+    auto deeperMyModulePVG = std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule/pointlessVariableGroup");
+
+    BOOST_CHECK((deeperHierarchies < deeperMyModule && deeperHierarchiesNeed < deeperMyModule) ||
+        (deeperMyModule < deeperHierarchies && deeperMyModulePVG < deeperHierarchies));
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testBreadthFirstSearch) {
+    TestApplication app;
+
+    std::vector<std::string> pvNames;
+
+    auto pvNamesFiller = [&](auto proxy) { pvNames.push_back(proxy.getFullyQualifiedPath()); };
+
+    app.getModel().visit(pvNamesFiller, ChimeraTK::Model::breadthFirstSearch, ChimeraTK::Model::keepDirectories,
+        ChimeraTK::Model::keepParenthood);
+
+    BOOST_TEST(pvNames.size() == 10);
+
+    // All directories have been found
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies/need") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule/pointlessVariableGroup") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/somepath") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/MyModule") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/MyModule/pointlessVariableGroup") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Devices") != pvNames.end());
+    BOOST_CHECK(std::find(pvNames.begin(), pvNames.end(), "/Devices/Dummy0") != pvNames.end());
+
+    // Check ordering: breadth first, not depth first
+    auto deeperHierarchies = std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies");
+    auto deeperHierarchiesNeed = std::find(pvNames.begin(), pvNames.end(), "/Deeper/hierarchies/need");
+    auto deeperMyModule = std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule");
+    auto deeperMyModulePVG = std::find(pvNames.begin(), pvNames.end(), "/Deeper/MyModule/pointlessVariableGroup");
+
+    BOOST_CHECK(deeperHierarchies < deeperHierarchiesNeed);
+    BOOST_CHECK(deeperMyModule < deeperHierarchiesNeed);
+    BOOST_CHECK(deeperHierarchies < deeperMyModulePVG);
+    BOOST_CHECK(deeperMyModule < deeperMyModulePVG);
+  }
+
+  /*********************************************************************************************************************/
+  /* Test edge/relationship filters */
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepPvAccess) {
+    TestApplication app;
+
+    // Run check on ApplicationModule MyModule
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariable(proxy)) {
+          BOOST_CHECK(proxy.getName() == "readBack" || proxy.getName() == "actuator");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.getModel().visit(checker, ChimeraTK::Model::keepPvAccess, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 2);
+    }
+
+    // Run check on the PV readBack
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
+          BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
+        }
+        else if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
+          BOOST_CHECK(proxy.getName() == "MyModule");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.pointlessVariableGroup.readBack.getModel().visit(
+          checker, ChimeraTK::Model::keepPvAccess, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 2);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepOwnership) {
+    TestApplication app;
+
+    // Run check on ApplicationModule MyModule
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariable(proxy)) {
+          BOOST_CHECK(proxy.getName() == "actuator");
+        }
+        else if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
+        }
+        else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.getModel().visit(checker, ChimeraTK::Model::keepOwnership, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 3);
+    }
+
+    // Run check on the PV readBack
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
+        }
+        else if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
+          BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.pointlessVariableGroup.readBack.getModel().visit(
+          checker, ChimeraTK::Model::keepOwnership, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 2);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepParenthood) {
+    TestApplication app;
+
+    // Run check on directory MyModule
+    {
+      // get the directory. this relies on some other features...
+      auto dir =
+          app.myModule.getModel().visit(ChimeraTK::Model::returnDirectory, ChimeraTK::Model::getNeighbourDirectory,
+              ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::DirectoryProxy{}));
+      assert(dir.isValid());
+
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariable(proxy)) {
+          BOOST_CHECK(proxy.getName() == "actuator" || proxy.getName() == "readBack");
+        }
+        else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
+        }
+        else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      dir.visit(checker, ChimeraTK::Model::keepParenthood, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 4);
+    }
+
+    // Run check on the PV readBack
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          BOOST_CHECK(proxy.getName() == "MyModule");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.pointlessVariableGroup.readBack.getModel().visit(
+          checker, ChimeraTK::Model::keepParenthood, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 1);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepNeighbourhood) {
+    TestApplication app;
+
+    // Run check on ApplicationModule MyModule
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          BOOST_CHECK(proxy.getName() == "MyModule");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.getModel().visit(checker, ChimeraTK::Model::keepNeighbourhood, ChimeraTK::Model::adjacentOutSearch);
+
+      BOOST_TEST(foundElements == 1);
+    }
+
+    // Run check on the directory /Deeper/hierarchies
+    {
+      // get the directory. this relies on some other features...
+      ChimeraTK::Model::DirectoryProxy dir;
+      [[maybe_unused]] auto found = app.getModel().visitByPath("/Deeper/hierarchies", [&](auto proxy) {
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          dir = proxy;
+        }
+      });
+      assert(found);
+
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
+        }
+        else if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
+          BOOST_CHECK(proxy.getName() == ".");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      dir.visit(checker, ChimeraTK::Model::keepNeighbourhood, ChimeraTK::Model::adjacentInSearch);
+
+      BOOST_TEST(foundElements == 2);
+    }
+  }
+
+  /*********************************************************************************************************************/
+  /* Test vertex/object type filters */
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepModuleGroups) {
+    TestApplication app;
+
+    // Run check on root
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.getModel().visit(checker, ChimeraTK::Model::keepModuleGroups, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 1);
+    }
+
+    // Run check on the application module "."
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.testModule.getModel().visit(
+          checker, ChimeraTK::Model::keepModuleGroups, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 1);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepApplicationModules) {
+    TestApplication app;
+
+    // Run check on module group Deeper/hierarchies
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
+          BOOST_CHECK(proxy.getName() == ".");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.getModel().visit(
+          checker, ChimeraTK::Model::keepApplicationModules, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 1);
+    }
+
+    // Run check on PV "also"
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
+          BOOST_CHECK(proxy.getName() == ".");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.testModule.also.getModel().visit(
+          checker, ChimeraTK::Model::keepApplicationModules, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements ==
+          2); // The element is found twice because there is an ownership relation and a PV access relation
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepVariableGroups) {
+    TestApplication app;
+
+    // Run check on application module MyModule
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.getModel().visit(checker, ChimeraTK::Model::keepVariableGroups, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 1);
+    }
+
+    // Run check on PV "tests"
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "need");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.testModule.need.tests.getModel().visit(
+          checker, ChimeraTK::Model::keepVariableGroups, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 1);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepDeviceModules) {
+    TestApplication app;
+
+    // Run check on root
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
+          BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.getModel().visit(checker, ChimeraTK::Model::keepDeviceModules, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 2); // found twice because ownership and neighbourhood relation
+    }
+
+    // Run check on PV "tests"
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
+          BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.testModule.need.tests.getModel().visit(
+          checker, ChimeraTK::Model::keepDeviceModules, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 2); // found twice because ownership and pv acces relation
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepProcessVariables) {
+    TestApplication app;
+
+    // Run check on application module MyModule
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariable(proxy)) {
+          BOOST_CHECK(proxy.getName() == "readBack" || proxy.getName() == "actuator");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.getModel().visit(checker, ChimeraTK::Model::keepProcessVariables, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 3); // actuator is found twice due to pvAccess and ownership relation
+    }
+
+    // Run check on the directory /Deeper/hierarchies
+    {
+      // get the directory. this relies on some other features...
+      ChimeraTK::Model::DirectoryProxy dir;
+      [[maybe_unused]] auto found = app.getModel().visitByPath("/Deeper/hierarchies", [&](auto proxy) {
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          dir = proxy;
+        }
+      });
+      assert(found);
+
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariable(proxy)) {
+          BOOST_CHECK(proxy.getName() == "also");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      dir.visit(checker, ChimeraTK::Model::keepProcessVariables, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 1);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepDirectories) {
+    TestApplication app;
+
+    // Run check on application module MyModule
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          BOOST_CHECK(proxy.getName() == "MyModule");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.myModule.getModel().visit(checker, ChimeraTK::Model::keepDirectories, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 1);
+    }
+
+    // Run check on the directory /Deeper/hierarchies
+    {
+      // get the directory. this relies on some other features...
+      ChimeraTK::Model::DirectoryProxy dir;
+      [[maybe_unused]] auto found = app.getModel().visitByPath("/Deeper/hierarchies", [&](auto proxy) {
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          dir = proxy;
+        }
+      });
+      assert(found);
+
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          BOOST_CHECK(proxy.getName() == "Deeper" || proxy.getName() == "need");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      dir.visit(checker, ChimeraTK::Model::keepDirectories, ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 2);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepName) {
+    TestApplication app;
+
+    // Run check on application root
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          BOOST_CHECK(proxy.getName() == "MyModule");
+        }
+        else if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
+          BOOST_CHECK(proxy.getName() == "MyModule");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.getModel().visit(checker, ChimeraTK::Model::keepName("MyModule"), ChimeraTK::Model::adjacentSearch);
+
+      BOOST_TEST(foundElements == 2);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testKeepTag) {
+    TestApplication app;
+
+    // Search for tag A
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        BOOST_CHECK(proxy.getFullyQualifiedPath() == "/Deeper/hierarchies/also" ||
+            proxy.getFullyQualifiedPath() == "/Deeper/hierarchies/need/tests");
+      };
+
+      app.getModel().visit(checker, ChimeraTK::Model::keepTag("A"), ChimeraTK::Model::depthFirstSearch,
+          ChimeraTK::Model::keepProcessVariables);
+
+      BOOST_TEST(foundElements == 2);
+    }
+
+    // Search for tag B
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        BOOST_CHECK(proxy.getFullyQualifiedPath() == "/MyModule/actuator" ||
+            proxy.getFullyQualifiedPath() == "/Deeper/MyModule/actuator" ||
+            proxy.getFullyQualifiedPath() == "/Deeper/hierarchies/need/tests");
+      };
+
+      app.getModel().visit(checker, ChimeraTK::Model::keepTag("B"), ChimeraTK::Model::depthFirstSearch,
+          ChimeraTK::Model::keepProcessVariables);
+
+      BOOST_TEST(foundElements == 3);
+    }
+  }
+
+  /*********************************************************************************************************************/
+  /* Test search options */
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testReturnFirstHit) {
+    TestApplication app;
+    std::string alias;
+
+    // Check returning a string
+    auto returnAlias = [&](auto proxy) -> std::string { return proxy.getAliasOrCdd(); };
+    alias = app.getModel().visit(returnAlias, ChimeraTK::Model::depthFirstSearch, ChimeraTK::Model::keepDeviceModules,
+        ChimeraTK::Model::returnFirstHit(std::string{}));
+    BOOST_TEST(alias == "Dummy0");
+
+    // Check returning nothing (void)
+    alias = "";
+    auto setAlias = [&](auto proxy) -> void { alias = proxy.getAliasOrCdd(); };
+    app.getModel().visit(setAlias, ChimeraTK::Model::depthFirstSearch, ChimeraTK::Model::keepDeviceModules,
+        ChimeraTK::Model::returnFirstHit());
+    BOOST_TEST(alias == "Dummy0");
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testContinueSearchDisjunctTrees) {
+    TestApplication app;
+
+    size_t hits{0};
+    auto countHits = [&](auto) { ++hits; };
+    app.getModel().visit(countHits, ChimeraTK::Model::depthFirstSearch, ChimeraTK::Model::keepPvAccess,
+        ChimeraTK::Model::keepProcessVariables);
+
+    // first make sure nothing is found when doing a DFS without continueSearchDisjunctTrees from root with the
+    // keepPvAccess
+    BOOST_TEST(hits == 0);
+
+    // same test again with continueSearchDisjunctTrees should now find something as the search is continued in the
+    // disjuct parts
+    app.getModel().visit(countHits, ChimeraTK::Model::depthFirstSearch, ChimeraTK::Model::keepPvAccess,
+        ChimeraTK::Model::keepProcessVariables, ChimeraTK::Model::continueSearchDisjunctTrees);
+    BOOST_TEST(hits == 10);
+  }
+
+  /*********************************************************************************************************************/
+  /* Test OrSet and AndSet of filters */
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testOrSetVertexFilter) {
+    TestApplication app;
+
     size_t foundElements = 0;
 
     auto checker = [&](auto proxy) {
       ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariable(proxy)) {
-        BOOST_CHECK(proxy.getName() == "actuator");
-      }
-      else if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
-      }
-      else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.myModule.getModel().visit(checker, ChimeraTK::Model::keepOwnership, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 3);
-  }
-
-  // Run check on the PV readBack
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
+      if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
+        BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
       }
       else if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
         BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
@@ -746,34 +1289,125 @@ BOOST_AUTO_TEST_CASE(testKeepOwnership) {
       }
     };
 
-    app.myModule.pointlessVariableGroup.readBack.getModel().visit(
-        checker, ChimeraTK::Model::keepOwnership, ChimeraTK::Model::adjacentSearch);
+    app.getModel().visit(checker, ChimeraTK::Model::keepModuleGroups || ChimeraTK::Model::keepDeviceModules,
+        ChimeraTK::Model::adjacentSearch);
 
-    BOOST_TEST(foundElements == 2);
+    BOOST_TEST(foundElements == 3); // the DeviceModule is found twice (ownership + neighbourhood)
   }
-}
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(testKeepParenthood) {
-  TestApplication app;
-
-  // Run check on directory MyModule
-  {
-    // get the directory. this relies on some other features...
-    auto dir = app.myModule.getModel().visit(ChimeraTK::Model::returnDirectory, ChimeraTK::Model::getNeighbourDirectory,
-        ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::DirectoryProxy{}));
-    assert(dir.isValid());
+  BOOST_AUTO_TEST_CASE(testAndSetVertexFilter) {
+    TestApplication app;
 
     size_t foundElements = 0;
 
     auto checker = [&](auto proxy) {
       ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariable(proxy)) {
-        BOOST_CHECK(proxy.getName() == "actuator" || proxy.getName() == "readBack");
+      if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
+        BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
+      }
+      else {
+        BOOST_FAIL("Wrong vertex type found");
+      }
+    };
+
+    app.getModel().visit(checker,
+        ChimeraTK::Model::keepModuleGroups && ChimeraTK::Model::keepName("Deeper/hierarchies"),
+        ChimeraTK::Model::adjacentSearch);
+
+    BOOST_TEST(foundElements == 1);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testAndSetInOrSetVertexFilter) {
+    TestApplication app;
+
+    size_t foundElements = 0;
+
+    auto checker = [&](auto proxy) {
+      ++foundElements;
+      if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
+        BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
+      }
+      else if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
+        BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
+      }
+      else {
+        BOOST_FAIL("Wrong vertex type found");
+      }
+    };
+
+    app.getModel().visit(checker,
+        (ChimeraTK::Model::keepModuleGroups && ChimeraTK::Model::keepName("Deeper/hierarchies")) ||
+            ChimeraTK::Model::keepDeviceModules,
+        ChimeraTK::Model::adjacentOutSearch);
+
+    BOOST_TEST(foundElements == 2);
+
+    foundElements = 0;
+
+    app.getModel().visit(checker,
+        ChimeraTK::Model::keepDeviceModules ||
+            (ChimeraTK::Model::keepModuleGroups && ChimeraTK::Model::keepName("Deeper/hierarchies")),
+        ChimeraTK::Model::adjacentOutSearch);
+
+    BOOST_TEST(foundElements == 2);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testOrSetInAndSetVertexFilter) {
+    TestApplication app;
+
+    size_t foundElements = 0;
+
+    auto checker = [&](auto proxy) {
+      ++foundElements;
+      if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
+        BOOST_CHECK(proxy.getName() == "MyModule");
       }
       else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
+        BOOST_CHECK(proxy.getName() == "MyModule");
+      }
+      else {
+        BOOST_FAIL("Wrong vertex type found");
+      }
+    };
+
+    app.getModel().visit(checker,
+        (ChimeraTK::Model::keepApplicationModules || ChimeraTK::Model::keepDirectories) &&
+            ChimeraTK::Model::keepName("MyModule"),
+        ChimeraTK::Model::adjacentOutSearch);
+
+    BOOST_TEST(foundElements == 2);
+
+    foundElements = 0;
+
+    app.getModel().visit(checker,
+        ChimeraTK::Model::keepName("MyModule") &&
+            (ChimeraTK::Model::keepApplicationModules || ChimeraTK::Model::keepDirectories),
+        ChimeraTK::Model::adjacentOutSearch);
+
+    BOOST_TEST(foundElements == 2);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testOrSetEdgeFilter) {
+    TestApplication app;
+
+    size_t foundElements = 0;
+
+    auto checker = [&](auto proxy) {
+      ++foundElements;
+      if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
+        BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
+      }
+      else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+        BOOST_CHECK(proxy.getName() == "Deeper" || proxy.getName() == "MyModule" || proxy.getName() == "somepath" ||
+            proxy.getName() == "Devices");
       }
       else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
       }
@@ -782,1068 +1416,442 @@ BOOST_AUTO_TEST_CASE(testKeepParenthood) {
       }
     };
 
-    dir.visit(checker, ChimeraTK::Model::keepParenthood, ChimeraTK::Model::adjacentSearch);
+    app.getModel().visit(checker, ChimeraTK::Model::keepNeighbourhood || ChimeraTK::Model::keepParenthood,
+        ChimeraTK::Model::adjacentSearch);
 
-    BOOST_TEST(foundElements == 4);
+    BOOST_TEST(foundElements == 7); // ROOT is found twice: incoming and outgoing neighbourhood to itself
   }
 
-  // Run check on the PV readBack
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        BOOST_CHECK(proxy.getName() == "MyModule");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.myModule.pointlessVariableGroup.readBack.getModel().visit(
-        checker, ChimeraTK::Model::keepParenthood, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testKeepNeighbourhood) {
-  TestApplication app;
-
-  // Run check on ApplicationModule MyModule
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        BOOST_CHECK(proxy.getName() == "MyModule");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.myModule.getModel().visit(checker, ChimeraTK::Model::keepNeighbourhood, ChimeraTK::Model::adjacentOutSearch);
-
-    BOOST_TEST(foundElements == 1);
-  }
-
-  // Run check on the directory /Deeper/hierarchies
-  {
-    // get the directory. this relies on some other features...
-    ChimeraTK::Model::DirectoryProxy dir;
-    [[maybe_unused]] auto found = app.getModel().visitByPath("/Deeper/hierarchies", [&](auto proxy) {
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        dir = proxy;
-      }
-    });
-    assert(found);
-
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
-      }
-      else if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
-        BOOST_CHECK(proxy.getName() == ".");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    dir.visit(checker, ChimeraTK::Model::keepNeighbourhood, ChimeraTK::Model::adjacentInSearch);
-
-    BOOST_TEST(foundElements == 2);
-  }
-}
-
-/*********************************************************************************************************************/
-/* Test vertex/object type filters */
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testKeepModuleGroups) {
-  TestApplication app;
-
-  // Run check on root
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.getModel().visit(checker, ChimeraTK::Model::keepModuleGroups, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 1);
-  }
-
-  // Run check on the application module "."
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.testModule.getModel().visit(
-        checker, ChimeraTK::Model::keepModuleGroups, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testKeepApplicationModules) {
-  TestApplication app;
-
-  // Run check on module group Deeper/hierarchies
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
-        BOOST_CHECK(proxy.getName() == ".");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.getModel().visit(
-        checker, ChimeraTK::Model::keepApplicationModules, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 1);
-  }
-
-  // Run check on PV "also"
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
-        BOOST_CHECK(proxy.getName() == ".");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.testModule.also.getModel().visit(
-        checker, ChimeraTK::Model::keepApplicationModules, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements ==
-        2); // The element is found twice because there is an ownership relation and a PV access relation
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testKeepVariableGroups) {
-  TestApplication app;
-
-  // Run check on application module MyModule
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.myModule.getModel().visit(checker, ChimeraTK::Model::keepVariableGroups, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 1);
-  }
-
-  // Run check on PV "tests"
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "need");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.testModule.need.tests.getModel().visit(
-        checker, ChimeraTK::Model::keepVariableGroups, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testKeepDeviceModules) {
-  TestApplication app;
-
-  // Run check on root
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
-        BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.getModel().visit(checker, ChimeraTK::Model::keepDeviceModules, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 2); // found twice because ownership and neighbourhood relation
-  }
-
-  // Run check on PV "tests"
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
-        BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.testModule.need.tests.getModel().visit(
-        checker, ChimeraTK::Model::keepDeviceModules, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 2); // found twice because ownership and pv acces relation
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testKeepProcessVariables) {
-  TestApplication app;
-
-  // Run check on application module MyModule
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariable(proxy)) {
-        BOOST_CHECK(proxy.getName() == "readBack" || proxy.getName() == "actuator");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.myModule.getModel().visit(checker, ChimeraTK::Model::keepProcessVariables, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 3); // actuator is found twice due to pvAccess and ownership relation
-  }
-
-  // Run check on the directory /Deeper/hierarchies
-  {
-    // get the directory. this relies on some other features...
-    ChimeraTK::Model::DirectoryProxy dir;
-    [[maybe_unused]] auto found = app.getModel().visitByPath("/Deeper/hierarchies", [&](auto proxy) {
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        dir = proxy;
-      }
-    });
-    assert(found);
-
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariable(proxy)) {
-        BOOST_CHECK(proxy.getName() == "also");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    dir.visit(checker, ChimeraTK::Model::keepProcessVariables, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testKeepDirectories) {
-  TestApplication app;
-
-  // Run check on application module MyModule
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        BOOST_CHECK(proxy.getName() == "MyModule");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.myModule.getModel().visit(checker, ChimeraTK::Model::keepDirectories, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 1);
-  }
-
-  // Run check on the directory /Deeper/hierarchies
-  {
-    // get the directory. this relies on some other features...
-    ChimeraTK::Model::DirectoryProxy dir;
-    [[maybe_unused]] auto found = app.getModel().visitByPath("/Deeper/hierarchies", [&](auto proxy) {
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        dir = proxy;
-      }
-    });
-    assert(found);
-
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        BOOST_CHECK(proxy.getName() == "Deeper" || proxy.getName() == "need");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    dir.visit(checker, ChimeraTK::Model::keepDirectories, ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 2);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testKeepName) {
-  TestApplication app;
-
-  // Run check on application root
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        BOOST_CHECK(proxy.getName() == "MyModule");
-      }
-      else if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
-        BOOST_CHECK(proxy.getName() == "MyModule");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.getModel().visit(checker, ChimeraTK::Model::keepName("MyModule"), ChimeraTK::Model::adjacentSearch);
-
-    BOOST_TEST(foundElements == 2);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testKeepTag) {
-  TestApplication app;
-
-  // Search for tag A
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      BOOST_CHECK(proxy.getFullyQualifiedPath() == "/Deeper/hierarchies/also" ||
-          proxy.getFullyQualifiedPath() == "/Deeper/hierarchies/need/tests");
-    };
-
-    app.getModel().visit(checker, ChimeraTK::Model::keepTag("A"), ChimeraTK::Model::depthFirstSearch,
-        ChimeraTK::Model::keepProcessVariables);
-
-    BOOST_TEST(foundElements == 2);
-  }
-
-  // Search for tag B
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      BOOST_CHECK(proxy.getFullyQualifiedPath() == "/MyModule/actuator" ||
-          proxy.getFullyQualifiedPath() == "/Deeper/MyModule/actuator" ||
-          proxy.getFullyQualifiedPath() == "/Deeper/hierarchies/need/tests");
-    };
-
-    app.getModel().visit(checker, ChimeraTK::Model::keepTag("B"), ChimeraTK::Model::depthFirstSearch,
-        ChimeraTK::Model::keepProcessVariables);
-
-    BOOST_TEST(foundElements == 3);
-  }
-}
-
-/*********************************************************************************************************************/
-/* Test search options */
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testReturnFirstHit) {
-  TestApplication app;
-  std::string alias;
-
-  // Check returning a string
-  auto returnAlias = [&](auto proxy) -> std::string { return proxy.getAliasOrCdd(); };
-  alias = app.getModel().visit(returnAlias, ChimeraTK::Model::depthFirstSearch, ChimeraTK::Model::keepDeviceModules,
-      ChimeraTK::Model::returnFirstHit(std::string{}));
-  BOOST_TEST(alias == "Dummy0");
-
-  // Check returning nothing (void)
-  alias = "";
-  auto setAlias = [&](auto proxy) -> void { alias = proxy.getAliasOrCdd(); };
-  app.getModel().visit(setAlias, ChimeraTK::Model::depthFirstSearch, ChimeraTK::Model::keepDeviceModules,
-      ChimeraTK::Model::returnFirstHit());
-  BOOST_TEST(alias == "Dummy0");
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testContinueSearchDisjunctTrees) {
-  TestApplication app;
-
-  size_t hits{0};
-  auto countHits = [&](auto) { ++hits; };
-  app.getModel().visit(countHits, ChimeraTK::Model::depthFirstSearch, ChimeraTK::Model::keepPvAccess,
-      ChimeraTK::Model::keepProcessVariables);
-
-  // first make sure nothing is found when doing a DFS without continueSearchDisjunctTrees from root with the
-  // keepPvAccess
-  BOOST_TEST(hits == 0);
-
-  // same test again with continueSearchDisjunctTrees should now find something as the search is continued in the
-  // disjuct parts
-  app.getModel().visit(countHits, ChimeraTK::Model::depthFirstSearch, ChimeraTK::Model::keepPvAccess,
-      ChimeraTK::Model::keepProcessVariables, ChimeraTK::Model::continueSearchDisjunctTrees);
-  BOOST_TEST(hits == 10);
-}
-
-/*********************************************************************************************************************/
-/* Test OrSet and AndSet of filters */
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testOrSetVertexFilter) {
-  TestApplication app;
-
-  size_t foundElements = 0;
-
-  auto checker = [&](auto proxy) {
-    ++foundElements;
-    if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
-      BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
+  // Note: AndSet for edge filters does not really make any sense, since each edge can have only one single type!
+
+  /*********************************************************************************************************************/
+  /* Test combined search configurations */
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testOwnedModuleGroups) {
+    TestApplication app;
+
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.getModel().visit(checker, ChimeraTK::Model::ownedModuleGroups);
+
+      BOOST_TEST(foundElements == 1);
     }
-    else if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
-      BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testOwnedApplicationModules) {
+    TestApplication app;
+
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
+          BOOST_CHECK(proxy.getName() == ".");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.getModel().visit(checker, ChimeraTK::Model::ownedApplicationModules);
+
+      BOOST_TEST(foundElements == 1);
     }
-    else {
-      BOOST_FAIL("Wrong vertex type found");
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testOwnedVariableGroups) {
+    TestApplication app;
+
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "need");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.testModule.getModel().visit(checker, ChimeraTK::Model::ownedVariableGroups);
+
+      BOOST_TEST(foundElements == 1);
     }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testOwnedVariables) {
+    TestApplication app;
+
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariable(proxy)) {
+          BOOST_CHECK(proxy.getName() == "also");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.testModule.getModel().visit(checker, ChimeraTK::Model::ownedVariables);
+
+      BOOST_TEST(foundElements == 1);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testChildDirectories) {
+    TestApplication app;
+
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          BOOST_CHECK(proxy.getName() == "Deeper" || proxy.getName() == "MyModule" || proxy.getName() == "somepath" ||
+              proxy.getName() == "Devices");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.getModel().visit(checker, ChimeraTK::Model::childDirectories);
+
+      BOOST_TEST(foundElements == 4);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testChildVariables) {
+    TestApplication app;
+
+    {
+      // get the directory. this relies on some other features...
+      ChimeraTK::Model::DirectoryProxy dir;
+      [[maybe_unused]] auto found = app.getModel().visitByPath("/MyModule", [&](auto proxy) {
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          dir = proxy;
+        }
+      });
+      assert(found);
+
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariable(proxy)) {
+          BOOST_CHECK(proxy.getName() == "readBack" || proxy.getName() == "actuator");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      dir.visit(checker, ChimeraTK::Model::childVariables);
+
+      BOOST_TEST(foundElements == 2);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testChildren) {
+    TestApplication app;
+
+    {
+      // get the directory. this relies on some other features...
+      ChimeraTK::Model::DirectoryProxy dir;
+      [[maybe_unused]] auto found = app.getModel().visitByPath("/MyModule", [&](auto proxy) {
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          dir = proxy;
+        }
+      });
+      assert(found);
+
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isVariable(proxy)) {
+          BOOST_CHECK(proxy.getName() == "readBack" || proxy.getName() == "actuator");
+        }
+        else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      dir.visit(checker, ChimeraTK::Model::children);
+
+      BOOST_TEST(foundElements == 3);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testGetOwner) {
+    TestApplication app;
+
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.testModule.getModel().visit(checker, ChimeraTK::Model::getOwner);
+
+      BOOST_TEST(foundElements == 1);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testGetParent) {
+    TestApplication app;
+
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          BOOST_CHECK(proxy.getName() == "need");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.testModule.need.tests.getModel().visit(checker, ChimeraTK::Model::getParent);
+
+      BOOST_TEST(foundElements == 1);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testGetNeighbourDirectory) {
+    TestApplication app;
+
+    {
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          BOOST_CHECK(proxy.getName() == "hierarchies");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      app.deeperHierarchies.testModule.getModel().visit(checker, ChimeraTK::Model::getNeighbourDirectory);
+
+      BOOST_TEST(foundElements == 1);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testNeighbourModules) {
+    TestApplication app;
+
+    {
+      // get the directory. this relies on some other features...
+      ChimeraTK::Model::DirectoryProxy dir;
+      [[maybe_unused]] auto found = app.getModel().visitByPath("/Deeper/hierarchies", [&](auto proxy) {
+        if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
+          dir = proxy;
+        }
+      });
+      assert(found);
+
+      size_t foundElements = 0;
+
+      auto checker = [&](auto proxy) {
+        ++foundElements;
+        if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
+          BOOST_CHECK(proxy.getName() == ".");
+        }
+        else if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
+          BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
+        }
+        else {
+          BOOST_FAIL("Wrong vertex type found");
+        }
+      };
+
+      dir.visit(checker, ChimeraTK::Model::neighbourModules);
+
+      BOOST_TEST(foundElements == 2);
+    }
+  }
+
+  /*********************************************************************************************************************/
+  /* Test pre-defined visitor functors */
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testReturnModuleGroup) {
+    TestApplication app;
+
+    {
+      ChimeraTK::Model::ModuleGroupProxy rv =
+          app.deeperHierarchies.testModule.getModel().visit(ChimeraTK::Model::returnModuleGroup,
+              ChimeraTK::Model::getOwner, ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::ModuleGroupProxy{}));
+
+      BOOST_TEST(rv.isValid());
+      BOOST_TEST(rv.getName() == "Deeper/hierarchies");
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testReturnApplicationModule) {
+    TestApplication app;
+
+    {
+      ChimeraTK::Model::ApplicationModuleProxy rv =
+          app.deeperHierarchies.testModule.need.getModel().visit(ChimeraTK::Model::returnApplicationModule,
+              ChimeraTK::Model::getOwner, ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::ApplicationModuleProxy{}));
+
+      BOOST_TEST(rv.isValid());
+      BOOST_TEST(rv.getName() == ".");
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testReturnVariableGroup) {
+    TestApplication app;
+
+    {
+      ChimeraTK::Model::VariableGroupProxy rv =
+          app.myModule2.pointlessVariableGroup.readBack.getModel().visit(ChimeraTK::Model::returnVariableGroup,
+              ChimeraTK::Model::getOwner, ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::VariableGroupProxy{}));
+
+      BOOST_TEST(rv.isValid());
+      BOOST_TEST(rv.getName() == "pointlessVariableGroup");
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testReturnProcessVariable) {
+    TestApplication app;
+
+    {
+      ChimeraTK::Model::ProcessVariableProxy rv = app.deeperHierarchies.testModule.need.getModel().visit(
+          ChimeraTK::Model::returnProcessVariable, ChimeraTK::Model::ownedVariables,
+          ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::ProcessVariableProxy{}));
+
+      BOOST_TEST(rv.isValid());
+      BOOST_TEST(rv.getName() == "tests");
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testReturnDirectory) {
+    TestApplication app;
+
+    {
+      ChimeraTK::Model::DirectoryProxy rv = app.deeperHierarchies.testModule.need.getModel().visit(
+          ChimeraTK::Model::returnDirectory, ChimeraTK::Model::getNeighbourDirectory,
+          ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::DirectoryProxy{}));
+
+      BOOST_TEST(rv.isValid());
+      BOOST_TEST(rv.getName() == "need");
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testIllegalNames) {
+    TestApplication app;
+
+    constexpr std::string_view illegalCharsToTest = "-~!@#$%^&*()-=+{}|[]\\;':\",.<>?` ";
+
+    for(auto c : illegalCharsToTest) {
+      std::string nameToTest = "MyModule" + std::string(1, c) + "withIllegalChar";
+      BOOST_CHECK_THROW(
+          (app.myModule = MyModule(&app, nameToTest, "ApplicationModule directly owned by app")), ctk::logic_error);
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  struct RogueModule : ctk::ApplicationModule {
+    ctk::ScalarPushInput<int> var{this, "trigger", "", ""};
+
+    // This module has a push input and creates a temporary input in its constructor with the same name
+    // The second one is never used and thrown away immediately. This is the smallest possible reproduction
+    // for redmine issue 11105
+    RogueModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
+        const std::unordered_set<std::string>& tags = {})
+    : ctk::ApplicationModule(owner, name, description, tags) {
+      auto v = ctk::ScalarPushInput<int>{this, "trigger", "", ""};
+    }
+
+    void mainLoop() override {}
   };
 
-  app.getModel().visit(checker, ChimeraTK::Model::keepModuleGroups || ChimeraTK::Model::keepDeviceModules,
-      ChimeraTK::Model::adjacentSearch);
+  struct TestApplication2 : ctk::Application {
+    TestApplication2() : Application("testSuite") {}
+    ctk::SetDMapFilePath dmap{"test.dmap"};
 
-  BOOST_TEST(foundElements == 3); // the DeviceModule is found twice (ownership + neighbourhood)
-}
+    ~TestApplication2() override { shutdown(); }
 
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testAndSetVertexFilter) {
-  TestApplication app;
-
-  size_t foundElements = 0;
-
-  auto checker = [&](auto proxy) {
-    ++foundElements;
-    if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
-      BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
-    }
-    else {
-      BOOST_FAIL("Wrong vertex type found");
-    }
+    RogueModule myModule{this, "MyModule", "ApplicationModule directly owned by app"};
   };
 
-  app.getModel().visit(checker, ChimeraTK::Model::keepModuleGroups && ChimeraTK::Model::keepName("Deeper/hierarchies"),
-      ChimeraTK::Model::adjacentSearch);
-
-  BOOST_TEST(foundElements == 1);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testAndSetInOrSetVertexFilter) {
-  TestApplication app;
-
-  size_t foundElements = 0;
-
-  auto checker = [&](auto proxy) {
-    ++foundElements;
-    if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
-      BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
-    }
-    else if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
-      BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
-    }
-    else {
-      BOOST_FAIL("Wrong vertex type found");
-    }
-  };
-
-  app.getModel().visit(checker,
-      (ChimeraTK::Model::keepModuleGroups && ChimeraTK::Model::keepName("Deeper/hierarchies")) ||
-          ChimeraTK::Model::keepDeviceModules,
-      ChimeraTK::Model::adjacentOutSearch);
-
-  BOOST_TEST(foundElements == 2);
-
-  foundElements = 0;
-
-  app.getModel().visit(checker,
-      ChimeraTK::Model::keepDeviceModules ||
-          (ChimeraTK::Model::keepModuleGroups && ChimeraTK::Model::keepName("Deeper/hierarchies")),
-      ChimeraTK::Model::adjacentOutSearch);
-
-  BOOST_TEST(foundElements == 2);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testOrSetInAndSetVertexFilter) {
-  TestApplication app;
-
-  size_t foundElements = 0;
-
-  auto checker = [&](auto proxy) {
-    ++foundElements;
-    if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
-      BOOST_CHECK(proxy.getName() == "MyModule");
-    }
-    else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-      BOOST_CHECK(proxy.getName() == "MyModule");
-    }
-    else {
-      BOOST_FAIL("Wrong vertex type found");
-    }
-  };
-
-  app.getModel().visit(checker,
-      (ChimeraTK::Model::keepApplicationModules || ChimeraTK::Model::keepDirectories) &&
-          ChimeraTK::Model::keepName("MyModule"),
-      ChimeraTK::Model::adjacentOutSearch);
-
-  BOOST_TEST(foundElements == 2);
-
-  foundElements = 0;
-
-  app.getModel().visit(checker,
-      ChimeraTK::Model::keepName("MyModule") &&
-          (ChimeraTK::Model::keepApplicationModules || ChimeraTK::Model::keepDirectories),
-      ChimeraTK::Model::adjacentOutSearch);
-
-  BOOST_TEST(foundElements == 2);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testOrSetEdgeFilter) {
-  TestApplication app;
-
-  size_t foundElements = 0;
-
-  auto checker = [&](auto proxy) {
-    ++foundElements;
-    if constexpr(ChimeraTK::Model::isDeviceModule(proxy)) {
-      BOOST_CHECK(proxy.getAliasOrCdd() == "Dummy0");
-    }
-    else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-      BOOST_CHECK(proxy.getName() == "Deeper" || proxy.getName() == "MyModule" || proxy.getName() == "somepath" ||
-          proxy.getName() == "Devices");
-    }
-    else if constexpr(ChimeraTK::Model::isRoot(proxy)) {
-    }
-    else {
-      BOOST_FAIL("Wrong vertex type found");
-    }
-  };
-
-  app.getModel().visit(checker, ChimeraTK::Model::keepNeighbourhood || ChimeraTK::Model::keepParenthood,
-      ChimeraTK::Model::adjacentSearch);
-
-  BOOST_TEST(foundElements == 7); // ROOT is found twice: incoming and outgoing neighbourhood to itself
-}
-
-// Note: AndSet for edge filters does not really make any sense, since each edge can have only one single type!
-
-/*********************************************************************************************************************/
-/* Test combined search configurations */
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testOwnedModuleGroups) {
-  TestApplication app;
-
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.getModel().visit(checker, ChimeraTK::Model::ownedModuleGroups);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testOwnedApplicationModules) {
-  TestApplication app;
-
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
-        BOOST_CHECK(proxy.getName() == ".");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.getModel().visit(checker, ChimeraTK::Model::ownedApplicationModules);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testOwnedVariableGroups) {
-  TestApplication app;
-
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariableGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "need");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.testModule.getModel().visit(checker, ChimeraTK::Model::ownedVariableGroups);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testOwnedVariables) {
-  TestApplication app;
-
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariable(proxy)) {
-        BOOST_CHECK(proxy.getName() == "also");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.testModule.getModel().visit(checker, ChimeraTK::Model::ownedVariables);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testChildDirectories) {
-  TestApplication app;
-
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        BOOST_CHECK(proxy.getName() == "Deeper" || proxy.getName() == "MyModule" || proxy.getName() == "somepath" ||
-            proxy.getName() == "Devices");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.getModel().visit(checker, ChimeraTK::Model::childDirectories);
-
-    BOOST_TEST(foundElements == 4);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testChildVariables) {
-  TestApplication app;
-
-  {
-    // get the directory. this relies on some other features...
-    ChimeraTK::Model::DirectoryProxy dir;
-    [[maybe_unused]] auto found = app.getModel().visitByPath("/MyModule", [&](auto proxy) {
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        dir = proxy;
-      }
-    });
-    assert(found);
-
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariable(proxy)) {
-        BOOST_CHECK(proxy.getName() == "readBack" || proxy.getName() == "actuator");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    dir.visit(checker, ChimeraTK::Model::childVariables);
-
-    BOOST_TEST(foundElements == 2);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testChildren) {
-  TestApplication app;
-
-  {
-    // get the directory. this relies on some other features...
-    ChimeraTK::Model::DirectoryProxy dir;
-    [[maybe_unused]] auto found = app.getModel().visitByPath("/MyModule", [&](auto proxy) {
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        dir = proxy;
-      }
-    });
-    assert(found);
-
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isVariable(proxy)) {
-        BOOST_CHECK(proxy.getName() == "readBack" || proxy.getName() == "actuator");
-      }
-      else if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        BOOST_CHECK(proxy.getName() == "pointlessVariableGroup");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    dir.visit(checker, ChimeraTK::Model::children);
-
-    BOOST_TEST(foundElements == 3);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testGetOwner) {
-  TestApplication app;
-
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.testModule.getModel().visit(checker, ChimeraTK::Model::getOwner);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testGetParent) {
-  TestApplication app;
-
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        BOOST_CHECK(proxy.getName() == "need");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.testModule.need.tests.getModel().visit(checker, ChimeraTK::Model::getParent);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testGetNeighbourDirectory) {
-  TestApplication app;
-
-  {
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        BOOST_CHECK(proxy.getName() == "hierarchies");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    app.deeperHierarchies.testModule.getModel().visit(checker, ChimeraTK::Model::getNeighbourDirectory);
-
-    BOOST_TEST(foundElements == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testNeighbourModules) {
-  TestApplication app;
-
-  {
-    // get the directory. this relies on some other features...
-    ChimeraTK::Model::DirectoryProxy dir;
-    [[maybe_unused]] auto found = app.getModel().visitByPath("/Deeper/hierarchies", [&](auto proxy) {
-      if constexpr(ChimeraTK::Model::isDirectory(proxy)) {
-        dir = proxy;
-      }
-    });
-    assert(found);
-
-    size_t foundElements = 0;
-
-    auto checker = [&](auto proxy) {
-      ++foundElements;
-      if constexpr(ChimeraTK::Model::isApplicationModule(proxy)) {
-        BOOST_CHECK(proxy.getName() == ".");
-      }
-      else if constexpr(ChimeraTK::Model::isModuleGroup(proxy)) {
-        BOOST_CHECK(proxy.getName() == "Deeper/hierarchies");
-      }
-      else {
-        BOOST_FAIL("Wrong vertex type found");
-      }
-    };
-
-    dir.visit(checker, ChimeraTK::Model::neighbourModules);
-
-    BOOST_TEST(foundElements == 2);
-  }
-}
-
-/*********************************************************************************************************************/
-/* Test pre-defined visitor functors */
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testReturnModuleGroup) {
-  TestApplication app;
-
-  {
-    ChimeraTK::Model::ModuleGroupProxy rv =
-        app.deeperHierarchies.testModule.getModel().visit(ChimeraTK::Model::returnModuleGroup,
-            ChimeraTK::Model::getOwner, ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::ModuleGroupProxy{}));
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testMassCreationOfUnusedAcecssors) {
+    TestApplication2 app;
+    ChimeraTK::Model::ProcessVariableProxy rv = app.myModule.getModel().visit(ChimeraTK::Model::returnProcessVariable,
+        ChimeraTK::Model::ownedVariables, ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::ProcessVariableProxy{}));
 
     BOOST_TEST(rv.isValid());
-    BOOST_TEST(rv.getName() == "Deeper/hierarchies");
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testReturnApplicationModule) {
-  TestApplication app;
-
-  {
-    ChimeraTK::Model::ApplicationModuleProxy rv =
-        app.deeperHierarchies.testModule.need.getModel().visit(ChimeraTK::Model::returnApplicationModule,
-            ChimeraTK::Model::getOwner, ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::ApplicationModuleProxy{}));
-
-    BOOST_TEST(rv.isValid());
-    BOOST_TEST(rv.getName() == ".");
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testReturnVariableGroup) {
-  TestApplication app;
-
-  {
-    ChimeraTK::Model::VariableGroupProxy rv =
-        app.myModule2.pointlessVariableGroup.readBack.getModel().visit(ChimeraTK::Model::returnVariableGroup,
-            ChimeraTK::Model::getOwner, ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::VariableGroupProxy{}));
-
-    BOOST_TEST(rv.isValid());
-    BOOST_TEST(rv.getName() == "pointlessVariableGroup");
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testReturnProcessVariable) {
-  TestApplication app;
-
-  {
-    ChimeraTK::Model::ProcessVariableProxy rv = app.deeperHierarchies.testModule.need.getModel().visit(
-        ChimeraTK::Model::returnProcessVariable, ChimeraTK::Model::ownedVariables,
-        ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::ProcessVariableProxy{}));
-
-    BOOST_TEST(rv.isValid());
-    BOOST_TEST(rv.getName() == "tests");
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testReturnDirectory) {
-  TestApplication app;
-
-  {
-    ChimeraTK::Model::DirectoryProxy rv = app.deeperHierarchies.testModule.need.getModel().visit(
-        ChimeraTK::Model::returnDirectory, ChimeraTK::Model::getNeighbourDirectory,
-        ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::DirectoryProxy{}));
-
-    BOOST_TEST(rv.isValid());
-    BOOST_TEST(rv.getName() == "need");
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testIllegalNames) {
-  TestApplication app;
-
-  constexpr std::string_view illegalCharsToTest = "-~!@#$%^&*()-=+{}|[]\\;':\",.<>?` ";
-
-  for(auto c : illegalCharsToTest) {
-    std::string nameToTest = "MyModule" + std::string(1, c) + "withIllegalChar";
-    BOOST_CHECK_THROW(
-        (app.myModule = MyModule(&app, nameToTest, "ApplicationModule directly owned by app")), ctk::logic_error);
-  }
-}
-
-/*********************************************************************************************************************/
-
-struct RogueModule : ctk::ApplicationModule {
-  ctk::ScalarPushInput<int> var{this, "trigger", "", ""};
-
-  // This module has a push input and creates a temporary input in its constructor with the same name
-  // The second one is never used and thrown away immediately. This is the smallest possible reproduction
-  // for redmine issue 11105
-  RogueModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
-      const std::unordered_set<std::string>& tags = {})
-  : ctk::ApplicationModule(owner, name, description, tags) {
-    auto v = ctk::ScalarPushInput<int>{this, "trigger", "", ""};
+    BOOST_TEST(rv.getName() == "trigger");
   }
 
-  void mainLoop() override {}
-};
+  /*********************************************************************************************************************/
 
-struct TestApplication2 : ctk::Application {
-  TestApplication2() : Application("testSuite") {}
-  ctk::SetDMapFilePath dmap{"test.dmap"};
-
-  ~TestApplication2() override { shutdown(); }
-
-  RogueModule myModule{this, "MyModule", "ApplicationModule directly owned by app"};
-};
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testMassCreationOfUnusedAcecssors) {
-  TestApplication2 app;
-  ChimeraTK::Model::ProcessVariableProxy rv = app.myModule.getModel().visit(ChimeraTK::Model::returnProcessVariable,
-      ChimeraTK::Model::ownedVariables, ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::ProcessVariableProxy{}));
-
-  BOOST_TEST(rv.isValid());
-  BOOST_TEST(rv.getName() == "trigger");
-}
+} // namespace Tests::testApplicationPVModel

--- a/tests/executables_src/testModules.cc
+++ b/tests/executables_src/testModules.cc
@@ -17,1059 +17,1068 @@ using namespace boost::unit_test_framework;
 
 #include <boost/mpl/list.hpp>
 
-namespace ctk = ChimeraTK;
+namespace Tests::testModules {
 
-/*********************************************************************************************************************/
-/* Variable group used in the modules */
+  namespace ctk = ChimeraTK;
 
-struct SomeGroup : ctk::VariableGroup {
-  using ctk::VariableGroup::VariableGroup;
-  ctk::ScalarPushInput<std::string> inGroup{this, "inGroup", "", "This is a string", {"C", "A"}};
-  ctk::ArrayPushInput<int64_t> alsoInGroup{this, "alsoInGroup", "justANumber", 16, "A 64 bit number array", {"A", "D"}};
-};
+  /*********************************************************************************************************************/
+  /* Variable group used in the modules */
 
-/*********************************************************************************************************************/
-/* A plain application module for testing */
-
-struct TestModule : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  ctk::ScalarPushInput<int> someInput{this, "nameOfSomeInput", "cm", "This is just some input for testing", {"A", "B"}};
-  ctk::ScalarOutput<double> someOutput{this, "someOutput", "V", "Description", {"A", "C"}};
-
-  SomeGroup someGroup{this, "someGroup", "Description of my test group"};
-
-  struct AnotherGroup : ctk::VariableGroup {
+  struct SomeGroup : ctk::VariableGroup {
     using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarPushInput<uint8_t> foo{this, "foo", "counts", "Some counter", {"D"}};
-  } anotherGroup{this, "anotherName", "Description of my other group"};
-
-  void mainLoop() override {
-    while(true) {
-      someInput.read();
-      int val = someInput;
-      someOutput = val;
-      someOutput.write();
-    }
-  }
-};
-
-/*********************************************************************************************************************/
-/* Simple application with just one module */
-
-struct OneModuleApp : public ctk::Application {
-  OneModuleApp() : Application("myApp") {}
-  ~OneModuleApp() override { shutdown(); }
-
-  TestModule testModule{this, "testModule", "Module to test"};
-};
-
-/*********************************************************************************************************************/
-/* Application with a vector of modules */
-
-struct VectorOfModulesApp : public ctk::Application {
-  explicit VectorOfModulesApp(size_t numberOfInstances) : Application("myApp"), nInstances(numberOfInstances) {
-    for(size_t i = 0; i < numberOfInstances; ++i) {
-      std::string moduleName = "testModule_" + std::to_string(i) + "_instance";
-      vectorOfTestModule.emplace_back(this, moduleName, "Description");
-    }
-  }
-  ~VectorOfModulesApp() override { shutdown(); }
-
-  size_t nInstances;
-  std::vector<TestModule> vectorOfTestModule;
-};
-
-/*********************************************************************************************************************/
-/* An application module with a vector of a variable group*/
-
-struct VectorModule : public ctk::ApplicationModule {
-  VectorModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description, size_t nInstances,
-      const std::unordered_set<std::string>& tags = {})
-  : ctk::ApplicationModule(owner, name, description, tags) {
-    for(size_t i = 0; i < nInstances; ++i) {
-      std::string groupName = "testGroup_" + std::to_string(i);
-      vectorOfSomeGroup.emplace_back(this, groupName, "Description 2");
-      BOOST_CHECK(vectorOfSomeGroup.back().getModel().isValid());
-    }
-    for(size_t i = 0; i < nInstances; ++i) {
-      BOOST_CHECK(vectorOfSomeGroup[i].getModel().isValid());
-    }
-  }
-  VectorModule() = default;
-
-  ctk::ScalarPushInput<int> someInput{this, "nameOfSomeInput", "cm", "This is just some input for testing", {"A", "B"}};
-  ctk::ArrayOutput<double> someOutput{this, "someOutput", "V", 1, "Description", {"A", "C"}};
-
-  std::vector<SomeGroup> vectorOfSomeGroup;
-
-  struct AnotherGroup : ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarPushInput<uint8_t> foo{this, "foo", "counts", "Some counter", {"D"}};
-  } anotherGroup{this, "anotherName", "Description of my other group"};
-
-  void mainLoop() override {
-    while(true) {
-      someInput.read();
-      int val = someInput;
-      someOutput[0] = val;
-      someOutput.write();
-    }
-  }
-};
-
-/*********************************************************************************************************************/
-/* An module group with a vector of a application modules */
-
-struct VectorModuleGroup : public ctk::ModuleGroup {
-  VectorModuleGroup(ModuleGroup* owner, const std::string& name, const std::string& description, size_t nInstances,
-      const std::unordered_set<std::string>& tags = {})
-  : ctk::ModuleGroup(owner, name, description, tags) {
-    for(size_t i = 0; i < nInstances; ++i) {
-      std::string vovModuleName = "test_" + std::to_string(i);
-      vectorOfVectorModule.emplace_back(this, vovModuleName, "Description 3", nInstances);
-      BOOST_CHECK(vectorOfVectorModule.back().getModel().isValid());
-    }
-    for(size_t i = 0; i < nInstances; ++i) {
-      BOOST_CHECK(vectorOfVectorModule[i].getModel().isValid());
-    }
-  }
-
-  VectorModuleGroup() = default;
-
-  std::vector<VectorModule> vectorOfVectorModule;
-};
-
-/*********************************************************************************************************************/
-/* Application with a vector of module groups containing a vector of modules
- * containing a vector of variable groups */
-
-struct VectorOfEverythingApp : public ctk::Application {
-  explicit VectorOfEverythingApp(size_t numberOfInstances) : Application("myApp"), nInstances(numberOfInstances) {
-    for(size_t i = 0; i < nInstances; ++i) {
-      std::string name = "testModule_" + std::to_string(i) + "_instance";
-      vectorOfVectorModuleGroup.emplace_back(this, name, "Description", nInstances);
-      BOOST_CHECK(vectorOfVectorModuleGroup.back().getModel().isValid());
-    }
-    for(size_t i = 0; i < nInstances; ++i) {
-      BOOST_CHECK(vectorOfVectorModuleGroup[i].getModel().isValid());
-    }
-  }
-  ~VectorOfEverythingApp() override { shutdown(); }
-
-  size_t nInstances;
-  std::vector<VectorModuleGroup> vectorOfVectorModuleGroup;
-};
-
-/*********************************************************************************************************************/
-/* Application with various modules that get initialised late in the constructor. */
-
-struct AssignModuleLaterApp : public ctk::Application {
-  AssignModuleLaterApp() : Application("myApp") {
-    modGroupInstanceToAssignLater = std::move(modGroupInstanceSource);
-    modInstanceToAssignLater = std::move(modInstanceSource);
-  }
-  ~AssignModuleLaterApp() override { shutdown(); }
-
-  VectorModuleGroup modGroupInstanceSource{this, "modGroupInstanceToAssignLater",
-      "This instance of VectorModuleGroup was assigned using the operator=()", 42};
-  VectorModule modInstanceSource{
-      this, "modInstanceToAssignLater", "This instance of VectorModule was assigned using the operator=()", 13};
-
-  VectorModuleGroup modGroupInstanceToAssignLater;
-  VectorModule modInstanceToAssignLater;
-};
-
-/*********************************************************************************************************************/
-/* test module and variable ownerships */
-
-BOOST_AUTO_TEST_CASE(test_ownership) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> test_ownership" << std::endl;
-
-  OneModuleApp app;
-
-  BOOST_CHECK(app.testModule.getOwner() == &app);
-  BOOST_CHECK(app.testModule.someGroup.getOwner() == &(app.testModule));
-  BOOST_CHECK(app.testModule.anotherGroup.getOwner() == &(app.testModule));
-
-  BOOST_CHECK(app.testModule.someInput.getOwner() == &(app.testModule));
-  BOOST_CHECK(app.testModule.someOutput.getOwner() == &(app.testModule));
-
-  BOOST_CHECK(app.testModule.someGroup.inGroup.getOwner() == &(app.testModule.someGroup));
-  BOOST_CHECK(app.testModule.someGroup.alsoInGroup.getOwner() == &(app.testModule.someGroup));
-
-  BOOST_CHECK(app.testModule.anotherGroup.foo.getOwner() == &(app.testModule.anotherGroup));
-}
-
-/*********************************************************************************************************************/
-/* test that modules cannot be owned by the wrong types */
-
-BOOST_AUTO_TEST_CASE(test_badHierarchies) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> test_badHierarchies" << std::endl;
-
-  // ******************************************
-  // *** Tests for ApplicationModule
-
-  // check app ApplicationModules cannot be owned by nothing
-  {
-    OneModuleApp app;
-    try {
-      TestModule willFail(static_cast<ChimeraTK::ModuleGroup*>(nullptr), "willFail", "");
-      BOOST_FAIL("Exception expected");
-    }
-    catch(ChimeraTK::logic_error&) {
-    }
-  }
-
-  // ******************************************
-  // *** Tests for VariableGroup
-
-  // check app VariableGroup cannot be owned by nothing
-  {
-    OneModuleApp app;
-    try {
-      SomeGroup willFail(static_cast<ChimeraTK::VariableGroup*>(nullptr), "willFail", "");
-      BOOST_FAIL("Exception expected");
-    }
-    catch(ChimeraTK::logic_error&) {
-    }
-  }
-
-  // ******************************************
-  // *** Tests for ModuleGroup
-
-  // check app ModuleGroups cannot be owned by nothing
-  {
-    OneModuleApp app;
-    try {
-      VectorModuleGroup willFail(nullptr, "willFail", "", 1);
-      BOOST_FAIL("Exception expected");
-    }
-    catch(ChimeraTK::logic_error&) {
-    }
-  }
-}
-
-/*********************************************************************************************************************/
-/* test that modules can be owned by the right types */
-
-BOOST_AUTO_TEST_CASE(test_allowedHierarchies) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> test_allowedHierarchies" << std::endl;
-
-  // ******************************************
-  // *** Tests for ApplicationModule
-  // check ApplicationModules can be owned by Applications
-  try {
-    OneModuleApp app;
-    TestModule shouldNotFail(&(app), "shouldNotFail", "");
-  }
-  catch(ChimeraTK::logic_error&) {
-    BOOST_CHECK(false);
-  }
-
-  // check ApplicationModules can be owned by ModuleGroups
-  try {
-    VectorOfEverythingApp app(1);
-    auto* v = &(app.vectorOfVectorModuleGroup[0]);
-    BOOST_CHECK(v != nullptr);
-    TestModule shouldNotFail(v, "shouldNotFail", "");
-  }
-  catch(ChimeraTK::logic_error&) {
-    BOOST_FAIL("Exception not expected!");
-  }
-
-  // ******************************************
-  // *** Tests for VariableGroup
-
-  // check VariableGroup can be owned by ApplicationModules
-  try {
-    OneModuleApp app;
-    SomeGroup shouldNotFail(&(app.testModule), "shouldNotFail", "");
-  }
-  catch(ChimeraTK::logic_error&) {
-    BOOST_CHECK(false);
-  }
-
-  // check VariableGroup can be owned by VariableGroup
-  try {
-    OneModuleApp app;
-    SomeGroup shouldNotFail(&(app.testModule.someGroup), "shouldNotFail", "");
-  }
-  catch(ChimeraTK::logic_error&) {
-    BOOST_CHECK(false);
-  }
-
-  // ******************************************
-  // *** Tests for ModuleGroup
-
-  // check ModuleGroup can be owned by Applications
-  try {
-    OneModuleApp app;
-    VectorModuleGroup shouldNotFail(&(app), "shouldNotFail", "", 1);
-  }
-  catch(ChimeraTK::logic_error&) {
-    BOOST_CHECK(false);
-  }
-
-  // check ModuleGroup can be owned by ModuleGroups
-  try {
-    VectorOfEverythingApp app(1);
-    VectorModuleGroup shouldNotFail(&(app.vectorOfVectorModuleGroup[0]), "shouldNotFail", "", 1);
-  }
-  catch(ChimeraTK::logic_error&) {
-    BOOST_CHECK(false);
-  }
-}
-
-/*********************************************************************************************************************/
-/* test getSubmoduleList() and getSubmoduleListRecursive() */
-
-BOOST_AUTO_TEST_CASE(test_getSubmoduleList) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> test_getSubmoduleList" << std::endl;
-
-  OneModuleApp app;
-
-  {
-    std::list<ctk::Module*> list = app.getSubmoduleList();
-    BOOST_CHECK(list.size() == 1);
-    BOOST_CHECK(list.front() == &(app.testModule));
-  }
-
-  {
-    std::list<ctk::Module*> list = app.testModule.getSubmoduleList();
-    BOOST_CHECK(list.size() == 2);
-    size_t foundSomeGroup = 0;
-    size_t foundAnotherGroup = 0;
-    for(const auto* mod : list) {
-      if(mod == &(app.testModule.someGroup)) {
-        foundSomeGroup++;
-      }
-      if(mod == &(app.testModule.anotherGroup)) {
-        foundAnotherGroup++;
-      }
-    }
-    BOOST_CHECK(foundSomeGroup == 1);
-    BOOST_CHECK(foundAnotherGroup == 1);
-  }
-
-  {
-    std::list<ctk::Module*> list = app.getSubmoduleListRecursive();
-    BOOST_CHECK(list.size() == 3);
-    size_t foundTestModule = 0;
-    size_t foundSomeGroup = 0;
-    size_t foundAnotherGroup = 0;
-    for(const auto* mod : list) {
-      if(mod == &(app.testModule)) {
-        foundTestModule++;
-      }
-      if(mod == &(app.testModule.someGroup)) {
-        foundSomeGroup++;
-      }
-      if(mod == &(app.testModule.anotherGroup)) {
-        foundAnotherGroup++;
-      }
-    }
-    BOOST_CHECK(foundTestModule == 1);
-    BOOST_CHECK(foundSomeGroup == 1);
-    BOOST_CHECK(foundAnotherGroup == 1);
-  }
-
-  {
-    std::list<ctk::Module*> list = app.testModule.getSubmoduleListRecursive(); // identical to getSubmoduleList(),
-                                                                               // since no deeper hierarchies
-    BOOST_CHECK(list.size() == 2);
-    size_t foundSomeGroup = 0;
-    size_t foundAnotherGroup = 0;
-    for(const auto* mod : list) {
-      if(mod == &(app.testModule.someGroup)) {
-        foundSomeGroup++;
-      }
-      if(mod == &(app.testModule.anotherGroup)) {
-        foundAnotherGroup++;
-      }
-    }
-    BOOST_CHECK(foundSomeGroup == 1);
-    BOOST_CHECK(foundAnotherGroup == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-/* test getAccessorList() and getAccessorListRecursive() */
-
-BOOST_AUTO_TEST_CASE(test_getAccessorList) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> test_getAccessorList" << std::endl;
-
-  OneModuleApp app;
-
-  {
-    std::list<ctk::VariableNetworkNode> list = app.testModule.getAccessorList();
-    BOOST_CHECK(list.size() == 2);
-    size_t foundSomeInput = 0;
-    size_t foundSomeOutput = 0;
-    for(const auto& var : list) {
-      if(var == ctk::VariableNetworkNode(app.testModule.someInput)) {
-        foundSomeInput++;
-      }
-      if(var == ctk::VariableNetworkNode(app.testModule.someOutput)) {
-        foundSomeOutput++;
-      }
-    }
-    BOOST_CHECK(foundSomeInput == 1);
-    BOOST_CHECK(foundSomeOutput == 1);
-  }
-
-  {
-    const SomeGroup& someGroup(app.testModule.someGroup);
-    const std::list<ctk::VariableNetworkNode> list = someGroup.getAccessorList();
-    BOOST_CHECK(list.size() == 2);
-    size_t foundInGroup = 0;
-    size_t foundAlsoInGroup = 0;
-    for(const auto& var : list) {
-      if(var == ctk::VariableNetworkNode(app.testModule.someGroup.inGroup)) {
-        foundInGroup++;
-      }
-      if(var == ctk::VariableNetworkNode(app.testModule.someGroup.alsoInGroup)) {
-        foundAlsoInGroup++;
-      }
-    }
-    BOOST_CHECK(foundInGroup == 1);
-    BOOST_CHECK(foundAlsoInGroup == 1);
-  }
-
-  {
-    std::list<ctk::VariableNetworkNode> list = app.getAccessorListRecursive();
-    BOOST_CHECK(list.size() == 5);
-    size_t foundSomeInput = 0;
-    size_t foundSomeOutput = 0;
-    size_t foundInGroup = 0;
-    size_t foundAlsoInGroup = 0;
-    size_t foundFoo = 0;
-    for(const auto& var : list) {
-      if(var == ctk::VariableNetworkNode(app.testModule.someInput)) {
-        foundSomeInput++;
-      }
-      if(var == ctk::VariableNetworkNode(app.testModule.someOutput)) {
-        foundSomeOutput++;
-      }
-      if(var == ctk::VariableNetworkNode(app.testModule.someGroup.inGroup)) {
-        foundInGroup++;
-      }
-      if(var == ctk::VariableNetworkNode(app.testModule.someGroup.alsoInGroup)) {
-        foundAlsoInGroup++;
-      }
-      if(var == ctk::VariableNetworkNode(app.testModule.anotherGroup.foo)) {
-        foundFoo++;
-      }
-    }
-    BOOST_CHECK(foundSomeInput == 1);
-    BOOST_CHECK(foundSomeOutput == 1);
-    BOOST_CHECK(foundInGroup == 1);
-    BOOST_CHECK(foundAlsoInGroup == 1);
-    BOOST_CHECK(foundFoo == 1);
-  }
-
-  {
-    std::list<ctk::VariableNetworkNode> list = app.testModule.getAccessorListRecursive();
-    BOOST_CHECK(list.size() == 5);
-    size_t foundSomeInput = 0;
-    size_t foundSomeOutput = 0;
-    size_t foundInGroup = 0;
-    size_t foundAlsoInGroup = 0;
-    size_t foundFoo = 0;
-    for(const auto& var : list) {
-      if(var == ctk::VariableNetworkNode(app.testModule.someInput)) {
-        foundSomeInput++;
-      }
-      if(var == ctk::VariableNetworkNode(app.testModule.someOutput)) {
-        foundSomeOutput++;
-      }
-      if(var == ctk::VariableNetworkNode(app.testModule.someGroup.inGroup)) {
-        foundInGroup++;
-      }
-      if(var == ctk::VariableNetworkNode(app.testModule.someGroup.alsoInGroup)) {
-        foundAlsoInGroup++;
-      }
-      if(var == ctk::VariableNetworkNode(app.testModule.anotherGroup.foo)) {
-        foundFoo++;
-      }
-    }
-    BOOST_CHECK(foundSomeInput == 1);
-    BOOST_CHECK(foundSomeOutput == 1);
-    BOOST_CHECK(foundInGroup == 1);
-    BOOST_CHECK(foundAlsoInGroup == 1);
-    BOOST_CHECK(foundFoo == 1);
-  }
-
-  {
-    std::list<ctk::VariableNetworkNode> list = app.testModule.anotherGroup.getAccessorListRecursive();
-    BOOST_CHECK(list.size() == 1);
-    size_t foundFoo = 0;
-    for(const auto& var : list) {
-      if(var == ctk::VariableNetworkNode(app.testModule.anotherGroup.foo)) {
-        foundFoo++;
-      }
-    }
-    BOOST_CHECK(foundFoo == 1);
-  }
-}
-
-/*********************************************************************************************************************/
-/* test addTag() */
-
-BOOST_AUTO_TEST_CASE(testAddTag) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testAddTag" << std::endl;
-
-  OneModuleApp app;
-  app.testModule.addTag("newTag");
-
-  size_t nFound = 0;
-  auto checker = [&](auto proxy) {
-    ++nFound;
-    auto name = proxy.getFullyQualifiedPath();
-    BOOST_CHECK(name == "/testModule/nameOfSomeInput" || name == "/testModule/someOutput" ||
-        name == "/testModule/anotherName/foo" || name == "/testModule/someGroup/inGroup" ||
-        name == "/testModule/someGroup/alsoInGroup");
+    ctk::ScalarPushInput<std::string> inGroup{this, "inGroup", "", "This is a string", {"C", "A"}};
+    ctk::ArrayPushInput<int64_t> alsoInGroup{
+        this, "alsoInGroup", "justANumber", 16, "A 64 bit number array", {"A", "D"}};
   };
 
-  app.testModule.getModel().visit(
-      checker, ctk::Model::keepProcessVariables && ctk::Model::keepTag("newTag"), ChimeraTK::Model::depthFirstSearch);
+  /*********************************************************************************************************************/
+  /* A plain application module for testing */
 
-  BOOST_TEST(nFound == 5);
-}
+  struct TestModule : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-/*********************************************************************************************************************/
-/* test addTag() with negated tags, in order to remove tags */
+    ctk::ScalarPushInput<int> someInput{
+        this, "nameOfSomeInput", "cm", "This is just some input for testing", {"A", "B"}};
+    ctk::ScalarOutput<double> someOutput{this, "someOutput", "V", "Description", {"A", "C"}};
 
-BOOST_AUTO_TEST_CASE(testAddTagNegated) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testAddTagNegated" << std::endl;
+    SomeGroup someGroup{this, "someGroup", "Description of my test group"};
 
-  BOOST_TEST(ChimeraTK::negateTag("newTag") == "!newTag");
-  BOOST_TEST(ChimeraTK::negateTag("!newTag") == "newTag");
+    struct AnotherGroup : ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarPushInput<uint8_t> foo{this, "foo", "counts", "Some counter", {"D"}};
+    } anotherGroup{this, "anotherName", "Description of my other group"};
 
-  {
-    // negated tags on module level
+    void mainLoop() override {
+      while(true) {
+        someInput.read();
+        int val = someInput;
+        someOutput = val;
+        someOutput.write();
+      }
+    }
+  };
+
+  /*********************************************************************************************************************/
+  /* Simple application with just one module */
+
+  struct OneModuleApp : public ctk::Application {
+    OneModuleApp() : Application("myApp") {}
+    ~OneModuleApp() override { shutdown(); }
+
+    TestModule testModule{this, "testModule", "Module to test"};
+  };
+
+  /*********************************************************************************************************************/
+  /* Application with a vector of modules */
+
+  struct VectorOfModulesApp : public ctk::Application {
+    explicit VectorOfModulesApp(size_t numberOfInstances) : Application("myApp"), nInstances(numberOfInstances) {
+      for(size_t i = 0; i < numberOfInstances; ++i) {
+        std::string moduleName = "testModule_" + std::to_string(i) + "_instance";
+        vectorOfTestModule.emplace_back(this, moduleName, "Description");
+      }
+    }
+    ~VectorOfModulesApp() override { shutdown(); }
+
+    size_t nInstances;
+    std::vector<TestModule> vectorOfTestModule;
+  };
+
+  /*********************************************************************************************************************/
+  /* An application module with a vector of a variable group*/
+
+  struct VectorModule : public ctk::ApplicationModule {
+    VectorModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description, size_t nInstances,
+        const std::unordered_set<std::string>& tags = {})
+    : ctk::ApplicationModule(owner, name, description, tags) {
+      for(size_t i = 0; i < nInstances; ++i) {
+        std::string groupName = "testGroup_" + std::to_string(i);
+        vectorOfSomeGroup.emplace_back(this, groupName, "Description 2");
+        BOOST_CHECK(vectorOfSomeGroup.back().getModel().isValid());
+      }
+      for(size_t i = 0; i < nInstances; ++i) {
+        BOOST_CHECK(vectorOfSomeGroup[i].getModel().isValid());
+      }
+    }
+    VectorModule() = default;
+
+    ctk::ScalarPushInput<int> someInput{
+        this, "nameOfSomeInput", "cm", "This is just some input for testing", {"A", "B"}};
+    ctk::ArrayOutput<double> someOutput{this, "someOutput", "V", 1, "Description", {"A", "C"}};
+
+    std::vector<SomeGroup> vectorOfSomeGroup;
+
+    struct AnotherGroup : ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarPushInput<uint8_t> foo{this, "foo", "counts", "Some counter", {"D"}};
+    } anotherGroup{this, "anotherName", "Description of my other group"};
+
+    void mainLoop() override {
+      while(true) {
+        someInput.read();
+        int val = someInput;
+        someOutput[0] = val;
+        someOutput.write();
+      }
+    }
+  };
+
+  /*********************************************************************************************************************/
+  /* An module group with a vector of a application modules */
+
+  struct VectorModuleGroup : public ctk::ModuleGroup {
+    VectorModuleGroup(ModuleGroup* owner, const std::string& name, const std::string& description, size_t nInstances,
+        const std::unordered_set<std::string>& tags = {})
+    : ctk::ModuleGroup(owner, name, description, tags) {
+      for(size_t i = 0; i < nInstances; ++i) {
+        std::string vovModuleName = "test_" + std::to_string(i);
+        vectorOfVectorModule.emplace_back(this, vovModuleName, "Description 3", nInstances);
+        BOOST_CHECK(vectorOfVectorModule.back().getModel().isValid());
+      }
+      for(size_t i = 0; i < nInstances; ++i) {
+        BOOST_CHECK(vectorOfVectorModule[i].getModel().isValid());
+      }
+    }
+
+    VectorModuleGroup() = default;
+
+    std::vector<VectorModule> vectorOfVectorModule;
+  };
+
+  /*********************************************************************************************************************/
+  /* Application with a vector of module groups containing a vector of modules
+   * containing a vector of variable groups */
+
+  struct VectorOfEverythingApp : public ctk::Application {
+    explicit VectorOfEverythingApp(size_t numberOfInstances) : Application("myApp"), nInstances(numberOfInstances) {
+      for(size_t i = 0; i < nInstances; ++i) {
+        std::string name = "testModule_" + std::to_string(i) + "_instance";
+        vectorOfVectorModuleGroup.emplace_back(this, name, "Description", nInstances);
+        BOOST_CHECK(vectorOfVectorModuleGroup.back().getModel().isValid());
+      }
+      for(size_t i = 0; i < nInstances; ++i) {
+        BOOST_CHECK(vectorOfVectorModuleGroup[i].getModel().isValid());
+      }
+    }
+    ~VectorOfEverythingApp() override { shutdown(); }
+
+    size_t nInstances;
+    std::vector<VectorModuleGroup> vectorOfVectorModuleGroup;
+  };
+
+  /*********************************************************************************************************************/
+  /* Application with various modules that get initialised late in the constructor. */
+
+  struct AssignModuleLaterApp : public ctk::Application {
+    AssignModuleLaterApp() : Application("myApp") {
+      modGroupInstanceToAssignLater = std::move(modGroupInstanceSource);
+      modInstanceToAssignLater = std::move(modInstanceSource);
+    }
+    ~AssignModuleLaterApp() override { shutdown(); }
+
+    VectorModuleGroup modGroupInstanceSource{this, "modGroupInstanceToAssignLater",
+        "This instance of VectorModuleGroup was assigned using the operator=()", 42};
+    VectorModule modInstanceSource{
+        this, "modInstanceToAssignLater", "This instance of VectorModule was assigned using the operator=()", 13};
+
+    VectorModuleGroup modGroupInstanceToAssignLater;
+    VectorModule modInstanceToAssignLater;
+  };
+
+  /*********************************************************************************************************************/
+  /* test module and variable ownerships */
+
+  BOOST_AUTO_TEST_CASE(test_ownership) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> test_ownership" << std::endl;
+
     OneModuleApp app;
+
+    BOOST_CHECK(app.testModule.getOwner() == &app);
+    BOOST_CHECK(app.testModule.someGroup.getOwner() == &(app.testModule));
+    BOOST_CHECK(app.testModule.anotherGroup.getOwner() == &(app.testModule));
+
+    BOOST_CHECK(app.testModule.someInput.getOwner() == &(app.testModule));
+    BOOST_CHECK(app.testModule.someOutput.getOwner() == &(app.testModule));
+
+    BOOST_CHECK(app.testModule.someGroup.inGroup.getOwner() == &(app.testModule.someGroup));
+    BOOST_CHECK(app.testModule.someGroup.alsoInGroup.getOwner() == &(app.testModule.someGroup));
+
+    BOOST_CHECK(app.testModule.anotherGroup.foo.getOwner() == &(app.testModule.anotherGroup));
+  }
+
+  /*********************************************************************************************************************/
+  /* test that modules cannot be owned by the wrong types */
+
+  BOOST_AUTO_TEST_CASE(test_badHierarchies) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> test_badHierarchies" << std::endl;
+
+    // ******************************************
+    // *** Tests for ApplicationModule
+
+    // check app ApplicationModules cannot be owned by nothing
+    {
+      OneModuleApp app;
+      try {
+        TestModule willFail(static_cast<ChimeraTK::ModuleGroup*>(nullptr), "willFail", "");
+        BOOST_FAIL("Exception expected");
+      }
+      catch(ChimeraTK::logic_error&) {
+      }
+    }
+
+    // ******************************************
+    // *** Tests for VariableGroup
+
+    // check app VariableGroup cannot be owned by nothing
+    {
+      OneModuleApp app;
+      try {
+        SomeGroup willFail(static_cast<ChimeraTK::VariableGroup*>(nullptr), "willFail", "");
+        BOOST_FAIL("Exception expected");
+      }
+      catch(ChimeraTK::logic_error&) {
+      }
+    }
+
+    // ******************************************
+    // *** Tests for ModuleGroup
+
+    // check app ModuleGroups cannot be owned by nothing
+    {
+      OneModuleApp app;
+      try {
+        VectorModuleGroup willFail(nullptr, "willFail", "", 1);
+        BOOST_FAIL("Exception expected");
+      }
+      catch(ChimeraTK::logic_error&) {
+      }
+    }
+  }
+
+  /*********************************************************************************************************************/
+  /* test that modules can be owned by the right types */
+
+  BOOST_AUTO_TEST_CASE(test_allowedHierarchies) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> test_allowedHierarchies" << std::endl;
+
+    // ******************************************
+    // *** Tests for ApplicationModule
+    // check ApplicationModules can be owned by Applications
+    try {
+      OneModuleApp app;
+      TestModule shouldNotFail(&(app), "shouldNotFail", "");
+    }
+    catch(ChimeraTK::logic_error&) {
+      BOOST_CHECK(false);
+    }
+
+    // check ApplicationModules can be owned by ModuleGroups
+    try {
+      VectorOfEverythingApp app(1);
+      auto* v = &(app.vectorOfVectorModuleGroup[0]);
+      BOOST_CHECK(v != nullptr);
+      TestModule shouldNotFail(v, "shouldNotFail", "");
+    }
+    catch(ChimeraTK::logic_error&) {
+      BOOST_FAIL("Exception not expected!");
+    }
+
+    // ******************************************
+    // *** Tests for VariableGroup
+
+    // check VariableGroup can be owned by ApplicationModules
+    try {
+      OneModuleApp app;
+      SomeGroup shouldNotFail(&(app.testModule), "shouldNotFail", "");
+    }
+    catch(ChimeraTK::logic_error&) {
+      BOOST_CHECK(false);
+    }
+
+    // check VariableGroup can be owned by VariableGroup
+    try {
+      OneModuleApp app;
+      SomeGroup shouldNotFail(&(app.testModule.someGroup), "shouldNotFail", "");
+    }
+    catch(ChimeraTK::logic_error&) {
+      BOOST_CHECK(false);
+    }
+
+    // ******************************************
+    // *** Tests for ModuleGroup
+
+    // check ModuleGroup can be owned by Applications
+    try {
+      OneModuleApp app;
+      VectorModuleGroup shouldNotFail(&(app), "shouldNotFail", "", 1);
+    }
+    catch(ChimeraTK::logic_error&) {
+      BOOST_CHECK(false);
+    }
+
+    // check ModuleGroup can be owned by ModuleGroups
+    try {
+      VectorOfEverythingApp app(1);
+      VectorModuleGroup shouldNotFail(&(app.vectorOfVectorModuleGroup[0]), "shouldNotFail", "", 1);
+    }
+    catch(ChimeraTK::logic_error&) {
+      BOOST_CHECK(false);
+    }
+  }
+
+  /*********************************************************************************************************************/
+  /* test getSubmoduleList() and getSubmoduleListRecursive() */
+
+  BOOST_AUTO_TEST_CASE(test_getSubmoduleList) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> test_getSubmoduleList" << std::endl;
+
+    OneModuleApp app;
+
+    {
+      std::list<ctk::Module*> list = app.getSubmoduleList();
+      BOOST_CHECK(list.size() == 1);
+      BOOST_CHECK(list.front() == &(app.testModule));
+    }
+
+    {
+      std::list<ctk::Module*> list = app.testModule.getSubmoduleList();
+      BOOST_CHECK(list.size() == 2);
+      size_t foundSomeGroup = 0;
+      size_t foundAnotherGroup = 0;
+      for(const auto* mod : list) {
+        if(mod == &(app.testModule.someGroup)) {
+          foundSomeGroup++;
+        }
+        if(mod == &(app.testModule.anotherGroup)) {
+          foundAnotherGroup++;
+        }
+      }
+      BOOST_CHECK(foundSomeGroup == 1);
+      BOOST_CHECK(foundAnotherGroup == 1);
+    }
+
+    {
+      std::list<ctk::Module*> list = app.getSubmoduleListRecursive();
+      BOOST_CHECK(list.size() == 3);
+      size_t foundTestModule = 0;
+      size_t foundSomeGroup = 0;
+      size_t foundAnotherGroup = 0;
+      for(const auto* mod : list) {
+        if(mod == &(app.testModule)) {
+          foundTestModule++;
+        }
+        if(mod == &(app.testModule.someGroup)) {
+          foundSomeGroup++;
+        }
+        if(mod == &(app.testModule.anotherGroup)) {
+          foundAnotherGroup++;
+        }
+      }
+      BOOST_CHECK(foundTestModule == 1);
+      BOOST_CHECK(foundSomeGroup == 1);
+      BOOST_CHECK(foundAnotherGroup == 1);
+    }
+
+    {
+      std::list<ctk::Module*> list = app.testModule.getSubmoduleListRecursive(); // identical to getSubmoduleList(),
+                                                                                 // since no deeper hierarchies
+      BOOST_CHECK(list.size() == 2);
+      size_t foundSomeGroup = 0;
+      size_t foundAnotherGroup = 0;
+      for(const auto* mod : list) {
+        if(mod == &(app.testModule.someGroup)) {
+          foundSomeGroup++;
+        }
+        if(mod == &(app.testModule.anotherGroup)) {
+          foundAnotherGroup++;
+        }
+      }
+      BOOST_CHECK(foundSomeGroup == 1);
+      BOOST_CHECK(foundAnotherGroup == 1);
+    }
+  }
+
+  /*********************************************************************************************************************/
+  /* test getAccessorList() and getAccessorListRecursive() */
+
+  BOOST_AUTO_TEST_CASE(test_getAccessorList) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> test_getAccessorList" << std::endl;
+
+    OneModuleApp app;
+
+    {
+      std::list<ctk::VariableNetworkNode> list = app.testModule.getAccessorList();
+      BOOST_CHECK(list.size() == 2);
+      size_t foundSomeInput = 0;
+      size_t foundSomeOutput = 0;
+      for(const auto& var : list) {
+        if(var == ctk::VariableNetworkNode(app.testModule.someInput)) {
+          foundSomeInput++;
+        }
+        if(var == ctk::VariableNetworkNode(app.testModule.someOutput)) {
+          foundSomeOutput++;
+        }
+      }
+      BOOST_CHECK(foundSomeInput == 1);
+      BOOST_CHECK(foundSomeOutput == 1);
+    }
+
+    {
+      const SomeGroup& someGroup(app.testModule.someGroup);
+      const std::list<ctk::VariableNetworkNode> list = someGroup.getAccessorList();
+      BOOST_CHECK(list.size() == 2);
+      size_t foundInGroup = 0;
+      size_t foundAlsoInGroup = 0;
+      for(const auto& var : list) {
+        if(var == ctk::VariableNetworkNode(app.testModule.someGroup.inGroup)) {
+          foundInGroup++;
+        }
+        if(var == ctk::VariableNetworkNode(app.testModule.someGroup.alsoInGroup)) {
+          foundAlsoInGroup++;
+        }
+      }
+      BOOST_CHECK(foundInGroup == 1);
+      BOOST_CHECK(foundAlsoInGroup == 1);
+    }
+
+    {
+      std::list<ctk::VariableNetworkNode> list = app.getAccessorListRecursive();
+      BOOST_CHECK(list.size() == 5);
+      size_t foundSomeInput = 0;
+      size_t foundSomeOutput = 0;
+      size_t foundInGroup = 0;
+      size_t foundAlsoInGroup = 0;
+      size_t foundFoo = 0;
+      for(const auto& var : list) {
+        if(var == ctk::VariableNetworkNode(app.testModule.someInput)) {
+          foundSomeInput++;
+        }
+        if(var == ctk::VariableNetworkNode(app.testModule.someOutput)) {
+          foundSomeOutput++;
+        }
+        if(var == ctk::VariableNetworkNode(app.testModule.someGroup.inGroup)) {
+          foundInGroup++;
+        }
+        if(var == ctk::VariableNetworkNode(app.testModule.someGroup.alsoInGroup)) {
+          foundAlsoInGroup++;
+        }
+        if(var == ctk::VariableNetworkNode(app.testModule.anotherGroup.foo)) {
+          foundFoo++;
+        }
+      }
+      BOOST_CHECK(foundSomeInput == 1);
+      BOOST_CHECK(foundSomeOutput == 1);
+      BOOST_CHECK(foundInGroup == 1);
+      BOOST_CHECK(foundAlsoInGroup == 1);
+      BOOST_CHECK(foundFoo == 1);
+    }
+
+    {
+      std::list<ctk::VariableNetworkNode> list = app.testModule.getAccessorListRecursive();
+      BOOST_CHECK(list.size() == 5);
+      size_t foundSomeInput = 0;
+      size_t foundSomeOutput = 0;
+      size_t foundInGroup = 0;
+      size_t foundAlsoInGroup = 0;
+      size_t foundFoo = 0;
+      for(const auto& var : list) {
+        if(var == ctk::VariableNetworkNode(app.testModule.someInput)) {
+          foundSomeInput++;
+        }
+        if(var == ctk::VariableNetworkNode(app.testModule.someOutput)) {
+          foundSomeOutput++;
+        }
+        if(var == ctk::VariableNetworkNode(app.testModule.someGroup.inGroup)) {
+          foundInGroup++;
+        }
+        if(var == ctk::VariableNetworkNode(app.testModule.someGroup.alsoInGroup)) {
+          foundAlsoInGroup++;
+        }
+        if(var == ctk::VariableNetworkNode(app.testModule.anotherGroup.foo)) {
+          foundFoo++;
+        }
+      }
+      BOOST_CHECK(foundSomeInput == 1);
+      BOOST_CHECK(foundSomeOutput == 1);
+      BOOST_CHECK(foundInGroup == 1);
+      BOOST_CHECK(foundAlsoInGroup == 1);
+      BOOST_CHECK(foundFoo == 1);
+    }
+
+    {
+      std::list<ctk::VariableNetworkNode> list = app.testModule.anotherGroup.getAccessorListRecursive();
+      BOOST_CHECK(list.size() == 1);
+      size_t foundFoo = 0;
+      for(const auto& var : list) {
+        if(var == ctk::VariableNetworkNode(app.testModule.anotherGroup.foo)) {
+          foundFoo++;
+        }
+      }
+      BOOST_CHECK(foundFoo == 1);
+    }
+  }
+
+  /*********************************************************************************************************************/
+  /* test addTag() */
+
+  BOOST_AUTO_TEST_CASE(testAddTag) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testAddTag" << std::endl;
+
+    OneModuleApp app;
+    app.testModule.addTag("newTag");
+
+    size_t nFound = 0;
+    auto checker = [&](auto proxy) {
+      ++nFound;
+      auto name = proxy.getFullyQualifiedPath();
+      BOOST_CHECK(name == "/testModule/nameOfSomeInput" || name == "/testModule/someOutput" ||
+          name == "/testModule/anotherName/foo" || name == "/testModule/someGroup/inGroup" ||
+          name == "/testModule/someGroup/alsoInGroup");
+    };
+
+    app.testModule.getModel().visit(
+        checker, ctk::Model::keepProcessVariables && ctk::Model::keepTag("newTag"), ChimeraTK::Model::depthFirstSearch);
+
+    BOOST_TEST(nFound == 5);
+  }
+
+  /*********************************************************************************************************************/
+  /* test addTag() with negated tags, in order to remove tags */
+
+  BOOST_AUTO_TEST_CASE(testAddTagNegated) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testAddTagNegated" << std::endl;
+
     BOOST_TEST(ChimeraTK::negateTag("newTag") == "!newTag");
     BOOST_TEST(ChimeraTK::negateTag("!newTag") == "newTag");
-    app.testModule.addTag("!newTag");
-    app.testModule.addTag("newTag");
 
-    const auto& tags = app.testModule.someOutput.getTags();
-    BOOST_CHECK(tags.find("newTag") == tags.end());
-  }
-  {
-    // negated tags on variable level
-    OneModuleApp app;
-    app.testModule.someOutput.addTag("newTag");
-    app.testModule.someOutput.addTag("!newTag");
+    {
+      // negated tags on module level
+      OneModuleApp app;
+      BOOST_TEST(ChimeraTK::negateTag("newTag") == "!newTag");
+      BOOST_TEST(ChimeraTK::negateTag("!newTag") == "newTag");
+      app.testModule.addTag("!newTag");
+      app.testModule.addTag("newTag");
 
-    const auto& tags = app.testModule.someOutput.getTags();
-    BOOST_CHECK(tags.find("newTag") == tags.end());
-  }
-  {
-    // negated tags on variable and module level, mixed
-    OneModuleApp app;
-    app.testModule.addTag("newTag");
-    app.testModule.someOutput.addTag("!newTag");
-
-    const auto& tags = app.testModule.someOutput.getTags();
-    BOOST_CHECK(tags.find("newTag") == tags.end());
-  }
-  // note, we currently do not test the tag set of the model associated with the accessors.
-  // the tags on the model level are not clear since a vertex in the model represents an output pv and its input
-  // in some other module at the same time
-}
-
-/*********************************************************************************************************************/
-/* test correct behaviour when using a std::vector of ApplicationModules */
-
-BOOST_AUTO_TEST_CASE(testVectorOfApplicationModule) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testVectorOfApplicationModule" << std::endl;
-
-  // create app with a vector containing 10 modules
-  size_t nInstances = 10;
-  VectorOfModulesApp app(nInstances);
-
-  // the app creates the 10 module instances, check if this is done proplery (a quite redundant test...)
-  BOOST_TEST(app.vectorOfTestModule.size() == nInstances);
-
-  // some direct checks on the created instances
-  for(size_t i = 0; i < nInstances; ++i) {
-    std::string name = "testModule_" + std::to_string(i) + "_instance";
-    BOOST_TEST(app.vectorOfTestModule[i].getName() == name);
-    auto node = static_cast<ctk::VariableNetworkNode>(app.vectorOfTestModule[i].someInput);
-    BOOST_TEST(node.getQualifiedName() == "/myApp/" + name + "/nameOfSomeInput");
-
-    // check accessor list
-    std::list<ctk::VariableNetworkNode> accList = app.vectorOfTestModule[i].getAccessorList();
-    BOOST_TEST(accList.size() == 2);
-    size_t foundSomeInput = 0;
-    size_t foundSomeOutput = 0;
-    for(auto& acc : accList) {
-      if(acc == ctk::VariableNetworkNode(app.vectorOfTestModule[i].someInput)) {
-        foundSomeInput++;
-      }
-      if(acc == ctk::VariableNetworkNode(app.vectorOfTestModule[i].someOutput)) {
-        foundSomeOutput++;
-      }
+      const auto& tags = app.testModule.someOutput.getTags();
+      BOOST_CHECK(tags.find("newTag") == tags.end());
     }
-    BOOST_TEST(foundSomeInput == 1);
-    BOOST_TEST(foundSomeOutput == 1);
+    {
+      // negated tags on variable level
+      OneModuleApp app;
+      app.testModule.someOutput.addTag("newTag");
+      app.testModule.someOutput.addTag("!newTag");
 
-    // check submodule list
-    std::list<ctk::Module*> modList = app.vectorOfTestModule[i].getSubmoduleList();
-    BOOST_TEST(modList.size() == 2);
-    size_t foundSomeGroup = 0;
-    size_t foundAnotherGroup = 0;
-    for(const auto* mod : modList) {
-      if(mod == &(app.vectorOfTestModule[i].someGroup)) {
-        foundSomeGroup++;
-      }
-      if(mod == &(app.vectorOfTestModule[i].anotherGroup)) {
-        foundAnotherGroup++;
-      }
+      const auto& tags = app.testModule.someOutput.getTags();
+      BOOST_CHECK(tags.find("newTag") == tags.end());
     }
-    BOOST_TEST(foundSomeGroup == 1);
-    BOOST_TEST(foundAnotherGroup == 1);
+    {
+      // negated tags on variable and module level, mixed
+      OneModuleApp app;
+      app.testModule.addTag("newTag");
+      app.testModule.someOutput.addTag("!newTag");
+
+      const auto& tags = app.testModule.someOutput.getTags();
+      BOOST_CHECK(tags.find("newTag") == tags.end());
+    }
+    // note, we currently do not test the tag set of the model associated with the accessors.
+    // the tags on the model level are not clear since a vertex in the model represents an output pv and its input
+    // in some other module at the same time
   }
 
-  // check if instances appear properly in getSubmoduleList()
-  {
-    std::list<ctk::Module*> list = app.getSubmoduleList();
-    BOOST_TEST(list.size() == nInstances);
-    std::map<size_t, size_t> instancesFound;
+  /*********************************************************************************************************************/
+  /* test correct behaviour when using a std::vector of ApplicationModules */
+
+  BOOST_AUTO_TEST_CASE(testVectorOfApplicationModule) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testVectorOfApplicationModule" << std::endl;
+
+    // create app with a vector containing 10 modules
+    size_t nInstances = 10;
+    VectorOfModulesApp app(nInstances);
+
+    // the app creates the 10 module instances, check if this is done proplery (a quite redundant test...)
+    BOOST_TEST(app.vectorOfTestModule.size() == nInstances);
+
+    // some direct checks on the created instances
     for(size_t i = 0; i < nInstances; ++i) {
-      instancesFound[i] = 0;
-    }
-    for(const auto* mod : list) {
-      for(size_t i = 0; i < nInstances; ++i) {
-        if(mod == &(app.vectorOfTestModule[i])) {
-          instancesFound[i]++;
+      std::string name = "testModule_" + std::to_string(i) + "_instance";
+      BOOST_TEST(app.vectorOfTestModule[i].getName() == name);
+      auto node = static_cast<ctk::VariableNetworkNode>(app.vectorOfTestModule[i].someInput);
+      BOOST_TEST(node.getQualifiedName() == "/myApp/" + name + "/nameOfSomeInput");
+
+      // check accessor list
+      std::list<ctk::VariableNetworkNode> accList = app.vectorOfTestModule[i].getAccessorList();
+      BOOST_TEST(accList.size() == 2);
+      size_t foundSomeInput = 0;
+      size_t foundSomeOutput = 0;
+      for(auto& acc : accList) {
+        if(acc == ctk::VariableNetworkNode(app.vectorOfTestModule[i].someInput)) {
+          foundSomeInput++;
+        }
+        if(acc == ctk::VariableNetworkNode(app.vectorOfTestModule[i].someOutput)) {
+          foundSomeOutput++;
         }
       }
-    }
-    for(size_t i = 0; i < nInstances; ++i) {
-      BOOST_TEST(instancesFound[i] == 1);
-    }
-  }
+      BOOST_TEST(foundSomeInput == 1);
+      BOOST_TEST(foundSomeOutput == 1);
 
-  // check if instances appear properly in getSubmoduleListRecursive() as well
-  {
-    std::list<ctk::Module*> list = app.getSubmoduleListRecursive();
-    BOOST_TEST(list.size() == 3 * nInstances);
-    std::map<size_t, size_t> instancesFound, instancesSomeGroupFound, instancesAnotherGroupFound;
-    for(size_t i = 0; i < nInstances; ++i) {
-      instancesFound[i] = 0;
-      instancesSomeGroupFound[i] = 0;
-      instancesAnotherGroupFound[i] = 0;
-    }
-    for(const auto* mod : list) {
-      for(size_t i = 0; i < nInstances; ++i) {
-        if(mod == &(app.vectorOfTestModule[i])) {
-          instancesFound[i]++;
-        }
+      // check submodule list
+      std::list<ctk::Module*> modList = app.vectorOfTestModule[i].getSubmoduleList();
+      BOOST_TEST(modList.size() == 2);
+      size_t foundSomeGroup = 0;
+      size_t foundAnotherGroup = 0;
+      for(const auto* mod : modList) {
         if(mod == &(app.vectorOfTestModule[i].someGroup)) {
-          instancesSomeGroupFound[i]++;
+          foundSomeGroup++;
         }
         if(mod == &(app.vectorOfTestModule[i].anotherGroup)) {
-          instancesAnotherGroupFound[i]++;
+          foundAnotherGroup++;
         }
       }
+      BOOST_TEST(foundSomeGroup == 1);
+      BOOST_TEST(foundAnotherGroup == 1);
     }
-    for(size_t i = 0; i < nInstances; ++i) {
-      BOOST_TEST(instancesFound[i] == 1);
-      BOOST_TEST(instancesSomeGroupFound[i] == 1);
-      BOOST_TEST(instancesAnotherGroupFound[i] == 1);
-    }
-  }
 
-  // check ownerships
-  for(size_t i = 0; i < nInstances; ++i) {
-    BOOST_CHECK(app.vectorOfTestModule[i].getOwner() == &app);
-    BOOST_CHECK(app.vectorOfTestModule[i].someInput.getOwner() == &(app.vectorOfTestModule[i]));
-    BOOST_CHECK(app.vectorOfTestModule[i].someOutput.getOwner() == &(app.vectorOfTestModule[i]));
-    BOOST_CHECK(app.vectorOfTestModule[i].someGroup.getOwner() == &(app.vectorOfTestModule[i]));
-    BOOST_CHECK(app.vectorOfTestModule[i].someGroup.inGroup.getOwner() == &(app.vectorOfTestModule[i].someGroup));
-    BOOST_CHECK(app.vectorOfTestModule[i].someGroup.alsoInGroup.getOwner() == &(app.vectorOfTestModule[i].someGroup));
-    BOOST_CHECK(app.vectorOfTestModule[i].anotherGroup.getOwner() == &(app.vectorOfTestModule[i]));
-    BOOST_CHECK(app.vectorOfTestModule[i].anotherGroup.foo.getOwner() == &(app.vectorOfTestModule[i].anotherGroup));
-  }
-}
-
-/*********************************************************************************************************************/
-/* test correct behaviour when using a std::vector of ModuleGroup, ApplicationModule and VariableGroup at the same
- * time */
-
-BOOST_AUTO_TEST_CASE(testVectorsOfAllModules) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testVectorsOfAllModules" << std::endl;
-
-  // create app with a vector containing 10 modules
-  size_t nInstances = 10;
-  VectorOfEverythingApp app(nInstances);
-
-  //-------------------------------------------------------------------------------------------------------------------
-  // the app creates the 10 module instances, check if this is done proplery (a quite redundant test...)
-  BOOST_CHECK(app.vectorOfVectorModuleGroup.size() == nInstances);
-  for(size_t i = 0; i < nInstances; ++i) {
-    BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule.size() == nInstances);
-    for(size_t k = 0; k < nInstances; ++k) {
-      BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup.size() == nInstances);
-    }
-  }
-
-  //-------------------------------------------------------------------------------------------------------------------
-  // check presence in lists (getSubmoduleList() and getAccessorList())
-
-  { // checks on first hierarchy level (application has the list of module groups)
-    std::list<ctk::Module*> list = app.getSubmoduleList();
-    BOOST_CHECK(list.size() == nInstances);
-    std::map<size_t, size_t> found;
-    for(size_t i = 0; i < nInstances; ++i) {
-      found[i] = 0;
-    }
-    for(const auto* mod : list) {
+    // check if instances appear properly in getSubmoduleList()
+    {
+      std::list<ctk::Module*> list = app.getSubmoduleList();
+      BOOST_TEST(list.size() == nInstances);
+      std::map<size_t, size_t> instancesFound;
       for(size_t i = 0; i < nInstances; ++i) {
-        if(mod == &(app.vectorOfVectorModuleGroup[i])) {
-          found[i]++;
-        }
-      }
-    }
-    for(size_t i = 0; i < nInstances; ++i) {
-      BOOST_CHECK(found[i] == 1);
-    }
-  }
-
-  { // checks on second hierarchy level (each module group has the list of modules)
-    for(size_t i = 0; i < nInstances; ++i) {
-      std::list<ctk::Module*> list = app.vectorOfVectorModuleGroup[i].getSubmoduleList();
-      BOOST_CHECK(list.size() == nInstances);
-
-      std::map<size_t, size_t> found;
-      for(size_t k = 0; k < nInstances; ++k) {
-        found[k] = 0;
+        instancesFound[i] = 0;
       }
       for(const auto* mod : list) {
-        for(size_t k = 0; k < nInstances; ++k) {
-          if(mod == &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k])) {
-            found[k]++;
+        for(size_t i = 0; i < nInstances; ++i) {
+          if(mod == &(app.vectorOfTestModule[i])) {
+            instancesFound[i]++;
           }
         }
       }
-      for(size_t k = 0; k < nInstances; ++k) {
-        BOOST_CHECK(found[k] == 1);
+      for(size_t i = 0; i < nInstances; ++i) {
+        BOOST_TEST(instancesFound[i] == 1);
       }
+    }
+
+    // check if instances appear properly in getSubmoduleListRecursive() as well
+    {
+      std::list<ctk::Module*> list = app.getSubmoduleListRecursive();
+      BOOST_TEST(list.size() == 3 * nInstances);
+      std::map<size_t, size_t> instancesFound, instancesSomeGroupFound, instancesAnotherGroupFound;
+      for(size_t i = 0; i < nInstances; ++i) {
+        instancesFound[i] = 0;
+        instancesSomeGroupFound[i] = 0;
+        instancesAnotherGroupFound[i] = 0;
+      }
+      for(const auto* mod : list) {
+        for(size_t i = 0; i < nInstances; ++i) {
+          if(mod == &(app.vectorOfTestModule[i])) {
+            instancesFound[i]++;
+          }
+          if(mod == &(app.vectorOfTestModule[i].someGroup)) {
+            instancesSomeGroupFound[i]++;
+          }
+          if(mod == &(app.vectorOfTestModule[i].anotherGroup)) {
+            instancesAnotherGroupFound[i]++;
+          }
+        }
+      }
+      for(size_t i = 0; i < nInstances; ++i) {
+        BOOST_TEST(instancesFound[i] == 1);
+        BOOST_TEST(instancesSomeGroupFound[i] == 1);
+        BOOST_TEST(instancesAnotherGroupFound[i] == 1);
+      }
+    }
+
+    // check ownerships
+    for(size_t i = 0; i < nInstances; ++i) {
+      BOOST_CHECK(app.vectorOfTestModule[i].getOwner() == &app);
+      BOOST_CHECK(app.vectorOfTestModule[i].someInput.getOwner() == &(app.vectorOfTestModule[i]));
+      BOOST_CHECK(app.vectorOfTestModule[i].someOutput.getOwner() == &(app.vectorOfTestModule[i]));
+      BOOST_CHECK(app.vectorOfTestModule[i].someGroup.getOwner() == &(app.vectorOfTestModule[i]));
+      BOOST_CHECK(app.vectorOfTestModule[i].someGroup.inGroup.getOwner() == &(app.vectorOfTestModule[i].someGroup));
+      BOOST_CHECK(app.vectorOfTestModule[i].someGroup.alsoInGroup.getOwner() == &(app.vectorOfTestModule[i].someGroup));
+      BOOST_CHECK(app.vectorOfTestModule[i].anotherGroup.getOwner() == &(app.vectorOfTestModule[i]));
+      BOOST_CHECK(app.vectorOfTestModule[i].anotherGroup.foo.getOwner() == &(app.vectorOfTestModule[i].anotherGroup));
     }
   }
 
-  { // checks on third hierarchy level (each module has accessors and variable groups)
+  /*********************************************************************************************************************/
+  /* test correct behaviour when using a std::vector of ModuleGroup, ApplicationModule and VariableGroup at the same
+   * time */
+
+  BOOST_AUTO_TEST_CASE(testVectorsOfAllModules) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testVectorsOfAllModules" << std::endl;
+
+    // create app with a vector containing 10 modules
+    size_t nInstances = 10;
+    VectorOfEverythingApp app(nInstances);
+
+    //-------------------------------------------------------------------------------------------------------------------
+    // the app creates the 10 module instances, check if this is done proplery (a quite redundant test...)
+    BOOST_CHECK(app.vectorOfVectorModuleGroup.size() == nInstances);
     for(size_t i = 0; i < nInstances; ++i) {
+      BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule.size() == nInstances);
       for(size_t k = 0; k < nInstances; ++k) {
-        // search for accessors
-        std::list<ctk::VariableNetworkNode> accList =
-            app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].getAccessorList();
-        BOOST_CHECK_EQUAL(accList.size(), 2);
-        size_t someInputFound = 0;
-        size_t someOutputFound = 0;
-        for(const auto& acc : accList) {
-          if(acc == ctk::VariableNetworkNode(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someInput)) {
-            someInputFound++;
-          }
-          if(acc == ctk::VariableNetworkNode(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someOutput)) {
-            someOutputFound++;
+        BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup.size() == nInstances);
+      }
+    }
+
+    //-------------------------------------------------------------------------------------------------------------------
+    // check presence in lists (getSubmoduleList() and getAccessorList())
+
+    { // checks on first hierarchy level (application has the list of module groups)
+      std::list<ctk::Module*> list = app.getSubmoduleList();
+      BOOST_CHECK(list.size() == nInstances);
+      std::map<size_t, size_t> found;
+      for(size_t i = 0; i < nInstances; ++i) {
+        found[i] = 0;
+      }
+      for(const auto* mod : list) {
+        for(size_t i = 0; i < nInstances; ++i) {
+          if(mod == &(app.vectorOfVectorModuleGroup[i])) {
+            found[i]++;
           }
         }
-        BOOST_CHECK_EQUAL(someInputFound, 1);
-        BOOST_CHECK_EQUAL(someOutputFound, 1);
+      }
+      for(size_t i = 0; i < nInstances; ++i) {
+        BOOST_CHECK(found[i] == 1);
+      }
+    }
 
-        // search for variable groups
-        std::list<ctk::Module*> modList = app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].getSubmoduleList();
-        BOOST_CHECK_EQUAL(modList.size(), nInstances + 1);
+    { // checks on second hierarchy level (each module group has the list of modules)
+      for(size_t i = 0; i < nInstances; ++i) {
+        std::list<ctk::Module*> list = app.vectorOfVectorModuleGroup[i].getSubmoduleList();
+        BOOST_CHECK(list.size() == nInstances);
 
-        std::map<size_t, size_t> someGroupFound;
-        for(size_t m = 0; m < nInstances; ++m) {
-          someGroupFound[m] = 0;
+        std::map<size_t, size_t> found;
+        for(size_t k = 0; k < nInstances; ++k) {
+          found[k] = 0;
         }
-        size_t anotherGroupFound = 0;
-        for(const auto* mod : modList) {
-          for(size_t m = 0; m < nInstances; ++m) {
-            if(mod == &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m])) {
-              someGroupFound[m]++;
+        for(const auto* mod : list) {
+          for(size_t k = 0; k < nInstances; ++k) {
+            if(mod == &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k])) {
+              found[k]++;
             }
           }
-          if(mod == &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].anotherGroup)) {
-            anotherGroupFound++;
-          }
         }
-        for(size_t m = 0; m < nInstances; ++m) {
-          BOOST_CHECK_EQUAL(someGroupFound[m], 1);
+        for(size_t k = 0; k < nInstances; ++k) {
+          BOOST_CHECK(found[k] == 1);
         }
-        BOOST_CHECK_EQUAL(anotherGroupFound, 1);
       }
     }
-  }
 
-  { // checks on fourth hierarchy level (each variable group has accessors)
-    for(size_t i = 0; i < nInstances; ++i) {
-      for(size_t k = 0; k < nInstances; ++k) {
-        for(size_t m = 0; m < nInstances; ++m) {
+    { // checks on third hierarchy level (each module has accessors and variable groups)
+      for(size_t i = 0; i < nInstances; ++i) {
+        for(size_t k = 0; k < nInstances; ++k) {
           // search for accessors
           std::list<ctk::VariableNetworkNode> accList =
-              app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].getAccessorList();
+              app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].getAccessorList();
           BOOST_CHECK_EQUAL(accList.size(), 2);
-          size_t inGroupFound = 0;
-          size_t alsoInGroupFound = 0;
+          size_t someInputFound = 0;
+          size_t someOutputFound = 0;
           for(const auto& acc : accList) {
-            if(acc ==
-                ctk::VariableNetworkNode(
-                    app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].inGroup)) {
-              inGroupFound++;
+            if(acc == ctk::VariableNetworkNode(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someInput)) {
+              someInputFound++;
             }
-            if(acc ==
-                ctk::VariableNetworkNode(
-                    app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].alsoInGroup)) {
-              alsoInGroupFound++;
+            if(acc == ctk::VariableNetworkNode(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someOutput)) {
+              someOutputFound++;
             }
           }
-          BOOST_CHECK_EQUAL(inGroupFound, 1);
-          BOOST_CHECK_EQUAL(alsoInGroupFound, 1);
+          BOOST_CHECK_EQUAL(someInputFound, 1);
+          BOOST_CHECK_EQUAL(someOutputFound, 1);
 
-          // make sure no further subgroups exist
-          BOOST_CHECK_EQUAL(
-              app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].getSubmoduleList().size(),
-              0);
+          // search for variable groups
+          std::list<ctk::Module*> modList = app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].getSubmoduleList();
+          BOOST_CHECK_EQUAL(modList.size(), nInstances + 1);
+
+          std::map<size_t, size_t> someGroupFound;
+          for(size_t m = 0; m < nInstances; ++m) {
+            someGroupFound[m] = 0;
+          }
+          size_t anotherGroupFound = 0;
+          for(const auto* mod : modList) {
+            for(size_t m = 0; m < nInstances; ++m) {
+              if(mod == &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m])) {
+                someGroupFound[m]++;
+              }
+            }
+            if(mod == &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].anotherGroup)) {
+              anotherGroupFound++;
+            }
+          }
+          for(size_t m = 0; m < nInstances; ++m) {
+            BOOST_CHECK_EQUAL(someGroupFound[m], 1);
+          }
+          BOOST_CHECK_EQUAL(anotherGroupFound, 1);
         }
       }
     }
-  }
 
-  //-------------------------------------------------------------------------------------------------------------------
-  // check ownerships
-  for(size_t i = 0; i < nInstances; ++i) {
-    BOOST_CHECK(app.vectorOfVectorModuleGroup[i].getOwner() == &app);
-    for(size_t k = 0; k < nInstances; ++k) {
-      BOOST_CHECK(
-          app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].getOwner() == &(app.vectorOfVectorModuleGroup[i]));
-      BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someInput.getOwner() ==
-          &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k]));
-      BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someOutput.getOwner() ==
-          &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k]));
-      for(size_t m = 0; m < nInstances; ++m) {
-        BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].getOwner() ==
-            &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k]));
-        BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].inGroup.getOwner() ==
-            &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m]));
-        BOOST_CHECK(
-            app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].alsoInGroup.getOwner() ==
-            &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m]));
-      }
-    }
-  }
+    { // checks on fourth hierarchy level (each variable group has accessors)
+      for(size_t i = 0; i < nInstances; ++i) {
+        for(size_t k = 0; k < nInstances; ++k) {
+          for(size_t m = 0; m < nInstances; ++m) {
+            // search for accessors
+            std::list<ctk::VariableNetworkNode> accList =
+                app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].getAccessorList();
+            BOOST_CHECK_EQUAL(accList.size(), 2);
+            size_t inGroupFound = 0;
+            size_t alsoInGroupFound = 0;
+            for(const auto& acc : accList) {
+              if(acc ==
+                  ctk::VariableNetworkNode(
+                      app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].inGroup)) {
+                inGroupFound++;
+              }
+              if(acc ==
+                  ctk::VariableNetworkNode(
+                      app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].alsoInGroup)) {
+                alsoInGroupFound++;
+              }
+            }
+            BOOST_CHECK_EQUAL(inGroupFound, 1);
+            BOOST_CHECK_EQUAL(alsoInGroupFound, 1);
 
-  //-------------------------------------------------------------------------------------------------------------------
-  // check pointers to accessors in VariableNetworkNode
-  for(size_t i = 0; i < nInstances; ++i) {
-    for(size_t k = 0; k < nInstances; ++k) {
-      {
-        const auto* a =
-            &(static_cast<ctk::VariableNetworkNode>(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someInput)
-                    .getAppAccessorNoType());
-        const auto* b = &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someInput);
-        BOOST_CHECK(a == b);
-      }
-      {
-        const auto* a =
-            &(static_cast<ctk::VariableNetworkNode>(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someOutput)
-                    .getAppAccessorNoType());
-        const auto* b = &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someOutput);
-        BOOST_CHECK(a == b);
-      }
-      for(size_t m = 0; m < nInstances; ++m) {
-        {
-          const auto* a = &(static_cast<ctk::VariableNetworkNode>(
-              app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].inGroup)
-                                .getAppAccessorNoType());
-          const auto* b = &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].inGroup);
-          BOOST_CHECK(a == b);
-        }
-        {
-          const auto* a = &(static_cast<ctk::VariableNetworkNode>(
-              app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].alsoInGroup)
-                                .getAppAccessorNoType());
-          const auto* b = &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].alsoInGroup);
-          BOOST_CHECK(a == b);
+            // make sure no further subgroups exist
+            BOOST_CHECK_EQUAL(
+                app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].getSubmoduleList().size(),
+                0);
+          }
         }
       }
     }
-  }
 
-  //-------------------------------------------------------------------------------------------------------------------
-  // check model
-  { // check presence of all PVs (and indirectly the directories)
-    size_t nFound = 0;
-    std::set<std::string> pvNames;
-
-    auto checker = [&](auto proxy) {
-      pvNames.emplace(proxy.getFullyQualifiedPath());
-      ++nFound;
-    };
-
-    app.getModel().visit(
-        checker, ctk::Model::depthFirstSearch, ctk::Model::keepProcessVariables, ctk::Model::keepParenthood);
-
-    size_t nExpected = 0;
+    //-------------------------------------------------------------------------------------------------------------------
+    // check ownerships
     for(size_t i = 0; i < nInstances; ++i) {
-      std::string mgName = "/testModule_" + std::to_string(i) + "_instance";
+      BOOST_CHECK(app.vectorOfVectorModuleGroup[i].getOwner() == &app);
       for(size_t k = 0; k < nInstances; ++k) {
-        std::string amName = mgName + "/test_" + std::to_string(k);
-        for(size_t l = 0; l < nInstances; ++l) {
-          std::string vgName = amName + "/testGroup_" + std::to_string(l);
-          BOOST_CHECK(pvNames.count(vgName + "/inGroup"));
-          BOOST_CHECK(pvNames.count(vgName + "/alsoInGroup"));
-          nExpected += 2;
+        BOOST_CHECK(
+            app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].getOwner() == &(app.vectorOfVectorModuleGroup[i]));
+        BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someInput.getOwner() ==
+            &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k]));
+        BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someOutput.getOwner() ==
+            &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k]));
+        for(size_t m = 0; m < nInstances; ++m) {
+          BOOST_CHECK(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].getOwner() ==
+              &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k]));
+          BOOST_CHECK(
+              app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].inGroup.getOwner() ==
+              &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m]));
+          BOOST_CHECK(
+              app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].alsoInGroup.getOwner() ==
+              &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m]));
         }
-
-        BOOST_CHECK(pvNames.count(amName + "/nameOfSomeInput"));
-        BOOST_CHECK(pvNames.count(amName + "/someOutput"));
-        BOOST_CHECK(pvNames.count(amName + "/anotherName/foo"));
-        nExpected += 3;
       }
     }
 
-    assert(nExpected == 2 * pow(nInstances, 3) + 3 * pow(nInstances, 2)); // = 2300 with nInstances = 10
-    BOOST_TEST(nFound == nExpected);
-  }
-
-  { // check presence of all module groups
-    size_t nFound = 0;
-    std::set<std::string> mgNames;
-
-    auto checker = [&](auto proxy) {
-      mgNames.emplace(proxy.getName());
-      ++nFound;
-    };
-
-    app.getModel().visit(
-        checker, ctk::Model::adjacentOutSearch, ctk::Model::keepOwnership, ctk::Model::keepModuleGroups);
-
+    //-------------------------------------------------------------------------------------------------------------------
+    // check pointers to accessors in VariableNetworkNode
     for(size_t i = 0; i < nInstances; ++i) {
-      std::string mgName = "testModule_" + std::to_string(i) + "_instance";
-      BOOST_CHECK(mgNames.count(mgName));
+      for(size_t k = 0; k < nInstances; ++k) {
+        {
+          const auto* a = &(
+              static_cast<ctk::VariableNetworkNode>(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someInput)
+                  .getAppAccessorNoType());
+          const auto* b = &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someInput);
+          BOOST_CHECK(a == b);
+        }
+        {
+          const auto* a = &(
+              static_cast<ctk::VariableNetworkNode>(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someOutput)
+                  .getAppAccessorNoType());
+          const auto* b = &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].someOutput);
+          BOOST_CHECK(a == b);
+        }
+        for(size_t m = 0; m < nInstances; ++m) {
+          {
+            const auto* a = &(static_cast<ctk::VariableNetworkNode>(
+                app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].inGroup)
+                                  .getAppAccessorNoType());
+            const auto* b = &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].inGroup);
+            BOOST_CHECK(a == b);
+          }
+          {
+            const auto* a = &(static_cast<ctk::VariableNetworkNode>(
+                app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].alsoInGroup)
+                                  .getAppAccessorNoType());
+            const auto* b =
+                &(app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].vectorOfSomeGroup[m].alsoInGroup);
+            BOOST_CHECK(a == b);
+          }
+        }
+      }
     }
 
-    BOOST_TEST(nFound == nInstances);
-  }
-
-  { // check presence of all application modules
-    for(size_t i = 0; i < nInstances; ++i) {
+    //-------------------------------------------------------------------------------------------------------------------
+    // check model
+    { // check presence of all PVs (and indirectly the directories)
       size_t nFound = 0;
-      std::set<std::string> amNames;
+      std::set<std::string> pvNames;
 
       auto checker = [&](auto proxy) {
-        amNames.emplace(proxy.getName());
+        pvNames.emplace(proxy.getFullyQualifiedPath());
         ++nFound;
       };
 
-      app.vectorOfVectorModuleGroup[i].getModel().visit(
-          checker, ctk::Model::adjacentOutSearch, ctk::Model::keepOwnership, ctk::Model::keepApplicationModules);
+      app.getModel().visit(
+          checker, ctk::Model::depthFirstSearch, ctk::Model::keepProcessVariables, ctk::Model::keepParenthood);
 
-      for(size_t k = 0; k < nInstances; ++k) {
-        std::string amName = "test_" + std::to_string(k);
-        BOOST_CHECK(amNames.count(amName));
+      size_t nExpected = 0;
+      for(size_t i = 0; i < nInstances; ++i) {
+        std::string mgName = "/testModule_" + std::to_string(i) + "_instance";
+        for(size_t k = 0; k < nInstances; ++k) {
+          std::string amName = mgName + "/test_" + std::to_string(k);
+          for(size_t l = 0; l < nInstances; ++l) {
+            std::string vgName = amName + "/testGroup_" + std::to_string(l);
+            BOOST_CHECK(pvNames.count(vgName + "/inGroup"));
+            BOOST_CHECK(pvNames.count(vgName + "/alsoInGroup"));
+            nExpected += 2;
+          }
+
+          BOOST_CHECK(pvNames.count(amName + "/nameOfSomeInput"));
+          BOOST_CHECK(pvNames.count(amName + "/someOutput"));
+          BOOST_CHECK(pvNames.count(amName + "/anotherName/foo"));
+          nExpected += 3;
+        }
+      }
+
+      assert(nExpected == 2 * pow(nInstances, 3) + 3 * pow(nInstances, 2)); // = 2300 with nInstances = 10
+      BOOST_TEST(nFound == nExpected);
+    }
+
+    { // check presence of all module groups
+      size_t nFound = 0;
+      std::set<std::string> mgNames;
+
+      auto checker = [&](auto proxy) {
+        mgNames.emplace(proxy.getName());
+        ++nFound;
+      };
+
+      app.getModel().visit(
+          checker, ctk::Model::adjacentOutSearch, ctk::Model::keepOwnership, ctk::Model::keepModuleGroups);
+
+      for(size_t i = 0; i < nInstances; ++i) {
+        std::string mgName = "testModule_" + std::to_string(i) + "_instance";
+        BOOST_CHECK(mgNames.count(mgName));
       }
 
       BOOST_TEST(nFound == nInstances);
     }
-  }
 
-  { // check presence of all variable groups
-    for(size_t i = 0; i < nInstances; ++i) {
-      for(size_t k = 0; k < nInstances; ++k) {
+    { // check presence of all application modules
+      for(size_t i = 0; i < nInstances; ++i) {
         size_t nFound = 0;
-        std::set<std::string> vgNames;
+        std::set<std::string> amNames;
 
         auto checker = [&](auto proxy) {
-          vgNames.emplace(proxy.getName());
+          amNames.emplace(proxy.getName());
           ++nFound;
         };
 
-        app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].getModel().visit(
-            checker, ctk::Model::adjacentOutSearch, ctk::Model::keepOwnership, ctk::Model::keepVariableGroups);
+        app.vectorOfVectorModuleGroup[i].getModel().visit(
+            checker, ctk::Model::adjacentOutSearch, ctk::Model::keepOwnership, ctk::Model::keepApplicationModules);
 
-        BOOST_CHECK(vgNames.count("anotherName"));
-        for(size_t l = 0; l < nInstances; ++l) {
-          std::string vgName = "testGroup_" + std::to_string(l);
-          BOOST_CHECK(vgNames.count(vgName));
+        for(size_t k = 0; k < nInstances; ++k) {
+          std::string amName = "test_" + std::to_string(k);
+          BOOST_CHECK(amNames.count(amName));
         }
 
-        BOOST_TEST(nFound == nInstances + 1);
+        BOOST_TEST(nFound == nInstances);
+      }
+    }
+
+    { // check presence of all variable groups
+      for(size_t i = 0; i < nInstances; ++i) {
+        for(size_t k = 0; k < nInstances; ++k) {
+          size_t nFound = 0;
+          std::set<std::string> vgNames;
+
+          auto checker = [&](auto proxy) {
+            vgNames.emplace(proxy.getName());
+            ++nFound;
+          };
+
+          app.vectorOfVectorModuleGroup[i].vectorOfVectorModule[k].getModel().visit(
+              checker, ctk::Model::adjacentOutSearch, ctk::Model::keepOwnership, ctk::Model::keepVariableGroups);
+
+          BOOST_CHECK(vgNames.count("anotherName"));
+          for(size_t l = 0; l < nInstances; ++l) {
+            std::string vgName = "testGroup_" + std::to_string(l);
+            BOOST_CHECK(vgNames.count(vgName));
+          }
+
+          BOOST_TEST(nFound == nInstances + 1);
+        }
       }
     }
   }
-}
 
-/*********************************************************************************************************************/
-/* test late initialisation of modules using the assignment operator */
+  /*********************************************************************************************************************/
+  /* test late initialisation of modules using the assignment operator */
 
-BOOST_AUTO_TEST_CASE(test_moveAssignmentOperator) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> test_moveAssignmentOperator" << std::endl;
-  std::cout << std::endl;
+  BOOST_AUTO_TEST_CASE(test_moveAssignmentOperator) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> test_moveAssignmentOperator" << std::endl;
+    std::cout << std::endl;
 
-  AssignModuleLaterApp app;
+    AssignModuleLaterApp app;
 
-  BOOST_CHECK(app.modGroupInstanceToAssignLater.getName() == "modGroupInstanceToAssignLater");
-  BOOST_CHECK(app.modGroupInstanceToAssignLater.getDescription() ==
-      "This instance of VectorModuleGroup was assigned using the operator=()");
+    BOOST_CHECK(app.modGroupInstanceToAssignLater.getName() == "modGroupInstanceToAssignLater");
+    BOOST_CHECK(app.modGroupInstanceToAssignLater.getDescription() ==
+        "This instance of VectorModuleGroup was assigned using the operator=()");
 
-  BOOST_CHECK(app.modInstanceToAssignLater.getName() == "modInstanceToAssignLater");
-  BOOST_CHECK(app.modInstanceToAssignLater.getDescription() ==
-      "This instance of VectorModule was assigned using the operator=()");
+    BOOST_CHECK(app.modInstanceToAssignLater.getName() == "modInstanceToAssignLater");
+    BOOST_CHECK(app.modInstanceToAssignLater.getDescription() ==
+        "This instance of VectorModule was assigned using the operator=()");
 
-  auto list = app.getSubmoduleList();
-  BOOST_CHECK(list.size() == 2);
+    auto list = app.getSubmoduleList();
+    BOOST_CHECK(list.size() == 2);
 
-  bool modGroupInstanceToAssignLater_found = false;
-  bool modInstanceToAssignLater_found = false;
-  for(const auto* mod : list) {
-    if(mod == &(app.modGroupInstanceToAssignLater)) {
-      modGroupInstanceToAssignLater_found = true;
+    bool modGroupInstanceToAssignLater_found = false;
+    bool modInstanceToAssignLater_found = false;
+    for(const auto* mod : list) {
+      if(mod == &(app.modGroupInstanceToAssignLater)) {
+        modGroupInstanceToAssignLater_found = true;
+      }
+      if(mod == &(app.modInstanceToAssignLater)) {
+        modInstanceToAssignLater_found = true;
+      }
     }
-    if(mod == &(app.modInstanceToAssignLater)) {
-      modInstanceToAssignLater_found = true;
-    }
+
+    BOOST_CHECK(modGroupInstanceToAssignLater_found);
+    BOOST_CHECK(modInstanceToAssignLater_found);
+    BOOST_CHECK_EQUAL(app.modGroupInstanceToAssignLater.getSubmoduleList().size(), 42);
+    BOOST_CHECK_EQUAL(app.modInstanceToAssignLater.getSubmoduleList().size(), 14);
   }
 
-  BOOST_CHECK(modGroupInstanceToAssignLater_found);
-  BOOST_CHECK(modInstanceToAssignLater_found);
-  BOOST_CHECK_EQUAL(app.modGroupInstanceToAssignLater.getSubmoduleList().size(), 42);
-  BOOST_CHECK_EQUAL(app.modInstanceToAssignLater.getSubmoduleList().size(), 14);
-}
+} // namespace Tests::testModules

--- a/tests/executables_src/testOptimiseUnmappedVariables.cc
+++ b/tests/executables_src/testOptimiseUnmappedVariables.cc
@@ -3,7 +3,7 @@
 #include <chrono>
 #include <future>
 
-#define BOOST_TEST_MODULE testApplication
+#define BOOST_TEST_MODULE testOptimiseUnmappedVariables
 
 #include "Application.h"
 #include "Multiplier.h"
@@ -19,107 +19,111 @@
 #include <boost/test/included/unit_test.hpp>
 #undef BOOST_NO_EXCEPTIONS
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testOptimiseUnmappedVariables {
 
-/*********************************************************************************************************************/
-/* Application without name */
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
-struct TestApp : public ctk::Application {
-  explicit TestApp(const std::string& name) : ctk::Application(name) {}
-  ~TestApp() override { shutdown(); }
+  /*********************************************************************************************************************/
+  /* Application without name */
 
-  ctk::ConstMultiplier<double> multiplierD{this, "Multiplier", "Some module", 42};
-  ctk::ScalarPipe<double> pipe{this, "/Multiplier/output", "/mySubModule/output", "unit", "Some pipe module"};
-};
+  struct TestApp : public ctk::Application {
+    explicit TestApp(const std::string& name) : ctk::Application(name) {}
+    ~TestApp() override { shutdown(); }
 
-/*********************************************************************************************************************/
+    ctk::ConstMultiplier<double> multiplierD{this, "Multiplier", "Some module", 42};
+    ctk::ScalarPipe<double> pipe{this, "/Multiplier/output", "/mySubModule/output", "unit", "Some pipe module"};
+  };
 
-BOOST_AUTO_TEST_CASE(testOptimiseUnmappedVariables) {
-  std::cout << "***************************************************************" << std::endl;
-  std::cout << "==> testOptimiseUnmappedVariables" << std::endl;
+  /*********************************************************************************************************************/
 
-  // test without even calling the function
-  {
-    TestApp app("testApp");
-    app.getModel().writeGraphViz("testOptimiseUnmappedVariables.dot");
-    ctk::TestFacility test{app};
-    auto input = test.getScalar<double>("/Multiplier/input");
-    auto tap = test.getScalar<double>("/Multiplier/output");
-    auto output = test.getScalar<double>("/mySubModule/output");
-    test.runApplication();
-    input = 10;
-    input.write();
-    test.stepApplication();
-    BOOST_CHECK(tap.readNonBlocking());
-    BOOST_CHECK_CLOSE(double(tap), 420., 0.001);
-    BOOST_CHECK(!tap.readNonBlocking());
-    BOOST_CHECK(output.readNonBlocking());
-    BOOST_CHECK_CLOSE(double(output), 420., 0.001);
-    BOOST_CHECK(!output.readNonBlocking());
+  BOOST_AUTO_TEST_CASE(testOptimiseUnmappedVariables) {
+    std::cout << "***************************************************************" << std::endl;
+    std::cout << "==> testOptimiseUnmappedVariables" << std::endl;
+
+    // test without even calling the function
+    {
+      TestApp app("testApp");
+      app.getModel().writeGraphViz("testOptimiseUnmappedVariables.dot");
+      ctk::TestFacility test{app};
+      auto input = test.getScalar<double>("/Multiplier/input");
+      auto tap = test.getScalar<double>("/Multiplier/output");
+      auto output = test.getScalar<double>("/mySubModule/output");
+      test.runApplication();
+      input = 10;
+      input.write();
+      test.stepApplication();
+      BOOST_CHECK(tap.readNonBlocking());
+      BOOST_CHECK_CLOSE(double(tap), 420., 0.001);
+      BOOST_CHECK(!tap.readNonBlocking());
+      BOOST_CHECK(output.readNonBlocking());
+      BOOST_CHECK_CLOSE(double(output), 420., 0.001);
+      BOOST_CHECK(!output.readNonBlocking());
+    }
+
+    // test passing empty set
+    {
+      TestApp app("testApp");
+      ctk::TestFacility test{app};
+      auto input = test.getScalar<double>("/Multiplier/input");
+      auto tap = test.getScalar<double>("/Multiplier/output");
+      auto output = test.getScalar<double>("/mySubModule/output");
+      app.optimiseUnmappedVariables({});
+      test.runApplication();
+      input = 10;
+      input.write();
+      test.stepApplication();
+      BOOST_CHECK(tap.readNonBlocking());
+      BOOST_CHECK_CLOSE(double(tap), 420., 0.001);
+      BOOST_CHECK(!tap.readNonBlocking());
+      BOOST_CHECK(output.readNonBlocking());
+      BOOST_CHECK_CLOSE(double(output), 420., 0.001);
+      BOOST_CHECK(!output.readNonBlocking());
+    }
+
+    // test passing single variable
+    {
+      TestApp app("testApp");
+      ctk::TestFacility test{app};
+      auto input = test.getScalar<double>("/Multiplier/input");
+      auto tap = test.getScalar<double>("/Multiplier/output");
+      auto output = test.getScalar<double>("/mySubModule/output");
+      app.optimiseUnmappedVariables({"/Multiplier/output"});
+      test.runApplication();
+      input = 10;
+      input.write();
+      test.stepApplication();
+      BOOST_CHECK(!tap.readNonBlocking());
+      BOOST_CHECK(output.readNonBlocking());
+      BOOST_CHECK_CLOSE(double(output), 420., 0.001);
+      BOOST_CHECK(!output.readNonBlocking());
+    }
+
+    // test passing two variables
+    {
+      TestApp app("testApp");
+      ctk::TestFacility test{app};
+      auto input = test.getScalar<double>("/Multiplier/input");
+      auto tap = test.getScalar<double>("/Multiplier/output");
+      auto output = test.getScalar<double>("/mySubModule/output");
+      app.optimiseUnmappedVariables({"/Multiplier/output", "/mySubModule/output"});
+      test.runApplication();
+      input = 10;
+      input.write();
+      test.stepApplication();
+      BOOST_CHECK(!tap.readNonBlocking());
+      BOOST_CHECK(!output.readNonBlocking());
+    }
+
+    // test passing unknown variables
+    {
+      TestApp app("testApp");
+      ctk::TestFacility test{app};
+      auto input = test.getScalar<double>("/Multiplier/input");
+      auto tap = test.getScalar<double>("/Multiplier/output");
+      auto output = test.getScalar<double>("/mySubModule/output");
+      BOOST_CHECK_THROW(app.optimiseUnmappedVariables({"/Multiplier/output", "/this/is/not/known"}), std::out_of_range);
+    }
   }
 
-  // test passing empty set
-  {
-    TestApp app("testApp");
-    ctk::TestFacility test{app};
-    auto input = test.getScalar<double>("/Multiplier/input");
-    auto tap = test.getScalar<double>("/Multiplier/output");
-    auto output = test.getScalar<double>("/mySubModule/output");
-    app.optimiseUnmappedVariables({});
-    test.runApplication();
-    input = 10;
-    input.write();
-    test.stepApplication();
-    BOOST_CHECK(tap.readNonBlocking());
-    BOOST_CHECK_CLOSE(double(tap), 420., 0.001);
-    BOOST_CHECK(!tap.readNonBlocking());
-    BOOST_CHECK(output.readNonBlocking());
-    BOOST_CHECK_CLOSE(double(output), 420., 0.001);
-    BOOST_CHECK(!output.readNonBlocking());
-  }
-
-  // test passing single variable
-  {
-    TestApp app("testApp");
-    ctk::TestFacility test{app};
-    auto input = test.getScalar<double>("/Multiplier/input");
-    auto tap = test.getScalar<double>("/Multiplier/output");
-    auto output = test.getScalar<double>("/mySubModule/output");
-    app.optimiseUnmappedVariables({"/Multiplier/output"});
-    test.runApplication();
-    input = 10;
-    input.write();
-    test.stepApplication();
-    BOOST_CHECK(!tap.readNonBlocking());
-    BOOST_CHECK(output.readNonBlocking());
-    BOOST_CHECK_CLOSE(double(output), 420., 0.001);
-    BOOST_CHECK(!output.readNonBlocking());
-  }
-
-  // test passing two variables
-  {
-    TestApp app("testApp");
-    ctk::TestFacility test{app};
-    auto input = test.getScalar<double>("/Multiplier/input");
-    auto tap = test.getScalar<double>("/Multiplier/output");
-    auto output = test.getScalar<double>("/mySubModule/output");
-    app.optimiseUnmappedVariables({"/Multiplier/output", "/mySubModule/output"});
-    test.runApplication();
-    input = 10;
-    input.write();
-    test.stepApplication();
-    BOOST_CHECK(!tap.readNonBlocking());
-    BOOST_CHECK(!output.readNonBlocking());
-  }
-
-  // test passing unknown variables
-  {
-    TestApp app("testApp");
-    ctk::TestFacility test{app};
-    auto input = test.getScalar<double>("/Multiplier/input");
-    auto tap = test.getScalar<double>("/Multiplier/output");
-    auto output = test.getScalar<double>("/mySubModule/output");
-    BOOST_CHECK_THROW(app.optimiseUnmappedVariables({"/Multiplier/output", "/this/is/not/known"}), std::out_of_range);
-  }
-}
+} // namespace Tests::testOptimiseUnmappedVariables

--- a/tests/executables_src/testProcessVariableRecovery.cc
+++ b/tests/executables_src/testProcessVariableRecovery.cc
@@ -22,203 +22,207 @@
 #include <boost/test/included/unit_test.hpp>
 #undef BOOST_NO_EXCEPTIONS
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testProcessVariableRecovery {
 
-static constexpr std::string_view deviceCDD{"(ExceptionDummy?map=test5.map)"};
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
-/* The test module is writing to the device. It is the "module under test".
- * This is the one whose variables are to be recovered. It is not the place the the
- * application first sees the exception.
- */
-struct TestModule : public ctk::ApplicationModule {
-  TestModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
-      const std::unordered_set<std::string>& tags = {})
-  : ApplicationModule(owner, name, description, tags), mainLoopStarted(2) {}
+  static constexpr std::string_view deviceCDD{"(ExceptionDummy?map=test5.map)"};
 
-  ctk::ScalarPushInput<int32_t> trigger{this, "trigger", "", "This is my trigger."};
-  ctk::ScalarOutput<int32_t> scalarOutput{this, "TO_DEV_SCALAR1", "", "Here I write a scalar"};
-  ctk::ArrayOutput<int32_t> arrayOutput{this, "TO_DEV_ARRAY1", "", 4, "Here I write an array"};
-
-  // We do not use testable mode for this test, so we need this barrier to synchronise to the beginning of the
-  // mainLoop(). This is required to make sure the initial value propagation is done.
-  // execute this right after the Application::run():
-  //   app.testModule.mainLoopStarted.wait(); // make sure the module's mainLoop() is entered
-  boost::barrier mainLoopStarted;
-
-  void mainLoop() override {
-    mainLoopStarted.wait();
-
-    while(true) {
-      scalarOutput = int32_t(trigger);
-      scalarOutput.write();
-      for(uint i = 0; i < 4; i++) {
-        arrayOutput[i] = int32_t(trigger);
-      }
-      arrayOutput.write();
-      trigger.read(); // read the blocking variable at the end so the initial values are propagated
-    }
-  }
-};
-
-/* dummy application */
-struct TestApplication : public ctk::Application {
-  TestApplication() : Application("testSuite") {}
-  ~TestApplication() override { shutdown(); }
-
-  ctk::DeviceModule dev{this, deviceCDD.data(), "/deviceTrigger"};
-  TestModule module{this, "TEST", "The test module"};
-};
-
-/*
- * Test application for the specific case of writing to a read-only accessor. Provides an input to an ApplicationModule
- * from a read-only accessor of the device. For the test, the accessor must not be routed through the control system,
- * the illegal write would be caught by the ControlSystemAdapter, not by the ExceptionHandlingDecorator under test here.
- */
-struct ReadOnlyTestApplication : public ctk::Application {
-  ReadOnlyTestApplication() : Application("ReadOnlytestApp") {}
-  ~ReadOnlyTestApplication() override { shutdown(); }
-
-  ctk::DeviceModule dev{this, deviceCDD.data(), "/weNowNeedATriggerHere"};
-
+  /* The test module is writing to the device. It is the "module under test".
+   * This is the one whose variables are to be recovered. It is not the place the the
+   * application first sees the exception.
+   */
   struct TestModule : public ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
+    TestModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
+        const std::unordered_set<std::string>& tags = {})
+    : ApplicationModule(owner, name, description, tags), mainLoopStarted(2) {}
 
-    ctk::ScalarPushInput<int> start{
-        this, "startTest", "", "This has to be written once, before writing to the device", {"CS"}};
-    ctk::ScalarPollInput<int32_t> scalarROInput{
-        this, "/TEST/FROM_DEV_SCALAR2", "", "Here I read from a scalar RO-register"};
+    ctk::ScalarPushInput<int32_t> trigger{this, "trigger", "", "This is my trigger."};
+    ctk::ScalarOutput<int32_t> scalarOutput{this, "TO_DEV_SCALAR1", "", "Here I write a scalar"};
+    ctk::ArrayOutput<int32_t> arrayOutput{this, "TO_DEV_ARRAY1", "", 4, "Here I write an array"};
+
+    // We do not use testable mode for this test, so we need this barrier to synchronise to the beginning of the
+    // mainLoop(). This is required to make sure the initial value propagation is done.
+    // execute this right after the Application::run():
+    //   app.testModule.mainLoopStarted.wait(); // make sure the module's mainLoop() is entered
+    boost::barrier mainLoopStarted;
 
     void mainLoop() override {
-      // Just to have a blocking read, gives the test time to dumpConnections and explicitly trigger before terminating.
-      start.read();
+      mainLoopStarted.wait();
 
-      scalarROInput = 42;
-      try {
-        scalarROInput.write();
-        BOOST_CHECK_MESSAGE(
-            false, "ReadOnlyTestApplication: Calling write() on input to read-only device register did not throw.");
-      }
-      catch(ChimeraTK::logic_error& e) {
-        const std::string exMsg{e.what()};
-        std::regex exceptionHandlingRegex{"^ChimeraTK::ExceptionhandlingDecorator:*"};
-        std::smatch exMatch;
-
-        std::cout << exMsg << std::endl;
-
-        BOOST_CHECK(std::regex_search(exMsg, exMatch, exceptionHandlingRegex));
+      while(true) {
+        scalarOutput = int32_t(trigger);
+        scalarOutput.write();
+        for(uint i = 0; i < 4; i++) {
+          arrayOutput[i] = int32_t(trigger);
+        }
+        arrayOutput.write();
+        trigger.read(); // read the blocking variable at the end so the initial values are propagated
       }
     }
+  };
 
-  } module{this, "READ_ONLY_TEST", "The test module"};
-};
+  /* dummy application */
+  struct TestApplication : public ctk::Application {
+    TestApplication() : Application("testSuite") {}
+    ~TestApplication() override { shutdown(); }
 
-/*********************************************************************************************************************/
+    ctk::DeviceModule dev{this, deviceCDD.data(), "/deviceTrigger"};
+    TestModule module{this, "TEST", "The test module"};
+  };
 
-BOOST_AUTO_TEST_CASE(testWriteToReadOnly) {
-  std::cout << "testWriteToReadOnly" << std::endl;
+  /*
+   * Test application for the specific case of writing to a read-only accessor. Provides an input to an ApplicationModule
+   * from a read-only accessor of the device. For the test, the accessor must not be routed through the control system,
+   * the illegal write would be caught by the ControlSystemAdapter, not by the ExceptionHandlingDecorator under test here.
+   */
+  struct ReadOnlyTestApplication : public ctk::Application {
+    ReadOnlyTestApplication() : Application("ReadOnlytestApp") {}
+    ~ReadOnlyTestApplication() override { shutdown(); }
 
-  ReadOnlyTestApplication app;
+    ctk::DeviceModule dev{this, deviceCDD.data(), "/weNowNeedATriggerHere"};
 
-  ctk::TestFacility test{app};
-  app.optimiseUnmappedVariables({"/TEST/FROM_DEV_SCALAR2"});
+    struct TestModule : public ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
 
-  test.runApplication();
+      ctk::ScalarPushInput<int> start{
+          this, "startTest", "", "This has to be written once, before writing to the device", {"CS"}};
+      ctk::ScalarPollInput<int32_t> scalarROInput{
+          this, "/TEST/FROM_DEV_SCALAR2", "", "Here I read from a scalar RO-register"};
 
-  // Should trigger the blocking read in ReadOnlyTestApplication's ApplicationModule. It then writes to a read-only
-  // register of the device, which should throw. Check is done in the module's mainLoop. We can not check here, as the
-  // exception gets thrown in the thread of the module.
-  test.writeScalar("/READ_ONLY_TEST/startTest", 1);
-}
+      void mainLoop() override {
+        // Just to have a blocking read, gives the test time to dumpConnections and explicitly trigger before terminating.
+        start.read();
 
-/*********************************************************************************************************************/
+        scalarROInput = 42;
+        try {
+          scalarROInput.write();
+          BOOST_CHECK_MESSAGE(
+              false, "ReadOnlyTestApplication: Calling write() on input to read-only device register did not throw.");
+        }
+        catch(ChimeraTK::logic_error& e) {
+          const std::string exMsg{e.what()};
+          std::regex exceptionHandlingRegex{"^ChimeraTK::ExceptionhandlingDecorator:*"};
+          std::smatch exMatch;
 
-BOOST_AUTO_TEST_CASE(testProcessVariableRecovery) {
-  std::cout << "testProcessVariableRecovery" << std::endl;
-  TestApplication app;
+          std::cout << exMsg << std::endl;
 
-  ctk::TestFacility test{app, false};
-  // Write initial values manually since we do not use the testable mode.
-  // Otherwise the main loops never start.
+          BOOST_CHECK(std::regex_search(exMsg, exMatch, exceptionHandlingRegex));
+        }
+      }
 
-  // initial value for the direct CS->DEV register
-  test.writeScalar("/TEST/TO_DEV_SCALAR2", 42);
-  std::vector<int32_t> array = {99, 99, 99, 99};
-  test.writeArray("/TEST/TO_DEV_ARRAY2", array);
+    } module{this, "READ_ONLY_TEST", "The test module"};
+  };
 
-  // initial value for the trigger
-  test.writeScalar("/TEST/trigger", 0);
+  /*********************************************************************************************************************/
 
-  app.run();
-  app.module.mainLoopStarted.wait();
+  BOOST_AUTO_TEST_CASE(testWriteToReadOnly) {
+    std::cout << "testWriteToReadOnly" << std::endl;
 
-  ctk::Device dummy;
-  dummy.open(deviceCDD.data());
+    ReadOnlyTestApplication app;
 
-  // wait for the device to be opened successfully so the access to the dummy does not throw
-  // (as they use the same backend it now throws if there has been an exception somewhere else)
-  CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(
-                          std::string("/Devices/") + ctk::Utilities::escapeName(deviceCDD.data(), false) + "/status"),
-      0, 10000);
+    ctk::TestFacility test{app};
+    app.optimiseUnmappedVariables({"/TEST/FROM_DEV_SCALAR2"});
 
-  // Check that the initial values are there.
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_SCALAR2"), 42, 10000);
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY2", 1, 0)[0], 99, 10000);
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY2", 1, 1)[0], 99, 10000);
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY2", 1, 2)[0], 99, 10000);
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY2", 1, 3)[0], 99, 10000);
+    test.runApplication();
 
-  // Update device register via application module.
-  auto trigger = test.getScalar<int32_t>("/TEST/trigger");
-  trigger = 100;
-  trigger.write();
-  // Check if the values are updated.
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_SCALAR1"), 100, 10000);
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY1", 1, 0)[0], 100, 10000);
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY1", 1, 1)[0], 100, 10000);
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY1", 1, 2)[0], 100, 10000);
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY1", 1, 3)[0], 100, 10000);
+    // Should trigger the blocking read in ReadOnlyTestApplication's ApplicationModule. It then writes to a read-only
+    // register of the device, which should throw. Check is done in the module's mainLoop. We can not check here, as the
+    // exception gets thrown in the thread of the module.
+    test.writeScalar("/READ_ONLY_TEST/startTest", 1);
+  }
 
-  auto dummyBackend = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-      ctk::BackendFactory::getInstance().createBackend(deviceCDD.data()));
+  /*********************************************************************************************************************/
 
-  // Set the device to throw.
-  dummyBackend->throwExceptionOpen = true;
+  BOOST_AUTO_TEST_CASE(testProcessVariableRecovery) {
+    std::cout << "testProcessVariableRecovery" << std::endl;
+    TestApplication app;
 
-  // Set dummy registers to 0.
-  dummy.write<int32_t>("/CONSTANT/VAR32", 0);
-  dummy.write<int32_t>("/TEST/TO_DEV_SCALAR1", 0);
-  dummy.write<int32_t>("/TEST/TO_DEV_SCALAR2", 0);
-  array = {0, 0, 0, 0};
-  dummy.write("/TEST/TO_DEV_ARRAY1", array);
-  dummy.write("/TEST/TO_DEV_ARRAY2", array);
+    ctk::TestFacility test{app, false};
+    // Write initial values manually since we do not use the testable mode.
+    // Otherwise the main loops never start.
 
-  CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/CONSTANT/VAR32"), 0, 10000);
-  dummyBackend->throwExceptionWrite = true;
-  dummyBackend->throwExceptionRead = true;
+    // initial value for the direct CS->DEV register
+    test.writeScalar("/TEST/TO_DEV_SCALAR2", 42);
+    std::vector<int32_t> array = {99, 99, 99, 99};
+    test.writeArray("/TEST/TO_DEV_ARRAY2", array);
 
-  // Now we trigger the reading module. This should put the device into an error state
-  auto trigger2 = test.getVoid("/deviceTrigger");
-  trigger2.write();
+    // initial value for the trigger
+    test.writeScalar("/TEST/trigger", 0);
 
-  // Verify that the device is in error state.
-  CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
-                          ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
-      1, 10000);
+    app.run();
+    app.module.mainLoopStarted.wait();
 
-  // Set device back to normal.
-  dummyBackend->throwExceptionWrite = false;
-  dummyBackend->throwExceptionRead = false;
-  dummyBackend->throwExceptionOpen = false;
-  // Verify if the device is ready.
-  CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
-                          ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
-      0, 10000);
+    ctk::Device dummy;
+    dummy.open(deviceCDD.data());
 
-  // Device should have the correct values now. Notice that we did not trigger the writer module!
-  BOOST_CHECK_EQUAL(dummy.read<int32_t>("/TEST/TO_DEV_SCALAR2"), 42);
-  BOOST_CHECK((dummy.read<int32_t>("/TEST/TO_DEV_ARRAY2", 0) == std::vector<int32_t>{99, 99, 99, 99}));
+    // wait for the device to be opened successfully so the access to the dummy does not throw
+    // (as they use the same backend it now throws if there has been an exception somewhere else)
+    CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(
+                            std::string("/Devices/") + ctk::Utilities::escapeName(deviceCDD.data(), false) + "/status"),
+        0, 10000);
 
-  BOOST_CHECK_EQUAL(dummy.read<int32_t>("/TEST/TO_DEV_SCALAR1"), 100);
-  BOOST_CHECK((dummy.read<int32_t>("/TEST/TO_DEV_ARRAY1", 0) == std::vector<int32_t>{100, 100, 100, 100}));
-}
+    // Check that the initial values are there.
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_SCALAR2"), 42, 10000);
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY2", 1, 0)[0], 99, 10000);
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY2", 1, 1)[0], 99, 10000);
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY2", 1, 2)[0], 99, 10000);
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY2", 1, 3)[0], 99, 10000);
+
+    // Update device register via application module.
+    auto trigger = test.getScalar<int32_t>("/TEST/trigger");
+    trigger = 100;
+    trigger.write();
+    // Check if the values are updated.
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_SCALAR1"), 100, 10000);
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY1", 1, 0)[0], 100, 10000);
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY1", 1, 1)[0], 100, 10000);
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY1", 1, 2)[0], 100, 10000);
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/TEST/TO_DEV_ARRAY1", 1, 3)[0], 100, 10000);
+
+    auto dummyBackend = boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+        ctk::BackendFactory::getInstance().createBackend(deviceCDD.data()));
+
+    // Set the device to throw.
+    dummyBackend->throwExceptionOpen = true;
+
+    // Set dummy registers to 0.
+    dummy.write<int32_t>("/CONSTANT/VAR32", 0);
+    dummy.write<int32_t>("/TEST/TO_DEV_SCALAR1", 0);
+    dummy.write<int32_t>("/TEST/TO_DEV_SCALAR2", 0);
+    array = {0, 0, 0, 0};
+    dummy.write("/TEST/TO_DEV_ARRAY1", array);
+    dummy.write("/TEST/TO_DEV_ARRAY2", array);
+
+    CHECK_EQUAL_TIMEOUT(dummy.read<int32_t>("/CONSTANT/VAR32"), 0, 10000);
+    dummyBackend->throwExceptionWrite = true;
+    dummyBackend->throwExceptionRead = true;
+
+    // Now we trigger the reading module. This should put the device into an error state
+    auto trigger2 = test.getVoid("/deviceTrigger");
+    trigger2.write();
+
+    // Verify that the device is in error state.
+    CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
+                            ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
+        1, 10000);
+
+    // Set device back to normal.
+    dummyBackend->throwExceptionWrite = false;
+    dummyBackend->throwExceptionRead = false;
+    dummyBackend->throwExceptionOpen = false;
+    // Verify if the device is ready.
+    CHECK_EQUAL_TIMEOUT(test.readScalar<int32_t>(ctk::RegisterPath("/Devices") /
+                            ctk::Utilities::escapeName(deviceCDD.data(), false) / "status"),
+        0, 10000);
+
+    // Device should have the correct values now. Notice that we did not trigger the writer module!
+    BOOST_CHECK_EQUAL(dummy.read<int32_t>("/TEST/TO_DEV_SCALAR2"), 42);
+    BOOST_CHECK((dummy.read<int32_t>("/TEST/TO_DEV_ARRAY2", 0) == std::vector<int32_t>{99, 99, 99, 99}));
+
+    BOOST_CHECK_EQUAL(dummy.read<int32_t>("/TEST/TO_DEV_SCALAR1"), 100);
+    BOOST_CHECK((dummy.read<int32_t>("/TEST/TO_DEV_ARRAY1", 0) == std::vector<int32_t>{100, 100, 100, 100}));
+  }
+
+} // namespace Tests::testProcessVariableRecovery

--- a/tests/executables_src/testPropagateDataFaultFlag.cc
+++ b/tests/executables_src/testPropagateDataFaultFlag.cc
@@ -26,1170 +26,1174 @@
 #include <boost/test/included/unit_test.hpp>
 #undef BOOST_NO_EXCEPTIONS
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testPropagateDataFaultFlag {
 
-/* dummy application */
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
-/*********************************************************************************************************************/
+  /* dummy application */
 
-struct TestModule1 : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-  ctk::ScalarPushInput<int> i1{this, "i1", "", ""};
-  ctk::ArrayPushInput<int> i2{this, "i2", "", 2, ""};
-  ctk::ScalarPushInputWB<int> i3{this, "i3", "", ""};
-  ctk::ScalarOutput<int> o1{this, "o1", "", ""};
-  ctk::ArrayOutput<int> o2{this, "o2", "", 2, ""};
-  ctk::StatusOutput oStat{this, "oStat", ""};
-  void mainLoop() override {
-    auto group = readAnyGroup();
-    while(true) {
-      if(i3 > 10) {
-        i3 = 10;
-        i3.write();
+  /*********************************************************************************************************************/
+
+  struct TestModule1 : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+    ctk::ScalarPushInput<int> i1{this, "i1", "", ""};
+    ctk::ArrayPushInput<int> i2{this, "i2", "", 2, ""};
+    ctk::ScalarPushInputWB<int> i3{this, "i3", "", ""};
+    ctk::ScalarOutput<int> o1{this, "o1", "", ""};
+    ctk::ArrayOutput<int> o2{this, "o2", "", 2, ""};
+    ctk::StatusOutput oStat{this, "oStat", ""};
+    void mainLoop() override {
+      auto group = readAnyGroup();
+      while(true) {
+        if(i3 > 10) {
+          i3 = 10;
+          i3.write();
+        }
+        o1 = int(i1);
+        o2[0] = i2[0];
+        o2[1] = i2[1];
+        o1.write();
+        o2.write();
+        if(i1 < 0) {
+          oStat.setDataValidity(ctk::DataValidity::faulty);
+        }
+        oStat.write();
+        group.readAny();
       }
-      o1 = int(i1);
-      o2[0] = i2[0];
-      o2[1] = i2[1];
-      o1.write();
-      o2.write();
-      if(i1 < 0) {
-        oStat.setDataValidity(ctk::DataValidity::faulty);
+    }
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TestModule2 : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+    ctk::ScalarPushInput<int> i1{this, "i1", "", ""};
+    ctk::ArrayPushInput<int> i2{this, "i2", "", 2, ""};
+    ctk::ScalarPushInputWB<int> i3{this, "i3", "", ""};
+    ctk::ScalarPushInput<int> o1{this, "o1", "", ""};
+    ctk::ArrayPushInput<int> o2{this, "o2", "", 2, ""};
+    void mainLoop() override {
+      auto group = readAnyGroup();
+      while(true) {
+        group.readAny();
       }
-      oStat.write();
-      group.readAny();
     }
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TestApplication1 : ctk::Application {
+    TestApplication1() : Application("testSuite") {}
+    ~TestApplication1() override { shutdown(); }
+
+    TestModule1 t1{this, "t1", ""};
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TestApplication2 : ctk::Application {
+    TestApplication2() : Application("testSuite") {}
+    ~TestApplication2() override { shutdown(); }
+
+    TestModule1 a{this, "A", ""};
+    TestModule2 b{this, "A", ""};
+  };
+
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
+
+  // first test without FanOuts of any kind
+  BOOST_AUTO_TEST_CASE(testDirectConnections) {
+    std::cout << "testDirectConnections" << std::endl;
+    TestApplication1 app;
+    app.debugMakeConnections();
+    ctk::TestFacility test(app);
+
+    auto i1 = test.getScalar<int>("/t1/i1");
+    auto i2 = test.getArray<int>("/t1/i2");
+    auto i3 = test.getScalar<int>("/t1/i3");
+    auto o1 = test.getScalar<int>("/t1/o1");
+    auto o2 = test.getArray<int>("/t1/o2");
+    auto oStat = test.getArray<int>("/t1/oStat");
+
+    test.runApplication();
+
+    // test if fault flag propagates to all outputs, except oStat
+    i1 = 1;
+    i1.setDataValidity(ctk::DataValidity::faulty);
+    i1.write();
+    test.stepApplication();
+    o1.read();
+    o2.read();
+    oStat.read();
+    BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(oStat.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(o1), 1);
+    BOOST_CHECK_EQUAL(o2[0], 0);
+    BOOST_CHECK_EQUAL(o2[1], 0);
+
+    // write another value but keep fault flag
+    i1 = 42;
+    BOOST_CHECK(i1.dataValidity() == ctk::DataValidity::faulty);
+    i1.write();
+    test.stepApplication();
+    o1.read();
+    o2.read();
+    BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(o1), 42);
+    BOOST_CHECK_EQUAL(o2[0], 0);
+    BOOST_CHECK_EQUAL(o2[1], 0);
+
+    // a write on the ok variable should not clear the flag
+    i2[0] = 10;
+    i2[1] = 11;
+    BOOST_CHECK(i2.dataValidity() == ctk::DataValidity::ok);
+    i2.write();
+    test.stepApplication();
+    o1.read();
+    o2.read();
+    BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(o1), 42);
+    BOOST_CHECK_EQUAL(o2[0], 10);
+    BOOST_CHECK_EQUAL(o2[1], 11);
+
+    // the return channel does not receive the flag
+    BOOST_CHECK(i3.readNonBlocking() == false);
+    BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::ok);
+    i3 = 20;
+    i3.write();
+    test.stepApplication();
+    o1.read();
+    o2.read();
+    i3.read();
+    BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(o1), 42);
+    BOOST_CHECK_EQUAL(o2[0], 10);
+    BOOST_CHECK_EQUAL(o2[1], 11);
+    BOOST_CHECK_EQUAL(int(i3), 10);
+
+    // clear the flag on i1, i3 does not get it
+    i1 = 3;
+    i1.setDataValidity(ctk::DataValidity::ok);
+    i1.write();
+    test.stepApplication();
+    o1.read();
+    o2.read();
+    BOOST_CHECK(i3.readNonBlocking() == false);
+    BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(o1), 3);
+    BOOST_CHECK_EQUAL(o2[0], 10);
+    BOOST_CHECK_EQUAL(o2[1], 11);
+    BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(i3), 10);
+
+    // send two data fault flags. both need to be cleared before the outputs go back to ok
+    i1 = 120;
+    i1.setDataValidity(ctk::DataValidity::faulty);
+    i1.write();
+    i3 = 121;
+    i3.setDataValidity(ctk::DataValidity::faulty);
+    i3.write();
+    test.stepApplication();
+    o1.readLatest();
+    o2.readLatest();
+    i3.read();
+    BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(o1), 120);
+    BOOST_CHECK_EQUAL(o2[0], 10);
+    BOOST_CHECK_EQUAL(o2[1], 11);
+    BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(i3), 10);
+
+    // clear first flag
+    i1 = 122;
+    i1.setDataValidity(ctk::DataValidity::ok);
+    i1.write();
+    test.stepApplication();
+    o1.read();
+    o2.read();
+    BOOST_CHECK(i3.readNonBlocking() == false);
+    BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(o1), 122);
+    BOOST_CHECK_EQUAL(o2[0], 10);
+    BOOST_CHECK_EQUAL(o2[1], 11);
+    BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(i3), 10);
+
+    // clear second flag
+    i3 = 123;
+    i3.setDataValidity(ctk::DataValidity::ok);
+    i3.write();
+    test.stepApplication();
+    o1.read();
+    o2.read();
+    i3.read();
+    BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(o1), 122);
+    BOOST_CHECK_EQUAL(o2[0], 10);
+    BOOST_CHECK_EQUAL(o2[1], 11);
+    BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(i3), 10);
+
+    // check that oStat can also receive data faulty, if set explicitly
+    i1 = -1;
+    i1.write();
+    test.stepApplication();
+    oStat.readLatest();
+    BOOST_CHECK(oStat.dataValidity() == ctk::DataValidity::faulty);
   }
-};
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-struct TestModule2 : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-  ctk::ScalarPushInput<int> i1{this, "i1", "", ""};
-  ctk::ArrayPushInput<int> i2{this, "i2", "", 2, ""};
-  ctk::ScalarPushInputWB<int> i3{this, "i3", "", ""};
-  ctk::ScalarPushInput<int> o1{this, "o1", "", ""};
-  ctk::ArrayPushInput<int> o2{this, "o2", "", 2, ""};
-  void mainLoop() override {
-    auto group = readAnyGroup();
-    while(true) {
-      group.readAny();
-    }
+  BOOST_AUTO_TEST_CASE(testWithFanOut) {
+    std::cout << "testWithFanOut" << std::endl;
+    TestApplication2 app;
+    ctk::TestFacility test(app);
+
+    auto Ai1 = test.getScalar<int>("A/i1");
+    auto Ai2 = test.getArray<int>("A/i2");
+    auto Ai3 = test.getScalar<int>("A/i3");
+    auto Ao1 = test.getScalar<int>("A/o1");
+    auto Ao2 = test.getArray<int>("A/o2");
+
+    test.runApplication();
+
+    // app.dumpConnections();
+
+    // test if fault flag propagates to all outputs
+    Ai1 = 1;
+    Ai1.setDataValidity(ctk::DataValidity::faulty);
+    Ai1.write();
+    test.stepApplication();
+    Ao1.read();
+    Ao2.read();
+    BOOST_CHECK(Ao1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(Ao2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(Ao1), 1);
+    BOOST_CHECK_EQUAL(Ao2[0], 0);
+    BOOST_CHECK_EQUAL(Ao2[1], 0);
+    BOOST_CHECK(app.b.o1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(app.b.o2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(app.b.o1), 1);
+    BOOST_CHECK_EQUAL(app.b.o2[0], 0);
+    BOOST_CHECK_EQUAL(app.b.o2[1], 0);
+    BOOST_CHECK(app.b.i1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(app.b.i1), 1);
+
+    // send fault flag on a second variable
+    Ai2[0] = 2;
+    Ai2[1] = 3;
+    Ai2.setDataValidity(ctk::DataValidity::faulty);
+    Ai2.write();
+    test.stepApplication();
+    Ao1.read();
+    Ao2.read();
+    BOOST_CHECK(Ao1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(Ao2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(Ao1), 1);
+    BOOST_CHECK_EQUAL(Ao2[0], 2);
+    BOOST_CHECK_EQUAL(Ao2[1], 3);
+    BOOST_CHECK(app.b.o1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(app.b.o2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(app.b.o1), 1);
+    BOOST_CHECK_EQUAL(app.b.o2[0], 2);
+    BOOST_CHECK_EQUAL(app.b.o2[1], 3);
+    BOOST_CHECK(app.b.i2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(app.b.i2[0], 2);
+    BOOST_CHECK_EQUAL(app.b.i2[1], 3);
+
+    // clear fault flag on a second variable
+    Ai2[0] = 4;
+    Ai2[1] = 5;
+    Ai2.setDataValidity(ctk::DataValidity::ok);
+    Ai2.write();
+    test.stepApplication();
+    Ao1.read();
+    Ao2.read();
+    BOOST_CHECK(Ao1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(Ao2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(Ao1), 1);
+    BOOST_CHECK_EQUAL(Ao2[0], 4);
+    BOOST_CHECK_EQUAL(Ao2[1], 5);
+    BOOST_CHECK(app.b.o1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(app.b.o2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(int(app.b.o1), 1);
+    BOOST_CHECK_EQUAL(app.b.o2[0], 4);
+    BOOST_CHECK_EQUAL(app.b.o2[1], 5);
+    BOOST_CHECK(app.b.i2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(app.b.i2[0], 4);
+    BOOST_CHECK_EQUAL(app.b.i2[1], 5);
+
+    // clear fault flag on a first variable
+    Ai1 = 6;
+    Ai1.setDataValidity(ctk::DataValidity::ok);
+    Ai1.write();
+    test.stepApplication();
+    Ao1.read();
+    Ao2.read();
+    BOOST_CHECK(Ao1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(Ao2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(Ao1), 6);
+    BOOST_CHECK_EQUAL(Ao2[0], 4);
+    BOOST_CHECK_EQUAL(Ao2[1], 5);
+    BOOST_CHECK(app.b.o1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(app.b.o2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(app.b.o1), 6);
+    BOOST_CHECK_EQUAL(app.b.o2[0], 4);
+    BOOST_CHECK_EQUAL(app.b.o2[1], 5);
+    BOOST_CHECK(app.b.i1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(app.b.i1), 6);
   }
-};
 
-/*********************************************************************************************************************/
-
-struct TestApplication1 : ctk::Application {
-  TestApplication1() : Application("testSuite") {}
-  ~TestApplication1() override { shutdown(); }
-
-  TestModule1 t1{this, "t1", ""};
-};
-
-/*********************************************************************************************************************/
-
-struct TestApplication2 : ctk::Application {
-  TestApplication2() : Application("testSuite") {}
-  ~TestApplication2() override { shutdown(); }
-
-  TestModule1 a{this, "A", ""};
-  TestModule2 b{this, "A", ""};
-};
-
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
-
-// first test without FanOuts of any kind
-BOOST_AUTO_TEST_CASE(testDirectConnections) {
-  std::cout << "testDirectConnections" << std::endl;
-  TestApplication1 app;
-  app.debugMakeConnections();
-  ctk::TestFacility test(app);
-
-  auto i1 = test.getScalar<int>("/t1/i1");
-  auto i2 = test.getArray<int>("/t1/i2");
-  auto i3 = test.getScalar<int>("/t1/i3");
-  auto o1 = test.getScalar<int>("/t1/o1");
-  auto o2 = test.getArray<int>("/t1/o2");
-  auto oStat = test.getArray<int>("/t1/oStat");
-
-  test.runApplication();
-
-  // test if fault flag propagates to all outputs, except oStat
-  i1 = 1;
-  i1.setDataValidity(ctk::DataValidity::faulty);
-  i1.write();
-  test.stepApplication();
-  o1.read();
-  o2.read();
-  oStat.read();
-  BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(oStat.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(o1), 1);
-  BOOST_CHECK_EQUAL(o2[0], 0);
-  BOOST_CHECK_EQUAL(o2[1], 0);
-
-  // write another value but keep fault flag
-  i1 = 42;
-  BOOST_CHECK(i1.dataValidity() == ctk::DataValidity::faulty);
-  i1.write();
-  test.stepApplication();
-  o1.read();
-  o2.read();
-  BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(o1), 42);
-  BOOST_CHECK_EQUAL(o2[0], 0);
-  BOOST_CHECK_EQUAL(o2[1], 0);
-
-  // a write on the ok variable should not clear the flag
-  i2[0] = 10;
-  i2[1] = 11;
-  BOOST_CHECK(i2.dataValidity() == ctk::DataValidity::ok);
-  i2.write();
-  test.stepApplication();
-  o1.read();
-  o2.read();
-  BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(o1), 42);
-  BOOST_CHECK_EQUAL(o2[0], 10);
-  BOOST_CHECK_EQUAL(o2[1], 11);
-
-  // the return channel does not receive the flag
-  BOOST_CHECK(i3.readNonBlocking() == false);
-  BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::ok);
-  i3 = 20;
-  i3.write();
-  test.stepApplication();
-  o1.read();
-  o2.read();
-  i3.read();
-  BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(o1), 42);
-  BOOST_CHECK_EQUAL(o2[0], 10);
-  BOOST_CHECK_EQUAL(o2[1], 11);
-  BOOST_CHECK_EQUAL(int(i3), 10);
-
-  // clear the flag on i1, i3 does not get it
-  i1 = 3;
-  i1.setDataValidity(ctk::DataValidity::ok);
-  i1.write();
-  test.stepApplication();
-  o1.read();
-  o2.read();
-  BOOST_CHECK(i3.readNonBlocking() == false);
-  BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(o1), 3);
-  BOOST_CHECK_EQUAL(o2[0], 10);
-  BOOST_CHECK_EQUAL(o2[1], 11);
-  BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(i3), 10);
-
-  // send two data fault flags. both need to be cleared before the outputs go back to ok
-  i1 = 120;
-  i1.setDataValidity(ctk::DataValidity::faulty);
-  i1.write();
-  i3 = 121;
-  i3.setDataValidity(ctk::DataValidity::faulty);
-  i3.write();
-  test.stepApplication();
-  o1.readLatest();
-  o2.readLatest();
-  i3.read();
-  BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(o1), 120);
-  BOOST_CHECK_EQUAL(o2[0], 10);
-  BOOST_CHECK_EQUAL(o2[1], 11);
-  BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(i3), 10);
-
-  // clear first flag
-  i1 = 122;
-  i1.setDataValidity(ctk::DataValidity::ok);
-  i1.write();
-  test.stepApplication();
-  o1.read();
-  o2.read();
-  BOOST_CHECK(i3.readNonBlocking() == false);
-  BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(o1), 122);
-  BOOST_CHECK_EQUAL(o2[0], 10);
-  BOOST_CHECK_EQUAL(o2[1], 11);
-  BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(i3), 10);
-
-  // clear second flag
-  i3 = 123;
-  i3.setDataValidity(ctk::DataValidity::ok);
-  i3.write();
-  test.stepApplication();
-  o1.read();
-  o2.read();
-  i3.read();
-  BOOST_CHECK(o1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(o2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(o1), 122);
-  BOOST_CHECK_EQUAL(o2[0], 10);
-  BOOST_CHECK_EQUAL(o2[1], 11);
-  BOOST_CHECK(i3.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(i3), 10);
-
-  // check that oStat can also receive data faulty, if set explicitly
-  i1 = -1;
-  i1.write();
-  test.stepApplication();
-  oStat.readLatest();
-  BOOST_CHECK(oStat.dataValidity() == ctk::DataValidity::faulty);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testWithFanOut) {
-  std::cout << "testWithFanOut" << std::endl;
-  TestApplication2 app;
-  ctk::TestFacility test(app);
-
-  auto Ai1 = test.getScalar<int>("A/i1");
-  auto Ai2 = test.getArray<int>("A/i2");
-  auto Ai3 = test.getScalar<int>("A/i3");
-  auto Ao1 = test.getScalar<int>("A/o1");
-  auto Ao2 = test.getArray<int>("A/o2");
-
-  test.runApplication();
-
-  // app.dumpConnections();
-
-  // test if fault flag propagates to all outputs
-  Ai1 = 1;
-  Ai1.setDataValidity(ctk::DataValidity::faulty);
-  Ai1.write();
-  test.stepApplication();
-  Ao1.read();
-  Ao2.read();
-  BOOST_CHECK(Ao1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(Ao2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(Ao1), 1);
-  BOOST_CHECK_EQUAL(Ao2[0], 0);
-  BOOST_CHECK_EQUAL(Ao2[1], 0);
-  BOOST_CHECK(app.b.o1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(app.b.o2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(app.b.o1), 1);
-  BOOST_CHECK_EQUAL(app.b.o2[0], 0);
-  BOOST_CHECK_EQUAL(app.b.o2[1], 0);
-  BOOST_CHECK(app.b.i1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(app.b.i1), 1);
-
-  // send fault flag on a second variable
-  Ai2[0] = 2;
-  Ai2[1] = 3;
-  Ai2.setDataValidity(ctk::DataValidity::faulty);
-  Ai2.write();
-  test.stepApplication();
-  Ao1.read();
-  Ao2.read();
-  BOOST_CHECK(Ao1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(Ao2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(Ao1), 1);
-  BOOST_CHECK_EQUAL(Ao2[0], 2);
-  BOOST_CHECK_EQUAL(Ao2[1], 3);
-  BOOST_CHECK(app.b.o1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(app.b.o2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(app.b.o1), 1);
-  BOOST_CHECK_EQUAL(app.b.o2[0], 2);
-  BOOST_CHECK_EQUAL(app.b.o2[1], 3);
-  BOOST_CHECK(app.b.i2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(app.b.i2[0], 2);
-  BOOST_CHECK_EQUAL(app.b.i2[1], 3);
-
-  // clear fault flag on a second variable
-  Ai2[0] = 4;
-  Ai2[1] = 5;
-  Ai2.setDataValidity(ctk::DataValidity::ok);
-  Ai2.write();
-  test.stepApplication();
-  Ao1.read();
-  Ao2.read();
-  BOOST_CHECK(Ao1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(Ao2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(Ao1), 1);
-  BOOST_CHECK_EQUAL(Ao2[0], 4);
-  BOOST_CHECK_EQUAL(Ao2[1], 5);
-  BOOST_CHECK(app.b.o1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(app.b.o2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(int(app.b.o1), 1);
-  BOOST_CHECK_EQUAL(app.b.o2[0], 4);
-  BOOST_CHECK_EQUAL(app.b.o2[1], 5);
-  BOOST_CHECK(app.b.i2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(app.b.i2[0], 4);
-  BOOST_CHECK_EQUAL(app.b.i2[1], 5);
-
-  // clear fault flag on a first variable
-  Ai1 = 6;
-  Ai1.setDataValidity(ctk::DataValidity::ok);
-  Ai1.write();
-  test.stepApplication();
-  Ao1.read();
-  Ao2.read();
-  BOOST_CHECK(Ao1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(Ao2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(Ao1), 6);
-  BOOST_CHECK_EQUAL(Ao2[0], 4);
-  BOOST_CHECK_EQUAL(Ao2[1], 5);
-  BOOST_CHECK(app.b.o1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(app.b.o2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(app.b.o1), 6);
-  BOOST_CHECK_EQUAL(app.b.o2[0], 4);
-  BOOST_CHECK_EQUAL(app.b.o2[1], 5);
-  BOOST_CHECK(app.b.i1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(app.b.i1), 6);
-}
-
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
-/*
- * Tests below verify data fault flag propagation on:
- * - Threaded FanOut
- * - Consuming FanOut
- * - Triggers
- */
-
-struct Module1 : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-  ctk::ScalarPushInput<int> fromThreadedFanout{this, "o1", "", "", {"DEVICE1", "CS"}};
-
-  // As a workaround the device side connection is done manually for
-  // acheiving this consumingFanout; see:
-  // TestApplication3::defineConnections
-  ctk::ScalarPollInput<int> fromConsumingFanout{this, "i1", "", "", {"CS"}};
-
-  ctk::ScalarPollInput<int> fromDevice{this, "i2", "", "", {"DEVICE2"}};
-  ctk::ScalarOutput<int> result{this, "Module1_result", "", "", {"CS"}};
-
-  void mainLoop() override {
-    while(true) {
-      result = fromConsumingFanout + fromThreadedFanout + fromDevice;
-      writeAll();
-      readAll(); // read last, so initial values are written in the first round
-    }
-  }
-};
-
-struct Module2 : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  struct : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarPushInput<int> result{this, "Module1_result", "", "", {"CS"}};
-  } m1VarsFromCS{this, "../m1", ""}; // "m1" being in there
-                                     // not good for a general case
-  ctk::ScalarOutput<int> result{this, "Module2_result", "", "", {"CS"}};
-
-  void mainLoop() override {
-    while(true) {
-      result = static_cast<int>(m1VarsFromCS.result);
-      writeAll();
-      readAll(); // read last, so initial values are written in the first round
-    }
-  }
-};
-
-// struct TestApplication3 : ctk::ApplicationModule {
-struct TestApplication3 : ctk::Application {
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
   /*
-   *   CS +-----> threaded fanout +------------------+
-   *                  +                              v
-   *                  +---------+                   +Device1+
-   *                            |                   |       |
-   *              Feeding       v                   |       |
-   *   CS   <----- fanout --+ Module1 <-----+       v       |
-   *                 |          ^           +Consuming      |
-   *                 |          +--------+    fanout        |
-   *                 +------+            +      +           |
-   *                        v         Device2   |           |
-   *   CS   <-----------+ Module2               |           |
-   *                                            |           |
-   *   CS   <-----------------------------------+           |
-   *                                                        |
-   *                                                        |
-   *   CS   <-----------+ Trigger fanout <------------------+
-   *                           ^
-   *                           |
-   *                           +
-   *                           CS
+   * Tests below verify data fault flag propagation on:
+   * - Threaded FanOut
+   * - Consuming FanOut
+   * - Triggers
    */
 
-  constexpr static char const* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=testDataValidity1.map)";
-  constexpr static char const* ExceptionDummyCDD2 = "(ExceptionDummy:1?map=testDataValidity2.map)";
-  TestApplication3() : Application("testDataFlagPropagation") {}
-  ~TestApplication3() override { shutdown(); }
+  struct Module1 : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+    ctk::ScalarPushInput<int> fromThreadedFanout{this, "o1", "", "", {"DEVICE1", "CS"}};
 
-  Module1 m1{this, "m1", ""};
-  Module2 m2{this, "m2", ""};
+    // As a workaround the device side connection is done manually for
+    // acheiving this consumingFanout; see:
+    // TestApplication3::defineConnections
+    ctk::ScalarPollInput<int> fromConsumingFanout{this, "i1", "", "", {"CS"}};
 
-  ctk::DeviceModule device1{this, ExceptionDummyCDD1, "/trigger"};
-  ctk::DeviceModule device2{this, ExceptionDummyCDD2, "/trigger"};
+    ctk::ScalarPollInput<int> fromDevice{this, "i2", "", "", {"DEVICE2"}};
+    ctk::ScalarOutput<int> result{this, "Module1_result", "", "", {"CS"}};
 
-  /*  void defineConnections() override {
-      device1["m1"]("i1") >> m1("i1");
-      findTag("CS").connectTo(cs);
-      findTag("DEVICE1").connectTo(device1);
-      findTag("DEVICE2").connectTo(device2);
-      device1["m1"]("i3")[cs("trigger", typeid(int), 1)] >> cs("i3", typeid(int), 1);
-    }*/
-};
+    void mainLoop() override {
+      while(true) {
+        result = fromConsumingFanout + fromThreadedFanout + fromDevice;
+        writeAll();
+        readAll(); // read last, so initial values are written in the first round
+      }
+    }
+  };
 
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
+  struct Module2 : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-struct FixtureTestFacility {
-  FixtureTestFacility()
-  : device1DummyBackend(boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-        ChimeraTK::BackendFactory::getInstance().createBackend(TestApplication3::ExceptionDummyCDD1))),
-    device2DummyBackend(boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-        ChimeraTK::BackendFactory::getInstance().createBackend(TestApplication3::ExceptionDummyCDD2))) {
-    device1DummyBackend->open();
-    device2DummyBackend->open();
-    test.runApplication();
+    struct : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarPushInput<int> result{this, "Module1_result", "", "", {"CS"}};
+    } m1VarsFromCS{this, "../m1", ""}; // "m1" being in there
+                                       // not good for a general case
+    ctk::ScalarOutput<int> result{this, "Module2_result", "", "", {"CS"}};
+
+    void mainLoop() override {
+      while(true) {
+        result = static_cast<int>(m1VarsFromCS.result);
+        writeAll();
+        readAll(); // read last, so initial values are written in the first round
+      }
+    }
+  };
+
+  // struct TestApplication3 : ctk::ApplicationModule {
+  struct TestApplication3 : ctk::Application {
+    /*
+     *   CS +-----> threaded fanout +------------------+
+     *                  +                              v
+     *                  +---------+                   +Device1+
+     *                            |                   |       |
+     *              Feeding       v                   |       |
+     *   CS   <----- fanout --+ Module1 <-----+       v       |
+     *                 |          ^           +Consuming      |
+     *                 |          +--------+    fanout        |
+     *                 +------+            +      +           |
+     *                        v         Device2   |           |
+     *   CS   <-----------+ Module2               |           |
+     *                                            |           |
+     *   CS   <-----------------------------------+           |
+     *                                                        |
+     *                                                        |
+     *   CS   <-----------+ Trigger fanout <------------------+
+     *                           ^
+     *                           |
+     *                           +
+     *                           CS
+     */
+
+    constexpr static char const* ExceptionDummyCDD1 = "(ExceptionDummy:1?map=testDataValidity1.map)";
+    constexpr static char const* ExceptionDummyCDD2 = "(ExceptionDummy:1?map=testDataValidity2.map)";
+    TestApplication3() : Application("testDataFlagPropagation") {}
+    ~TestApplication3() override { shutdown(); }
+
+    Module1 m1{this, "m1", ""};
+    Module2 m2{this, "m2", ""};
+
+    ctk::DeviceModule device1{this, ExceptionDummyCDD1, "/trigger"};
+    ctk::DeviceModule device2{this, ExceptionDummyCDD2, "/trigger"};
+
+    /*  void defineConnections() override {
+        device1["m1"]("i1") >> m1("i1");
+        findTag("CS").connectTo(cs);
+        findTag("DEVICE1").connectTo(device1);
+        findTag("DEVICE2").connectTo(device2);
+        device1["m1"]("i3")[cs("trigger", typeid(int), 1)] >> cs("i3", typeid(int), 1);
+      }*/
+  };
+
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
+
+  struct FixtureTestFacility {
+    FixtureTestFacility()
+    : device1DummyBackend(boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+          ChimeraTK::BackendFactory::getInstance().createBackend(TestApplication3::ExceptionDummyCDD1))),
+      device2DummyBackend(boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+          ChimeraTK::BackendFactory::getInstance().createBackend(TestApplication3::ExceptionDummyCDD2))) {
+      device1DummyBackend->open();
+      device2DummyBackend->open();
+      test.runApplication();
+    }
+
+    ~FixtureTestFacility() {
+      device1DummyBackend->throwExceptionRead = false;
+      device2DummyBackend->throwExceptionWrite = false;
+    }
+
+    boost::shared_ptr<ctk::ExceptionDummy> device1DummyBackend;
+    boost::shared_ptr<ctk::ExceptionDummy> device2DummyBackend;
+    TestApplication3 app;
+    ctk::TestFacility test{app};
+  };
+
+  BOOST_FIXTURE_TEST_SUITE(data_validity_propagation, FixtureTestFacility)
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testThreadedFanout) {
+    std::cout << "testThreadedFanout" << std::endl;
+    auto threadedFanoutInput = test.getScalar<int>("m1/o1");
+    auto m1_result = test.getScalar<int>("m1/Module1_result");
+    auto m2_result = test.getScalar<int>("m2/Module2_result");
+
+    threadedFanoutInput = 20;
+    threadedFanoutInput.write();
+    // write to register: m1.i1 linked with the consumingFanout.
+    auto consumingFanoutSource =
+        ctk::Device(TestApplication3::ExceptionDummyCDD1).getScalarRegisterAccessor<int>("/m1/i1/DUMMY_WRITEABLE");
+    consumingFanoutSource = 10;
+    consumingFanoutSource.write();
+
+    auto pollRegister =
+        ctk::Device(TestApplication3::ExceptionDummyCDD2).getScalarRegisterAccessor<int>("/m1/i2/DUMMY_WRITEABLE");
+    pollRegister = 5;
+    pollRegister.write();
+
+    test.stepApplication();
+
+    m1_result.read();
+    m2_result.read();
+    BOOST_CHECK_EQUAL(m1_result, 35);
+    BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::ok);
+
+    BOOST_CHECK_EQUAL(m2_result, 35);
+    BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::ok);
+
+    threadedFanoutInput = 10;
+    threadedFanoutInput.setDataValidity(ctk::DataValidity::faulty);
+    threadedFanoutInput.write();
+    test.stepApplication();
+
+    m1_result.read();
+    m2_result.read();
+    BOOST_CHECK_EQUAL(m1_result, 25);
+    BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK_EQUAL(m2_result, 25);
+    BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::faulty);
+
+    threadedFanoutInput = 40;
+    threadedFanoutInput.setDataValidity(ctk::DataValidity::ok);
+    threadedFanoutInput.write();
+    test.stepApplication();
+
+    m1_result.read();
+    m2_result.read();
+    BOOST_CHECK_EQUAL(m1_result, 55);
+    BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(m2_result, 55);
+    BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::ok);
   }
 
-  ~FixtureTestFacility() {
-    device1DummyBackend->throwExceptionRead = false;
-    device2DummyBackend->throwExceptionWrite = false;
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testInvalidTrigger) {
+    std::cout << "testInvalidTrigger" << std::endl;
+
+    auto deviceRegister =
+        ctk::Device(TestApplication3::ExceptionDummyCDD1).getScalarRegisterAccessor<int>("/m1/i3/DUMMY_WRITEABLE");
+    deviceRegister = 20;
+    deviceRegister.write();
+
+    auto trigger = test.getVoid("trigger");
+    auto result = test.getScalar<int>("/m1/i3"); // Cs hook into reg: m1.i3
+
+    //----------------------------------------------------------------//
+    // trigger works as expected
+    trigger.write();
+
+    test.stepApplication();
+
+    result.read();
+    BOOST_CHECK_EQUAL(result, 20);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
+
+    //----------------------------------------------------------------//
+    // faulty trigger
+    deviceRegister = 30;
+    deviceRegister.write();
+    trigger.setDataValidity(ctk::DataValidity::faulty);
+    trigger.write();
+
+    test.stepApplication();
+
+    result.read();
+    BOOST_CHECK_EQUAL(result, 30);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+
+    //----------------------------------------------------------------//
+    // recovery
+    deviceRegister = 50;
+    deviceRegister.write();
+
+    trigger.setDataValidity(ctk::DataValidity::ok);
+    trigger.write();
+
+    test.stepApplication();
+
+    result.read();
+    BOOST_CHECK_EQUAL(result, 50);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
   }
 
-  boost::shared_ptr<ctk::ExceptionDummy> device1DummyBackend;
-  boost::shared_ptr<ctk::ExceptionDummy> device2DummyBackend;
-  TestApplication3 app;
-  ctk::TestFacility test{app};
-};
+  BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_FIXTURE_TEST_SUITE(data_validity_propagation, FixtureTestFacility)
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-/*********************************************************************************************************************/
+  struct FixtureNoTestableMode {
+    FixtureNoTestableMode()
+    : device1DummyBackend(boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+          ChimeraTK::BackendFactory::getInstance().createBackend(TestApplication3::ExceptionDummyCDD1))),
+      device2DummyBackend(boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+          ChimeraTK::BackendFactory::getInstance().createBackend(TestApplication3::ExceptionDummyCDD2))) {
+      device1Status.replace(test.getScalar<int32_t>(ctk::RegisterPath("/Devices") /
+          ctk::Utilities::escapeName(TestApplication3::ExceptionDummyCDD1, false) / "status"));
+      device2Status.replace(test.getScalar<int32_t>(ctk::RegisterPath("/Devices") /
+          ctk::Utilities::escapeName(TestApplication3::ExceptionDummyCDD2, false) / "status"));
 
-BOOST_AUTO_TEST_CASE(testThreadedFanout) {
-  std::cout << "testThreadedFanout" << std::endl;
-  auto threadedFanoutInput = test.getScalar<int>("m1/o1");
-  auto m1_result = test.getScalar<int>("m1/Module1_result");
-  auto m2_result = test.getScalar<int>("m2/Module2_result");
+      device1DummyBackend->open();
+      device2DummyBackend->open();
+    }
 
-  threadedFanoutInput = 20;
-  threadedFanoutInput.write();
-  // write to register: m1.i1 linked with the consumingFanout.
-  auto consumingFanoutSource =
-      ctk::Device(TestApplication3::ExceptionDummyCDD1).getScalarRegisterAccessor<int>("/m1/i1/DUMMY_WRITEABLE");
-  consumingFanoutSource = 10;
-  consumingFanoutSource.write();
+    void waitForDevices() {
+      // the block below is a work around for a race condition; make sure
+      // all values are propagated to the device registers before starting
+      // the test.
+      static const int DEFAULT = 1234567;
+      test.setScalarDefault("m1/o1", DEFAULT);
 
-  auto pollRegister =
-      ctk::Device(TestApplication3::ExceptionDummyCDD2).getScalarRegisterAccessor<int>("/m1/i2/DUMMY_WRITEABLE");
-  pollRegister = 5;
-  pollRegister.write();
+      test.runApplication();
+      CHECK_EQUAL_TIMEOUT((device1Status.readLatest(), device1Status), 0, 100000);
+      CHECK_EQUAL_TIMEOUT((device2Status.readLatest(), device2Status), 0, 100000);
 
-  test.stepApplication();
+      // Making sure the default is written to the device before proceeding.
+      auto m1o1 = device1DummyBackend->getRegisterAccessor<int>("m1/o1", 1, 0, {});
+      CHECK_EQUAL_TIMEOUT((m1o1->read(), m1o1->accessData(0)), DEFAULT, 10000);
+    }
 
-  m1_result.read();
-  m2_result.read();
-  BOOST_CHECK_EQUAL(m1_result, 35);
-  BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::ok);
+    ~FixtureNoTestableMode() {
+      device1DummyBackend->throwExceptionRead = false;
+      device2DummyBackend->throwExceptionWrite = false;
+    }
 
-  BOOST_CHECK_EQUAL(m2_result, 35);
-  BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::ok);
+    boost::shared_ptr<ctk::ExceptionDummy> device1DummyBackend;
+    boost::shared_ptr<ctk::ExceptionDummy> device2DummyBackend;
+    TestApplication3 app;
+    ctk::TestFacility test{app, false};
+    ChimeraTK::ScalarRegisterAccessor<int> device1Status;
+    ChimeraTK::ScalarRegisterAccessor<int> device2Status;
+  };
 
-  threadedFanoutInput = 10;
-  threadedFanoutInput.setDataValidity(ctk::DataValidity::faulty);
-  threadedFanoutInput.write();
-  test.stepApplication();
+  /*********************************************************************************************************************/
 
-  m1_result.read();
-  m2_result.read();
-  BOOST_CHECK_EQUAL(m1_result, 25);
-  BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK_EQUAL(m2_result, 25);
-  BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::faulty);
+  BOOST_AUTO_TEST_SUITE(data_validity_propagation_noTestFacility)
 
-  threadedFanoutInput = 40;
-  threadedFanoutInput.setDataValidity(ctk::DataValidity::ok);
-  threadedFanoutInput.write();
-  test.stepApplication();
+  BOOST_FIXTURE_TEST_CASE(testDeviceReadFailure, FixtureNoTestableMode) {
+    std::cout << "testDeviceReadFailure" << std::endl;
+    waitForDevices();
 
-  m1_result.read();
-  m2_result.read();
-  BOOST_CHECK_EQUAL(m1_result, 55);
-  BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(m2_result, 55);
-  BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::ok);
-}
+    auto consumingFanoutSource =
+        ctk::Device(TestApplication3::ExceptionDummyCDD1).getScalarRegisterAccessor<int>("/m1/i1/DUMMY_WRITEABLE");
+    auto pollRegister =
+        ctk::Device(TestApplication3::ExceptionDummyCDD2).getScalarRegisterAccessor<int>("/m1/i2/DUMMY_WRITEABLE");
 
-/*********************************************************************************************************************/
+    auto threadedFanoutInput = test.getScalar<int>("m1/o1");
+    auto result = test.getScalar<int>("m1/Module1_result");
 
-BOOST_AUTO_TEST_CASE(testInvalidTrigger) {
-  std::cout << "testInvalidTrigger" << std::endl;
+    threadedFanoutInput = 10000;
+    consumingFanoutSource = 1000;
+    consumingFanoutSource.write();
+    pollRegister = 1;
+    pollRegister.write();
 
-  auto deviceRegister =
-      ctk::Device(TestApplication3::ExceptionDummyCDD1).getScalarRegisterAccessor<int>("/m1/i3/DUMMY_WRITEABLE");
-  deviceRegister = 20;
-  deviceRegister.write();
+    // -------------------------------------------------------------//
+    // without errors
+    threadedFanoutInput.write();
 
-  auto trigger = test.getVoid("trigger");
-  auto result = test.getScalar<int>("/m1/i3"); // Cs hook into reg: m1.i3
+    CHECK_TIMEOUT((result.readLatest(), result == 11001), 10000);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
 
-  //----------------------------------------------------------------//
-  // trigger works as expected
-  trigger.write();
+    // -------------------------------------------------------------//
+    // device module exception
+    threadedFanoutInput = 20000;
+    pollRegister = 0;
+    pollRegister.write();
 
-  test.stepApplication();
+    device2DummyBackend->throwExceptionRead = true;
 
-  result.read();
-  BOOST_CHECK_EQUAL(result, 20);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
+    threadedFanoutInput.write();
+    // The new value from the fanout input should have been propagated,
+    // the new value of the poll input is not seen, because it gets skipped
+    result.read();
+    BOOST_CHECK_EQUAL(result, 21001);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
 
-  //----------------------------------------------------------------//
-  // faulty trigger
-  deviceRegister = 30;
-  deviceRegister.write();
-  trigger.setDataValidity(ctk::DataValidity::faulty);
-  trigger.write();
+    // make sure the device module has seen the exception
+    CHECK_EQUAL_TIMEOUT((device2Status.readLatest(), device2Status), 1, 100000);
 
-  test.stepApplication();
+    // -------------------------------------------------------------//
 
-  result.read();
-  BOOST_CHECK_EQUAL(result, 30);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+    threadedFanoutInput = 30000;
+    threadedFanoutInput.write();
+    // Further reads to the poll input are skipped
+    result.read();
+    BOOST_CHECK_EQUAL(result, 31001);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
 
-  //----------------------------------------------------------------//
-  // recovery
-  deviceRegister = 50;
-  deviceRegister.write();
+    // -------------------------------------------------------------//
 
-  trigger.setDataValidity(ctk::DataValidity::ok);
-  trigger.write();
-
-  test.stepApplication();
-
-  result.read();
-  BOOST_CHECK_EQUAL(result, 50);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
-}
-
-BOOST_AUTO_TEST_SUITE_END()
-
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
-
-struct FixtureNoTestableMode {
-  FixtureNoTestableMode()
-  : device1DummyBackend(boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-        ChimeraTK::BackendFactory::getInstance().createBackend(TestApplication3::ExceptionDummyCDD1))),
-    device2DummyBackend(boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-        ChimeraTK::BackendFactory::getInstance().createBackend(TestApplication3::ExceptionDummyCDD2))) {
-    device1Status.replace(test.getScalar<int32_t>(ctk::RegisterPath("/Devices") /
-        ctk::Utilities::escapeName(TestApplication3::ExceptionDummyCDD1, false) / "status"));
-    device2Status.replace(test.getScalar<int32_t>(ctk::RegisterPath("/Devices") /
-        ctk::Utilities::escapeName(TestApplication3::ExceptionDummyCDD2, false) / "status"));
-
-    device1DummyBackend->open();
-    device2DummyBackend->open();
-  }
-
-  void waitForDevices() {
-    // the block below is a work around for a race condition; make sure
-    // all values are propagated to the device registers before starting
-    // the test.
-    static const int DEFAULT = 1234567;
-    test.setScalarDefault("m1/o1", DEFAULT);
-
-    test.runApplication();
-    CHECK_EQUAL_TIMEOUT((device1Status.readLatest(), device1Status), 0, 100000);
+    // recovery from device module exception
+    device2DummyBackend->throwExceptionRead = false;
     CHECK_EQUAL_TIMEOUT((device2Status.readLatest(), device2Status), 0, 100000);
 
-    // Making sure the default is written to the device before proceeding.
-    auto m1o1 = device1DummyBackend->getRegisterAccessor<int>("m1/o1", 1, 0, {});
-    CHECK_EQUAL_TIMEOUT((m1o1->read(), m1o1->accessData(0)), DEFAULT, 10000);
+    threadedFanoutInput = 40000;
+    threadedFanoutInput.write();
+    result.read();
+    // Now we expect also the last value written to the pollRegister being
+    // propagated and the DataValidity should be ok again.
+    BOOST_CHECK_EQUAL(result, 41000);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
   }
 
-  ~FixtureNoTestableMode() {
+  /*********************************************************************************************************************/
+
+  BOOST_FIXTURE_TEST_CASE(testReadDeviceWithTrigger, FixtureNoTestableMode) {
+    std::cout << "testReadDeviceWithTrigger" << std::endl;
+    waitForDevices();
+
+    auto trigger = test.getVoid("trigger");
+    auto fromDevice = test.getScalar<int>("/m1/i3"); // cs side display: m1.i3
+    //----------------------------------------------------------------//
+    fromDevice.read(); // there is an initial value
+    BOOST_CHECK_EQUAL(fromDevice, 0);
+
+    auto deviceRegister =
+        ctk::Device(TestApplication3::ExceptionDummyCDD1).getScalarRegisterAccessor<int>("/m1/i3/DUMMY_WRITEABLE");
+    deviceRegister = 30;
+    deviceRegister.write();
+
+    // trigger works as expected
+    trigger.write();
+
+    fromDevice.read();
+    BOOST_CHECK_EQUAL(fromDevice, 30);
+    BOOST_CHECK(fromDevice.dataValidity() == ctk::DataValidity::ok);
+
+    //----------------------------------------------------------------//
+    // Device module exception
+    deviceRegister = 10;
+    deviceRegister.write();
+
+    device1DummyBackend->throwExceptionRead = true;
+
+    trigger.write();
+
+    fromDevice.read();
+    BOOST_CHECK_EQUAL(fromDevice, 30);
+    BOOST_CHECK(fromDevice.dataValidity() == ctk::DataValidity::faulty);
+    //----------------------------------------------------------------//
+    // Recovery
     device1DummyBackend->throwExceptionRead = false;
-    device2DummyBackend->throwExceptionWrite = false;
-  }
 
-  boost::shared_ptr<ctk::ExceptionDummy> device1DummyBackend;
-  boost::shared_ptr<ctk::ExceptionDummy> device2DummyBackend;
-  TestApplication3 app;
-  ctk::TestFacility test{app, false};
-  ChimeraTK::ScalarRegisterAccessor<int> device1Status;
-  ChimeraTK::ScalarRegisterAccessor<int> device2Status;
-};
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_SUITE(data_validity_propagation_noTestFacility)
-
-BOOST_FIXTURE_TEST_CASE(testDeviceReadFailure, FixtureNoTestableMode) {
-  std::cout << "testDeviceReadFailure" << std::endl;
-  waitForDevices();
-
-  auto consumingFanoutSource =
-      ctk::Device(TestApplication3::ExceptionDummyCDD1).getScalarRegisterAccessor<int>("/m1/i1/DUMMY_WRITEABLE");
-  auto pollRegister =
-      ctk::Device(TestApplication3::ExceptionDummyCDD2).getScalarRegisterAccessor<int>("/m1/i2/DUMMY_WRITEABLE");
-
-  auto threadedFanoutInput = test.getScalar<int>("m1/o1");
-  auto result = test.getScalar<int>("m1/Module1_result");
-
-  threadedFanoutInput = 10000;
-  consumingFanoutSource = 1000;
-  consumingFanoutSource.write();
-  pollRegister = 1;
-  pollRegister.write();
-
-  // -------------------------------------------------------------//
-  // without errors
-  threadedFanoutInput.write();
-
-  CHECK_TIMEOUT((result.readLatest(), result == 11001), 10000);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
-
-  // -------------------------------------------------------------//
-  // device module exception
-  threadedFanoutInput = 20000;
-  pollRegister = 0;
-  pollRegister.write();
-
-  device2DummyBackend->throwExceptionRead = true;
-
-  threadedFanoutInput.write();
-  // The new value from the fanout input should have been propagated,
-  // the new value of the poll input is not seen, because it gets skipped
-  result.read();
-  BOOST_CHECK_EQUAL(result, 21001);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
-
-  // make sure the device module has seen the exception
-  CHECK_EQUAL_TIMEOUT((device2Status.readLatest(), device2Status), 1, 100000);
-
-  // -------------------------------------------------------------//
-
-  threadedFanoutInput = 30000;
-  threadedFanoutInput.write();
-  // Further reads to the poll input are skipped
-  result.read();
-  BOOST_CHECK_EQUAL(result, 31001);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
-
-  // -------------------------------------------------------------//
-
-  // recovery from device module exception
-  device2DummyBackend->throwExceptionRead = false;
-  CHECK_EQUAL_TIMEOUT((device2Status.readLatest(), device2Status), 0, 100000);
-
-  threadedFanoutInput = 40000;
-  threadedFanoutInput.write();
-  result.read();
-  // Now we expect also the last value written to the pollRegister being
-  // propagated and the DataValidity should be ok again.
-  BOOST_CHECK_EQUAL(result, 41000);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_FIXTURE_TEST_CASE(testReadDeviceWithTrigger, FixtureNoTestableMode) {
-  std::cout << "testReadDeviceWithTrigger" << std::endl;
-  waitForDevices();
-
-  auto trigger = test.getVoid("trigger");
-  auto fromDevice = test.getScalar<int>("/m1/i3"); // cs side display: m1.i3
-  //----------------------------------------------------------------//
-  fromDevice.read(); // there is an initial value
-  BOOST_CHECK_EQUAL(fromDevice, 0);
-
-  auto deviceRegister =
-      ctk::Device(TestApplication3::ExceptionDummyCDD1).getScalarRegisterAccessor<int>("/m1/i3/DUMMY_WRITEABLE");
-  deviceRegister = 30;
-  deviceRegister.write();
-
-  // trigger works as expected
-  trigger.write();
-
-  fromDevice.read();
-  BOOST_CHECK_EQUAL(fromDevice, 30);
-  BOOST_CHECK(fromDevice.dataValidity() == ctk::DataValidity::ok);
-
-  //----------------------------------------------------------------//
-  // Device module exception
-  deviceRegister = 10;
-  deviceRegister.write();
-
-  device1DummyBackend->throwExceptionRead = true;
-
-  trigger.write();
-
-  fromDevice.read();
-  BOOST_CHECK_EQUAL(fromDevice, 30);
-  BOOST_CHECK(fromDevice.dataValidity() == ctk::DataValidity::faulty);
-  //----------------------------------------------------------------//
-  // Recovery
-  device1DummyBackend->throwExceptionRead = false;
-
-  // Wait until the device has recovered. Otherwise the read might be skipped and we still read the previous value with
-  // the faulty flag.
-  while((void)device1Status.read(), device1Status == 1) {
-    usleep(1000);
-  }
-
-  trigger.write();
-
-  fromDevice.read();
-  BOOST_CHECK_EQUAL(fromDevice, 10);
-  BOOST_CHECK(fromDevice.dataValidity() == ctk::DataValidity::ok);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_FIXTURE_TEST_CASE(testConsumingFanout, FixtureNoTestableMode) {
-  std::cout << "testConsumingFanout" << std::endl;
-  waitForDevices();
-
-  auto threadedFanoutInput = test.getScalar<int>("m1/o1");
-  auto fromConsumingFanout = test.getScalar<int>("m1/i1"); // consumingfanout variable on cs side
-  auto result = test.getScalar<int>("m1/Module1_result");
-  fromConsumingFanout.read(); // initial value, don't care for this test
-  result.read();              // initial value, don't care for this test
-
-  auto pollRegisterSource =
-      ctk::Device(TestApplication3::ExceptionDummyCDD2).getScalarRegisterAccessor<int>("/m1/i2.DUMMY_WRITEABLE");
-  pollRegisterSource = 100;
-  pollRegisterSource.write();
-
-  threadedFanoutInput = 10;
-
-  auto consumingFanoutSource =
-      ctk::Device(TestApplication3::ExceptionDummyCDD1).getScalarRegisterAccessor<int>("/m1/i1.DUMMY_WRITEABLE");
-  consumingFanoutSource = 1;
-  consumingFanoutSource.write();
-
-  //----------------------------------------------------------//
-  // no device module exception
-  threadedFanoutInput.write();
-
-  result.read();
-  BOOST_CHECK_EQUAL(result, 111);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
-
-  fromConsumingFanout.read();
-  BOOST_CHECK_EQUAL(fromConsumingFanout, 1);
-  BOOST_CHECK(fromConsumingFanout.dataValidity() == ctk::DataValidity::ok);
-
-  // --------------------------------------------------------//
-  // device exception on consuming fanout source read
-  consumingFanoutSource = 0;
-  consumingFanoutSource.write();
-
-  device1DummyBackend->throwExceptionRead = true;
-  threadedFanoutInput = 20;
-  threadedFanoutInput.write();
-
-  CHECK_TIMEOUT(result.readLatest(), 10000);
-  BOOST_CHECK_EQUAL(result, 121);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
-
-  CHECK_TIMEOUT(fromConsumingFanout.readLatest(), 10000);
-  BOOST_CHECK_EQUAL(fromConsumingFanout, 1);
-  BOOST_CHECK(fromConsumingFanout.dataValidity() == ctk::DataValidity::faulty);
-
-  // --------------------------------------------------------//
-  // Recovery
-  device1DummyBackend->throwExceptionRead = false;
-
-  // Wait until the device has recovered. Otherwise the read might be skipped and we still read the previous value with
-  // the faulty flag.
-  while((void)device1Status.read(), device1Status == 1) {
-    usleep(1000);
-  }
-
-  threadedFanoutInput = 30;
-  threadedFanoutInput.write();
-
-  CHECK_TIMEOUT(result.readLatest(), 10000);
-  BOOST_CHECK_EQUAL(result, 130);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
-
-  CHECK_TIMEOUT(fromConsumingFanout.readLatest(), 10000);
-  BOOST_CHECK_EQUAL(fromConsumingFanout, 0);
-  BOOST_CHECK(fromConsumingFanout.dataValidity() == ctk::DataValidity::ok);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_FIXTURE_TEST_CASE(testDataFlowOnDeviceException, FixtureNoTestableMode) {
-  std::cout << "testDataFlowOnDeviceException" << std::endl;
-
-  auto threadedFanoutInput = test.getScalar<int>("m1/o1");
-  auto m1_result = test.getScalar<int>("m1/Module1_result");
-  auto m2_result = test.getScalar<int>("m2/Module2_result");
-
-  auto consumingFanoutSource = ctk::ScalarRegisterAccessor<int>(
-      device1DummyBackend->getRegisterAccessor<int>("/m1/i1.DUMMY_WRITEABLE", 0, 0, {}));
-  consumingFanoutSource = 1000;
-  consumingFanoutSource.write();
-
-  auto pollRegister = ctk::ScalarRegisterAccessor<int>(
-      device2DummyBackend->getRegisterAccessor<int>("/m1/i2.DUMMY_WRITEABLE", 0, 0, {}));
-  pollRegister = 100;
-  pollRegister.write();
-
-  waitForDevices();
-
-  // get rid of initial values
-  m1_result.read();
-  m2_result.read();
-
-  threadedFanoutInput = 1;
-
-  // ------------------------------------------------------------------//
-  // without exception
-  threadedFanoutInput.write();
-
-  CHECK_TIMEOUT(m1_result.readNonBlocking(), 10000);
-  BOOST_CHECK_EQUAL(m1_result, 1101);
-  BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::ok);
-
-  CHECK_TIMEOUT(m2_result.readNonBlocking(), 10000);
-  BOOST_CHECK_EQUAL(m2_result, 1101);
-  BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::ok);
-
-  // ------------------------------------------------------------------//
-  // faulty threadedFanout input
-  threadedFanoutInput.setDataValidity(ctk::DataValidity::faulty);
-  threadedFanoutInput.write();
-
-  CHECK_TIMEOUT(m1_result.readNonBlocking(), 10000);
-  BOOST_CHECK_EQUAL(m1_result, 1101);
-  BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::faulty);
-
-  CHECK_TIMEOUT(m2_result.readLatest(), 10000);
-  BOOST_CHECK_EQUAL(m2_result, 1101);
-  BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::faulty);
-
-  auto deviceStatus = test.getScalar<int32_t>(ctk::RegisterPath("/Devices") /
-      ChimeraTK::Utilities::escapeName(TestApplication3::ExceptionDummyCDD2, false) / "status");
-  // the device is still OK
-  CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 0, 10000);
-
-  // ---------------------------------------------------------------------//
-  // device module exception
-  device2DummyBackend->throwExceptionRead = true;
-  pollRegister = 200;
-  pollRegister.write();
-  threadedFanoutInput = 0;
-  threadedFanoutInput.write();
-
-  // Now the device has to go into the error state
-  CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 1, 10000);
-
-  // The new value of the threadedFanoutInput should be propagated, the
-  // pollRegister is skipped, see testDataValidPropagationOnException.
-  m1_result.read();
-  BOOST_CHECK_EQUAL(m1_result, 1100);
-  BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::faulty);
-  m2_result.read();
-  // Same for m2
-  BOOST_CHECK_EQUAL(m2_result, 1100);
-  BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::faulty);
-
-  // ---------------------------------------------------------------------//
-  // device exception recovery
-  device2DummyBackend->throwExceptionRead = false;
-
-  // device error recovers. There must be exactly one new status values with the right value.
-  deviceStatus.read();
-  BOOST_CHECK(deviceStatus == 0);
-  // nothing else in the queue
-  BOOST_CHECK(deviceStatus.readNonBlocking() == false);
-
-  // ---------------------------------------------------------------------//
-  // Now both, threadedFanoutInput and pollRegister should propagate
-  pollRegister = 300;
-  pollRegister.write();
-  threadedFanoutInput = 2;
-  threadedFanoutInput.write();
-
-  m1_result.read();
-  BOOST_CHECK_EQUAL(m1_result, 1302);
-  // Data validity still faulty because the input from the fan is invalid
-  BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::faulty);
-  // again, nothing else in the queue
-  BOOST_CHECK(m1_result.readNonBlocking() == false);
-
-  // same for m2
-  m2_result.read();
-  BOOST_CHECK_EQUAL(m2_result, 1302);
-  BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_CHECK(m2_result.readNonBlocking() == false);
-
-  // ---------------------------------------------------------------------//
-  // recovery: fanout input
-  threadedFanoutInput = 3;
-  threadedFanoutInput.setDataValidity(ctk::DataValidity::ok);
-  threadedFanoutInput.write();
-
-  m1_result.read();
-  BOOST_CHECK_EQUAL(m1_result, 1303);
-  BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(m1_result.readNonBlocking() == false);
-
-  m2_result.read();
-  BOOST_CHECK_EQUAL(m2_result, 1303);
-  BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK(m1_result.readNonBlocking() == false);
-}
-
-BOOST_AUTO_TEST_SUITE_END()
-
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
-
-// Module and Application for test case "testDataValidPropagationOnException"
-struct Module3 : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-  ctk::ScalarPushInput<int> pushTypeInputFromCS{this, "o1", "", "", {"CS"}};
-
-  ctk::ScalarPollInput<int> pollInputFromDevice{this, "/m1/i2", "", "", {"DEVICE2"}};
-  ctk::ScalarOutput<int> result{this, "Module3_result", "", "", {"CS"}};
-
-  void mainLoop() override {
-    while(true) {
-      result = pushTypeInputFromCS + pollInputFromDevice;
-      result.write();
-      readAll(); // read last, so initial values are written in the first round
+    // Wait until the device has recovered. Otherwise the read might be skipped and we still read the previous value
+    // with the faulty flag.
+    while((void)device1Status.read(), device1Status == 1) {
+      usleep(1000);
     }
+
+    trigger.write();
+
+    fromDevice.read();
+    BOOST_CHECK_EQUAL(fromDevice, 10);
+    BOOST_CHECK(fromDevice.dataValidity() == ctk::DataValidity::ok);
   }
-};
 
-struct TestApplication4 : ctk::Application {
-  /*
-   *
-   */
+  /*********************************************************************************************************************/
 
-  constexpr static char const* ExceptionDummyCDD2 = "(ExceptionDummy:1?map=testDataValidity2.map)";
-  TestApplication4() : Application("testDataFlagPropagation") {}
-  ~TestApplication4() override { shutdown(); }
+  BOOST_FIXTURE_TEST_CASE(testConsumingFanout, FixtureNoTestableMode) {
+    std::cout << "testConsumingFanout" << std::endl;
+    waitForDevices();
 
-  Module3 module{this, "module", ""};
+    auto threadedFanoutInput = test.getScalar<int>("m1/o1");
+    auto fromConsumingFanout = test.getScalar<int>("m1/i1"); // consumingfanout variable on cs side
+    auto result = test.getScalar<int>("m1/Module1_result");
+    fromConsumingFanout.read(); // initial value, don't care for this test
+    result.read();              // initial value, don't care for this test
 
-  ctk::DeviceModule device2{this, ExceptionDummyCDD2};
+    auto pollRegisterSource =
+        ctk::Device(TestApplication3::ExceptionDummyCDD2).getScalarRegisterAccessor<int>("/m1/i2.DUMMY_WRITEABLE");
+    pollRegisterSource = 100;
+    pollRegisterSource.write();
 
-  /*  void defineConnections() override {
-      findTag("CS").connectTo(cs);
-      findTag("DEVICE2").flatten().connectTo(device2["m1"]);
-    }*/
-};
+    threadedFanoutInput = 10;
 
-/*********************************************************************************************************************/
+    auto consumingFanoutSource =
+        ctk::Device(TestApplication3::ExceptionDummyCDD1).getScalarRegisterAccessor<int>("/m1/i1.DUMMY_WRITEABLE");
+    consumingFanoutSource = 1;
+    consumingFanoutSource.write();
 
-BOOST_AUTO_TEST_CASE(testDataValidPropagationOnException) {
-  std::cout << "testDataValidPropagationOnException" << std::endl;
+    //----------------------------------------------------------//
+    // no device module exception
+    threadedFanoutInput.write();
 
-  boost::shared_ptr<ctk::ExceptionDummy> device2DummyBackend(boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
-      ChimeraTK::BackendFactory::getInstance().createBackend(TestApplication3::ExceptionDummyCDD2)));
-  ctk::Device device2(TestApplication3::ExceptionDummyCDD2);
+    result.read();
+    BOOST_CHECK_EQUAL(result, 111);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
 
-  TestApplication4 app;
-  ctk::TestFacility test{app, false};
+    fromConsumingFanout.read();
+    BOOST_CHECK_EQUAL(fromConsumingFanout, 1);
+    BOOST_CHECK(fromConsumingFanout.dataValidity() == ctk::DataValidity::ok);
 
-  auto pollRegister = device2.getScalarRegisterAccessor<int>("/m1/i2.DUMMY_WRITEABLE");
-  device2.open();
-  pollRegister = 1;
-  pollRegister.write();
-  device2.close();
+    // --------------------------------------------------------//
+    // device exception on consuming fanout source read
+    consumingFanoutSource = 0;
+    consumingFanoutSource.write();
 
-  test.runApplication();
+    device1DummyBackend->throwExceptionRead = true;
+    threadedFanoutInput = 20;
+    threadedFanoutInput.write();
 
-  auto pushInput = test.getScalar<int>("module/o1");
-  auto result = test.getScalar<int>("module/Module3_result");
+    CHECK_TIMEOUT(result.readLatest(), 10000);
+    BOOST_CHECK_EQUAL(result, 121);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
 
-  auto deviceStatus = test.getScalar<int32_t>(ctk::RegisterPath("/Devices") /
-      ctk::Utilities::escapeName(TestApplication3::ExceptionDummyCDD2, false) / "status");
+    CHECK_TIMEOUT(fromConsumingFanout.readLatest(), 10000);
+    BOOST_CHECK_EQUAL(fromConsumingFanout, 1);
+    BOOST_CHECK(fromConsumingFanout.dataValidity() == ctk::DataValidity::faulty);
 
-  pushInput = 10;
-  pushInput.write();
+    // --------------------------------------------------------//
+    // Recovery
+    device1DummyBackend->throwExceptionRead = false;
 
-  CHECK_TIMEOUT((result.readLatest(), result == 11), 10000);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
-  CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 0, 10000);
+    // Wait until the device has recovered. Otherwise the read might be skipped and we still read the previous value
+    // with the faulty flag.
+    while((void)device1Status.read(), device1Status == 1) {
+      usleep(1000);
+    }
 
-  // Set data validity to faulty and trigger excetion in the same update
-  pollRegister = 2;
-  pollRegister.write();
-  pushInput = 20;
-  pushInput.setDataValidity(ctk::DataValidity::faulty);
-  device2DummyBackend->throwExceptionRead = true;
-  pushInput.write();
+    threadedFanoutInput = 30;
+    threadedFanoutInput.write();
 
-  CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 1, 10000);
-  result.read();
-  BOOST_CHECK(result.readLatest() == false);
-  // The new data from the pushInput and the DataValidity::faulty should have been propagated to the outout,
-  // the pollRegister should be skipped (Exceptionhandling spec B.2.2.3), so we don't expect the latest assigned value of 2
-  BOOST_CHECK_EQUAL(result, 21);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+    CHECK_TIMEOUT(result.readLatest(), 10000);
+    BOOST_CHECK_EQUAL(result, 130);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
 
-  // Writeing the pushInput should still trigger module execution and
-  // update the result value. Result validity should still be faulty because
-  // the device still has the exception
-  pushInput = 30;
-  pushInput.setDataValidity(ctk::DataValidity::ok);
-  pushInput.write();
-  result.read();
-  BOOST_CHECK_EQUAL(result, 31);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+    CHECK_TIMEOUT(fromConsumingFanout.readLatest(), 10000);
+    BOOST_CHECK_EQUAL(fromConsumingFanout, 0);
+    BOOST_CHECK(fromConsumingFanout.dataValidity() == ctk::DataValidity::ok);
+  }
 
-  // let the device recover
-  device2DummyBackend->throwExceptionRead = false;
-  CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 0, 10000);
+  /*********************************************************************************************************************/
 
-  // Everything should be back to normal, also the value of the pollRegister
-  // should be reflected in the output
-  pushInput = 40;
-  pollRegister = 3;
-  pollRegister.write();
-  pushInput.write();
-  result.read();
-  BOOST_CHECK_EQUAL(result, 43);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
-  // nothing more in the queue
-  BOOST_CHECK(result.readLatest() == false);
+  BOOST_FIXTURE_TEST_CASE(testDataFlowOnDeviceException, FixtureNoTestableMode) {
+    std::cout << "testDataFlowOnDeviceException" << std::endl;
 
-  // Check if we get faulty output from the exception alone,
-  // keep pushInput ok
-  pollRegister = 4;
-  pollRegister.write();
-  pushInput = 50;
-  device2DummyBackend->throwExceptionRead = true;
+    auto threadedFanoutInput = test.getScalar<int>("m1/o1");
+    auto m1_result = test.getScalar<int>("m1/Module1_result");
+    auto m2_result = test.getScalar<int>("m2/Module2_result");
 
-  pushInput.write();
-  result.read();
-  BOOST_CHECK(result.readLatest() == false);
-  // The new data from the pushInput, the device exception should yield DataValidity::faulty at the outout,
-  BOOST_CHECK_EQUAL(result, 53);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+    auto consumingFanoutSource = ctk::ScalarRegisterAccessor<int>(
+        device1DummyBackend->getRegisterAccessor<int>("/m1/i1.DUMMY_WRITEABLE", 0, 0, {}));
+    consumingFanoutSource = 1000;
+    consumingFanoutSource.write();
 
-  // Device status should report fault. We need to wait for it here to make sure the DeviceModule has seen the fault.
-  CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 1, 10000);
+    auto pollRegister = ctk::ScalarRegisterAccessor<int>(
+        device2DummyBackend->getRegisterAccessor<int>("/m1/i2.DUMMY_WRITEABLE", 0, 0, {}));
+    pollRegister = 100;
+    pollRegister.write();
 
-  // Also set pushInputValidity to faulty
-  pushInput = 60;
-  pushInput.setDataValidity(ctk::DataValidity::faulty);
-  pushInput.write();
-  result.read();
-  BOOST_CHECK_EQUAL(result, 63);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+    waitForDevices();
 
-  // let the device recover
-  device2DummyBackend->throwExceptionRead = false;
-  CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 0, 10000);
+    // get rid of initial values
+    m1_result.read();
+    m2_result.read();
 
-  // The new pollRegister value should now be reflected in the result,
-  // but it's still faulty from the pushInput
-  pushInput = 70;
-  pollRegister = 5;
-  pollRegister.write();
-  pushInput.write();
-  result.read();
-  BOOST_CHECK_EQUAL(result, 75);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+    threadedFanoutInput = 1;
 
-  // MAke pushInput ok, everything should be back to normal
-  pushInput = 80;
-  pushInput.setDataValidity(ctk::DataValidity::ok);
-  pollRegister = 6;
-  pollRegister.write();
-  pushInput.write();
-  result.read();
-  BOOST_CHECK_EQUAL(result, 86);
-  BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
-  // nothing more in the queue
-  BOOST_CHECK(result.readLatest() == false);
-}
+    // ------------------------------------------------------------------//
+    // without exception
+    threadedFanoutInput.write();
 
-/*********************************************************************************************************************/
+    CHECK_TIMEOUT(m1_result.readNonBlocking(), 10000);
+    BOOST_CHECK_EQUAL(m1_result, 1101);
+    BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::ok);
 
-struct TestModule3 : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-  ctk::ScalarOutput<int> o1{this, "o1", "", ""};
-  ctk::ArrayOutput<int> o2{this, "o2", "", 2, ""};
-  void mainLoop() override {}
-};
+    CHECK_TIMEOUT(m2_result.readNonBlocking(), 10000);
+    BOOST_CHECK_EQUAL(m2_result, 1101);
+    BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::ok);
 
-/*********************************************************************************************************************/
+    // ------------------------------------------------------------------//
+    // faulty threadedFanout input
+    threadedFanoutInput.setDataValidity(ctk::DataValidity::faulty);
+    threadedFanoutInput.write();
 
-struct TestApplication5 : ctk::Application {
-  TestApplication5() : Application("testSuite") {}
-  ~TestApplication5() override { shutdown(); }
+    CHECK_TIMEOUT(m1_result.readNonBlocking(), 10000);
+    BOOST_CHECK_EQUAL(m1_result, 1101);
+    BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::faulty);
 
-  TestModule3 a{this, "A", ""};
-};
+    CHECK_TIMEOUT(m2_result.readLatest(), 10000);
+    BOOST_CHECK_EQUAL(m2_result, 1101);
+    BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::faulty);
 
-/*********************************************************************************************************************/
+    auto deviceStatus = test.getScalar<int32_t>(ctk::RegisterPath("/Devices") /
+        ChimeraTK::Utilities::escapeName(TestApplication3::ExceptionDummyCDD2, false) / "status");
+    // the device is still OK
+    CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 0, 10000);
 
-BOOST_AUTO_TEST_CASE(testWriteIfDifferent) {
-  std::cout << "testWriteIfDifferent" << std::endl;
+    // ---------------------------------------------------------------------//
+    // device module exception
+    device2DummyBackend->throwExceptionRead = true;
+    pollRegister = 200;
+    pollRegister.write();
+    threadedFanoutInput = 0;
+    threadedFanoutInput.write();
 
-  TestApplication5 app;
-  ctk::TestFacility test{app, false};
+    // Now the device has to go into the error state
+    CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 1, 10000);
 
-  auto o1 = test.getScalar<int>("/A/o1");
-  auto o2 = test.getArray<int>("/A/o2");
+    // The new value of the threadedFanoutInput should be propagated, the
+    // pollRegister is skipped, see testDataValidPropagationOnException.
+    m1_result.read();
+    BOOST_CHECK_EQUAL(m1_result, 1100);
+    BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::faulty);
+    m2_result.read();
+    // Same for m2
+    BOOST_CHECK_EQUAL(m2_result, 1100);
+    BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::faulty);
 
-  test.runApplication();
+    // ---------------------------------------------------------------------//
+    // device exception recovery
+    device2DummyBackend->throwExceptionRead = false;
 
-  // initialise in defined conditions
-  app.a.o1 = 42;
-  app.a.o1.write();
-  BOOST_TEST(o1.readLatest());
-  BOOST_TEST(o1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_TEST(int(o1) == 42);
+    // device error recovers. There must be exactly one new status values with the right value.
+    deviceStatus.read();
+    BOOST_CHECK(deviceStatus == 0);
+    // nothing else in the queue
+    BOOST_CHECK(deviceStatus.readNonBlocking() == false);
 
-  app.a.o2 = {48, 59};
-  app.a.o2.write();
-  BOOST_TEST(o2.readLatest());
-  BOOST_TEST(o2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_TEST(std::vector<int>(o2) == std::vector<int>({48, 59}));
+    // ---------------------------------------------------------------------//
+    // Now both, threadedFanoutInput and pollRegister should propagate
+    pollRegister = 300;
+    pollRegister.write();
+    threadedFanoutInput = 2;
+    threadedFanoutInput.write();
 
-  // set module to faulty and write same value with writeIfDifferent again: faulty flag should be propagated
-  app.a.incrementDataFaultCounter();
-  app.a.o1.writeIfDifferent(42);
-  BOOST_TEST(o1.readNonBlocking());
-  BOOST_TEST(o1.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_TEST(int(o1) == 42);
+    m1_result.read();
+    BOOST_CHECK_EQUAL(m1_result, 1302);
+    // Data validity still faulty because the input from the fan is invalid
+    BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::faulty);
+    // again, nothing else in the queue
+    BOOST_CHECK(m1_result.readNonBlocking() == false);
 
-  // repeat with array
-  app.a.o2.writeIfDifferent({48, 59});
-  BOOST_TEST(o2.readNonBlocking());
-  BOOST_TEST(o2.dataValidity() == ctk::DataValidity::faulty);
-  BOOST_TEST(std::vector<int>(o2) == std::vector<int>({48, 59}));
+    // same for m2
+    m2_result.read();
+    BOOST_CHECK_EQUAL(m2_result, 1302);
+    BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_CHECK(m2_result.readNonBlocking() == false);
 
-  // repeat with ok validity
-  app.a.decrementDataFaultCounter();
-  app.a.o1.writeIfDifferent(42);
-  BOOST_TEST(o1.readNonBlocking());
-  BOOST_TEST(o1.dataValidity() == ctk::DataValidity::ok);
-  BOOST_TEST(int(o1) == 42);
+    // ---------------------------------------------------------------------//
+    // recovery: fanout input
+    threadedFanoutInput = 3;
+    threadedFanoutInput.setDataValidity(ctk::DataValidity::ok);
+    threadedFanoutInput.write();
 
-  app.a.o2.writeIfDifferent({48, 59});
-  BOOST_TEST(o2.readNonBlocking());
-  BOOST_TEST(o2.dataValidity() == ctk::DataValidity::ok);
-  BOOST_TEST(std::vector<int>(o2) == std::vector<int>({48, 59}));
-}
+    m1_result.read();
+    BOOST_CHECK_EQUAL(m1_result, 1303);
+    BOOST_CHECK(m1_result.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(m1_result.readNonBlocking() == false);
 
-/*********************************************************************************************************************/
+    m2_result.read();
+    BOOST_CHECK_EQUAL(m2_result, 1303);
+    BOOST_CHECK(m2_result.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK(m1_result.readNonBlocking() == false);
+  }
+
+  BOOST_AUTO_TEST_SUITE_END()
+
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
+
+  // Module and Application for test case "testDataValidPropagationOnException"
+  struct Module3 : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+    ctk::ScalarPushInput<int> pushTypeInputFromCS{this, "o1", "", "", {"CS"}};
+
+    ctk::ScalarPollInput<int> pollInputFromDevice{this, "/m1/i2", "", "", {"DEVICE2"}};
+    ctk::ScalarOutput<int> result{this, "Module3_result", "", "", {"CS"}};
+
+    void mainLoop() override {
+      while(true) {
+        result = pushTypeInputFromCS + pollInputFromDevice;
+        result.write();
+        readAll(); // read last, so initial values are written in the first round
+      }
+    }
+  };
+
+  struct TestApplication4 : ctk::Application {
+    /*
+     *
+     */
+
+    constexpr static char const* ExceptionDummyCDD2 = "(ExceptionDummy:1?map=testDataValidity2.map)";
+    TestApplication4() : Application("testDataFlagPropagation") {}
+    ~TestApplication4() override { shutdown(); }
+
+    Module3 module{this, "module", ""};
+
+    ctk::DeviceModule device2{this, ExceptionDummyCDD2};
+
+    /*  void defineConnections() override {
+        findTag("CS").connectTo(cs);
+        findTag("DEVICE2").flatten().connectTo(device2["m1"]);
+      }*/
+  };
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDataValidPropagationOnException) {
+    std::cout << "testDataValidPropagationOnException" << std::endl;
+
+    boost::shared_ptr<ctk::ExceptionDummy> device2DummyBackend(boost::dynamic_pointer_cast<ctk::ExceptionDummy>(
+        ChimeraTK::BackendFactory::getInstance().createBackend(TestApplication3::ExceptionDummyCDD2)));
+    ctk::Device device2(TestApplication3::ExceptionDummyCDD2);
+
+    TestApplication4 app;
+    ctk::TestFacility test{app, false};
+
+    auto pollRegister = device2.getScalarRegisterAccessor<int>("/m1/i2.DUMMY_WRITEABLE");
+    device2.open();
+    pollRegister = 1;
+    pollRegister.write();
+    device2.close();
+
+    test.runApplication();
+
+    auto pushInput = test.getScalar<int>("module/o1");
+    auto result = test.getScalar<int>("module/Module3_result");
+
+    auto deviceStatus = test.getScalar<int32_t>(ctk::RegisterPath("/Devices") /
+        ctk::Utilities::escapeName(TestApplication3::ExceptionDummyCDD2, false) / "status");
+
+    pushInput = 10;
+    pushInput.write();
+
+    CHECK_TIMEOUT((result.readLatest(), result == 11), 10000);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
+    CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 0, 10000);
+
+    // Set data validity to faulty and trigger excetion in the same update
+    pollRegister = 2;
+    pollRegister.write();
+    pushInput = 20;
+    pushInput.setDataValidity(ctk::DataValidity::faulty);
+    device2DummyBackend->throwExceptionRead = true;
+    pushInput.write();
+
+    CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 1, 10000);
+    result.read();
+    BOOST_CHECK(result.readLatest() == false);
+    // The new data from the pushInput and the DataValidity::faulty should have been propagated to the outout,
+    // the pollRegister should be skipped (Exceptionhandling spec B.2.2.3), so we don't expect the latest assigned value of 2
+    BOOST_CHECK_EQUAL(result, 21);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+
+    // Writeing the pushInput should still trigger module execution and
+    // update the result value. Result validity should still be faulty because
+    // the device still has the exception
+    pushInput = 30;
+    pushInput.setDataValidity(ctk::DataValidity::ok);
+    pushInput.write();
+    result.read();
+    BOOST_CHECK_EQUAL(result, 31);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+
+    // let the device recover
+    device2DummyBackend->throwExceptionRead = false;
+    CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 0, 10000);
+
+    // Everything should be back to normal, also the value of the pollRegister
+    // should be reflected in the output
+    pushInput = 40;
+    pollRegister = 3;
+    pollRegister.write();
+    pushInput.write();
+    result.read();
+    BOOST_CHECK_EQUAL(result, 43);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
+    // nothing more in the queue
+    BOOST_CHECK(result.readLatest() == false);
+
+    // Check if we get faulty output from the exception alone,
+    // keep pushInput ok
+    pollRegister = 4;
+    pollRegister.write();
+    pushInput = 50;
+    device2DummyBackend->throwExceptionRead = true;
+
+    pushInput.write();
+    result.read();
+    BOOST_CHECK(result.readLatest() == false);
+    // The new data from the pushInput, the device exception should yield DataValidity::faulty at the outout,
+    BOOST_CHECK_EQUAL(result, 53);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+
+    // Device status should report fault. We need to wait for it here to make sure the DeviceModule has seen the fault.
+    CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 1, 10000);
+
+    // Also set pushInputValidity to faulty
+    pushInput = 60;
+    pushInput.setDataValidity(ctk::DataValidity::faulty);
+    pushInput.write();
+    result.read();
+    BOOST_CHECK_EQUAL(result, 63);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+
+    // let the device recover
+    device2DummyBackend->throwExceptionRead = false;
+    CHECK_EQUAL_TIMEOUT((deviceStatus.readLatest(), deviceStatus), 0, 10000);
+
+    // The new pollRegister value should now be reflected in the result,
+    // but it's still faulty from the pushInput
+    pushInput = 70;
+    pollRegister = 5;
+    pollRegister.write();
+    pushInput.write();
+    result.read();
+    BOOST_CHECK_EQUAL(result, 75);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::faulty);
+
+    // MAke pushInput ok, everything should be back to normal
+    pushInput = 80;
+    pushInput.setDataValidity(ctk::DataValidity::ok);
+    pollRegister = 6;
+    pollRegister.write();
+    pushInput.write();
+    result.read();
+    BOOST_CHECK_EQUAL(result, 86);
+    BOOST_CHECK(result.dataValidity() == ctk::DataValidity::ok);
+    // nothing more in the queue
+    BOOST_CHECK(result.readLatest() == false);
+  }
+
+  /*********************************************************************************************************************/
+
+  struct TestModule3 : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+    ctk::ScalarOutput<int> o1{this, "o1", "", ""};
+    ctk::ArrayOutput<int> o2{this, "o2", "", 2, ""};
+    void mainLoop() override {}
+  };
+
+  /*********************************************************************************************************************/
+
+  struct TestApplication5 : ctk::Application {
+    TestApplication5() : Application("testSuite") {}
+    ~TestApplication5() override { shutdown(); }
+
+    TestModule3 a{this, "A", ""};
+  };
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testWriteIfDifferent) {
+    std::cout << "testWriteIfDifferent" << std::endl;
+
+    TestApplication5 app;
+    ctk::TestFacility test{app, false};
+
+    auto o1 = test.getScalar<int>("/A/o1");
+    auto o2 = test.getArray<int>("/A/o2");
+
+    test.runApplication();
+
+    // initialise in defined conditions
+    app.a.o1 = 42;
+    app.a.o1.write();
+    BOOST_TEST(o1.readLatest());
+    BOOST_TEST(o1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_TEST(int(o1) == 42);
+
+    app.a.o2 = {48, 59};
+    app.a.o2.write();
+    BOOST_TEST(o2.readLatest());
+    BOOST_TEST(o2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_TEST(std::vector<int>(o2) == std::vector<int>({48, 59}));
+
+    // set module to faulty and write same value with writeIfDifferent again: faulty flag should be propagated
+    app.a.incrementDataFaultCounter();
+    app.a.o1.writeIfDifferent(42);
+    BOOST_TEST(o1.readNonBlocking());
+    BOOST_TEST(o1.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_TEST(int(o1) == 42);
+
+    // repeat with array
+    app.a.o2.writeIfDifferent({48, 59});
+    BOOST_TEST(o2.readNonBlocking());
+    BOOST_TEST(o2.dataValidity() == ctk::DataValidity::faulty);
+    BOOST_TEST(std::vector<int>(o2) == std::vector<int>({48, 59}));
+
+    // repeat with ok validity
+    app.a.decrementDataFaultCounter();
+    app.a.o1.writeIfDifferent(42);
+    BOOST_TEST(o1.readNonBlocking());
+    BOOST_TEST(o1.dataValidity() == ctk::DataValidity::ok);
+    BOOST_TEST(int(o1) == 42);
+
+    app.a.o2.writeIfDifferent({48, 59});
+    BOOST_TEST(o2.readNonBlocking());
+    BOOST_TEST(o2.dataValidity() == ctk::DataValidity::ok);
+    BOOST_TEST(std::vector<int>(o2) == std::vector<int>({48, 59}));
+  }
+
+  /*********************************************************************************************************************/
+
+} // namespace Tests::testPropagateDataFaultFlag

--- a/tests/executables_src/testScriptedInitialisationHandler.cc
+++ b/tests/executables_src/testScriptedInitialisationHandler.cc
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
 // SPDX-License-Identifier: LGPL-3.0-or-later
-#define BOOST_TEST_MODULE testExceptionHandling
+#define BOOST_TEST_MODULE testScriptedInitialisationHandler
 #include "Application.h"
 #include "check_timeout.h"
 #include "DeviceModule.h"
@@ -12,144 +12,148 @@
 #include <filesystem>
 #include <fstream>
 
-using namespace ChimeraTK;
+namespace Tests::testScriptedInitialisationHandler {
 
-/*********************************************************************************************************************/
+  using namespace ChimeraTK;
 
-struct TestApp : public Application {
-  using Application::Application;
-  ~TestApp() override { shutdown(); }
+  /*********************************************************************************************************************/
 
-  SetDMapFilePath dmap{"test.dmap"};
+  struct TestApp : public Application {
+    using Application::Application;
+    ~TestApp() override { shutdown(); }
 
-  DeviceModule dev1{this, "Dummy0",
-      "/MyModule/actuator"}; // pick one of the writable variables to AC knows that data type for the trigger
+    SetDMapFilePath dmap{"test.dmap"};
 
-  // default name for the output variable (initScriptOutput)
-  ScriptedInitHandler initHandler1{this, "InitHander1", "description", "./deviceInitScript1.bash", dev1};
-  // change the name of the output variable in case a second script is needed. Shorten the error grace time to 1 second
-  ScriptedInitHandler initHandler2{
-      this, "InitHander2", "description", "./deviceInitScript2.bash", dev1, "secondInitScriptOutput", 1};
-};
+    DeviceModule dev1{this, "Dummy0",
+        "/MyModule/actuator"}; // pick one of the writable variables to AC knows that data type for the trigger
 
-/*********************************************************************************************************************/
+    // default name for the output variable (initScriptOutput)
+    ScriptedInitHandler initHandler1{this, "InitHander1", "description", "./deviceInitScript1.bash", dev1};
+    // change the name of the output variable in case a second script is needed. Shorten the error grace time to 1 second
+    ScriptedInitHandler initHandler2{
+        this, "InitHander2", "description", "./deviceInitScript2.bash", dev1, "secondInitScriptOutput", 1};
+  };
 
-struct Fixture {
-  TestApp testApp{"ScriptedInitApp"};
-  TestFacility testFacility{testApp, false};
-};
+  /*********************************************************************************************************************/
 
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
+  struct Fixture {
+    TestApp testApp{"ScriptedInitApp"};
+    TestFacility testFacility{testApp, false};
+  };
 
-BOOST_FIXTURE_TEST_CASE(testSuccess, Fixture) {
-  (void)std::filesystem::remove("device1Init.success");
-  (void)std::filesystem::remove("continueDevice1Init");
-  (void)std::filesystem::remove("produceDevice1InitError");
-  (void)std::filesystem::remove("produceDevice2InitError");
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-  testFacility.runApplication();
-  // testApp.dumpConnections();
+  BOOST_FIXTURE_TEST_CASE(testSuccess, Fixture) {
+    (void)std::filesystem::remove("device1Init.success");
+    (void)std::filesystem::remove("continueDevice1Init");
+    (void)std::filesystem::remove("produceDevice1InitError");
+    (void)std::filesystem::remove("produceDevice2InitError");
 
-  auto initMessage = testFacility.getScalar<std::string>("/Devices/Dummy0/initScriptOutput");
+    testFacility.runApplication();
+    // testApp.dumpConnections();
 
-  initMessage.read();
-  std::string referenceString; // currently emtpy
-  BOOST_CHECK_EQUAL(static_cast<std::string>(initMessage), referenceString);
+    auto initMessage = testFacility.getScalar<std::string>("/Devices/Dummy0/initScriptOutput");
 
-  initMessage.read();
-  referenceString += "starting device1 init\n";
-  BOOST_CHECK_EQUAL(static_cast<std::string>(initMessage), referenceString);
+    initMessage.read();
+    std::string referenceString; // currently emtpy
+    BOOST_CHECK_EQUAL(static_cast<std::string>(initMessage), referenceString);
 
-  // no more messages, script waiting for continue file
-  BOOST_CHECK(initMessage.readLatest() == false);
+    initMessage.read();
+    referenceString += "starting device1 init\n";
+    BOOST_CHECK_EQUAL(static_cast<std::string>(initMessage), referenceString);
 
-  // let the script finish
-  std::ofstream continueFile;
-  continueFile.open("continueDevice1Init", std::ios::out);
+    // no more messages, script waiting for continue file
+    BOOST_CHECK(initMessage.readLatest() == false);
 
-  initMessage.read();
-  referenceString += "device1 init successful\n";
-  BOOST_CHECK_EQUAL(static_cast<std::string>(initMessage), referenceString);
+    // let the script finish
+    std::ofstream continueFile;
+    continueFile.open("continueDevice1Init", std::ios::out);
 
-  initMessage.read();
-  referenceString += "Dummy0 initialisation SUCCESS!";
-  BOOST_CHECK_EQUAL(static_cast<std::string>(initMessage), referenceString);
+    initMessage.read();
+    referenceString += "device1 init successful\n";
+    BOOST_CHECK_EQUAL(static_cast<std::string>(initMessage), referenceString);
 
-  BOOST_CHECK(std::filesystem::exists("device1Init.success"));
+    initMessage.read();
+    referenceString += "Dummy0 initialisation SUCCESS!";
+    BOOST_CHECK_EQUAL(static_cast<std::string>(initMessage), referenceString);
 
-  auto secondInitMessage = testFacility.getScalar<std::string>("/Devices/Dummy0/secondInitScriptOutput");
-  referenceString = "just a second script\nDummy0 initialisation SUCCESS!";
-  CHECK_TIMEOUT((secondInitMessage.readLatest(), std::string(secondInitMessage) == referenceString), 20000);
+    BOOST_CHECK(std::filesystem::exists("device1Init.success"));
 
-  // cleanup
-  (void)std::filesystem::remove("device1Init.success");
-  (void)std::filesystem::remove("continueDevice1Init");
-}
+    auto secondInitMessage = testFacility.getScalar<std::string>("/Devices/Dummy0/secondInitScriptOutput");
+    referenceString = "just a second script\nDummy0 initialisation SUCCESS!";
+    CHECK_TIMEOUT((secondInitMessage.readLatest(), std::string(secondInitMessage) == referenceString), 20000);
 
-/*********************************************************************************************************************/
-
-BOOST_FIXTURE_TEST_CASE(testError, Fixture) {
-  std::ofstream produceErrorFile; // If the file exists, the script produces an error
-  produceErrorFile.open("produceDevice2InitError", std::ios::out);
-
-  // let script1 finish
-  std::ofstream continueFile;
-  continueFile.open("continueDevice1Init", std::ios::out);
-
-  testFacility.runApplication();
-
-  // testApp.dumpConnections();
-  auto secondInitMessage = testFacility.getScalar<std::string>("/Devices/Dummy0/secondInitScriptOutput");
-
-  // let the script run three times, check that always the output of the last run is visible in the control system
-  auto startTime = std::chrono::steady_clock::now();
-  for(int i = 0; i < 3; ++i) {
-    produceErrorFile.seekp(0);
-    produceErrorFile << i << std::flush;
-    std::string referenceString =
-        "Simulating error in second script: " + std::to_string(i) + "\n!!! Dummy0 initialisation FAILED!";
-    CHECK_TIMEOUT((secondInitMessage.readLatest(), std::string(secondInitMessage)) == referenceString, 20000);
+    // cleanup
+    (void)std::filesystem::remove("device1Init.success");
+    (void)std::filesystem::remove("continueDevice1Init");
   }
 
-  (void)std::filesystem::remove("produceDevice2InitError");
+  /*********************************************************************************************************************/
 
-  // recovery
-  std::string referenceString = "just a second script\nDummy0 initialisation SUCCESS!";
-  CHECK_TIMEOUT((secondInitMessage.readLatest(), std::string(secondInitMessage)) == referenceString, 20000);
-  // at least three failure grace periods
-  auto stopTime = std::chrono::steady_clock::now();
-  BOOST_CHECK(std::chrono::duration_cast<std::chrono::seconds>(stopTime - startTime).count() >= 3);
+  BOOST_FIXTURE_TEST_CASE(testError, Fixture) {
+    std::ofstream produceErrorFile; // If the file exists, the script produces an error
+    produceErrorFile.open("produceDevice2InitError", std::ios::out);
 
-  (void)std::filesystem::remove("device1Init.success");
-  (void)std::filesystem::remove("continueDevice1Init");
-}
+    // let script1 finish
+    std::ofstream continueFile;
+    continueFile.open("continueDevice1Init", std::ios::out);
 
-/*********************************************************************************************************************/
+    testFacility.runApplication();
 
-BOOST_FIXTURE_TEST_CASE(testLineByLineOutput, Fixture) {
-  std::ofstream produceErrorFile; // If the file exists, the script produces an error
-  produceErrorFile.open("produceDevice2InitSecondLine", std::ios::out);
+    // testApp.dumpConnections();
+    auto secondInitMessage = testFacility.getScalar<std::string>("/Devices/Dummy0/secondInitScriptOutput");
 
-  // let script1 finish
-  std::ofstream continueFile;
-  continueFile.open("continueDevice1Init", std::ios::out);
+    // let the script run three times, check that always the output of the last run is visible in the control system
+    auto startTime = std::chrono::steady_clock::now();
+    for(int i = 0; i < 3; ++i) {
+      produceErrorFile.seekp(0);
+      produceErrorFile << i << std::flush;
+      std::string referenceString =
+          "Simulating error in second script: " + std::to_string(i) + "\n!!! Dummy0 initialisation FAILED!";
+      CHECK_TIMEOUT((secondInitMessage.readLatest(), std::string(secondInitMessage)) == referenceString, 20000);
+    }
 
-  testFacility.runApplication();
+    (void)std::filesystem::remove("produceDevice2InitError");
 
-  // testApp.dumpConnections();
-  auto secondInitMessage = testFacility.getScalar<std::string>("/Devices/Dummy0/secondInitScriptOutput");
+    // recovery
+    std::string referenceString = "just a second script\nDummy0 initialisation SUCCESS!";
+    CHECK_TIMEOUT((secondInitMessage.readLatest(), std::string(secondInitMessage)) == referenceString, 20000);
+    // at least three failure grace periods
+    auto stopTime = std::chrono::steady_clock::now();
+    BOOST_CHECK(std::chrono::duration_cast<std::chrono::seconds>(stopTime - startTime).count() >= 3);
 
-  std::string referenceString = "Just another output line...\n";
-  CHECK_TIMEOUT((secondInitMessage.readLatest(), std::string(secondInitMessage)) == referenceString, 20000);
+    (void)std::filesystem::remove("device1Init.success");
+    (void)std::filesystem::remove("continueDevice1Init");
+  }
 
-  (void)std::filesystem::remove("produceDevice2InitSecondLine");
+  /*********************************************************************************************************************/
 
-  referenceString = "Just another output line...\njust a second script\nDummy0 initialisation SUCCESS!";
-  CHECK_TIMEOUT((secondInitMessage.readLatest(), std::string(secondInitMessage)) == referenceString, 20000);
+  BOOST_FIXTURE_TEST_CASE(testLineByLineOutput, Fixture) {
+    std::ofstream produceErrorFile; // If the file exists, the script produces an error
+    produceErrorFile.open("produceDevice2InitSecondLine", std::ios::out);
 
-  (void)std::filesystem::remove("device1Init.success");
-  (void)std::filesystem::remove("continueDevice1Init");
-}
+    // let script1 finish
+    std::ofstream continueFile;
+    continueFile.open("continueDevice1Init", std::ios::out);
 
-/*********************************************************************************************************************/
+    testFacility.runApplication();
+
+    // testApp.dumpConnections();
+    auto secondInitMessage = testFacility.getScalar<std::string>("/Devices/Dummy0/secondInitScriptOutput");
+
+    std::string referenceString = "Just another output line...\n";
+    CHECK_TIMEOUT((secondInitMessage.readLatest(), std::string(secondInitMessage)) == referenceString, 20000);
+
+    (void)std::filesystem::remove("produceDevice2InitSecondLine");
+
+    referenceString = "Just another output line...\njust a second script\nDummy0 initialisation SUCCESS!";
+    CHECK_TIMEOUT((secondInitMessage.readLatest(), std::string(secondInitMessage)) == referenceString, 20000);
+
+    (void)std::filesystem::remove("device1Init.success");
+    (void)std::filesystem::remove("continueDevice1Init");
+  }
+
+  /*********************************************************************************************************************/
+
+} // namespace Tests::testScriptedInitialisationHandler

--- a/tests/executables_src/testStatusAggregator.cc
+++ b/tests/executables_src/testStatusAggregator.cc
@@ -12,658 +12,663 @@
 #include <boost/test/included/unit_test.hpp>
 #undef BOOST_NO_EXCEPTIONS
 
-using namespace boost::unit_test_framework;
+namespace Tests::testStatusAggregator {
 
-namespace ctk = ChimeraTK;
+  using namespace boost::unit_test_framework;
 
-/**********************************************************************************************************************/
+  namespace ctk = ChimeraTK;
 
-struct StatusGenerator : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
+  /**********************************************************************************************************************/
 
-  StatusGenerator(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
-      const std::unordered_set<std::string>& tags = {},
-      ctk::StatusOutput::Status initialStatus = ctk::StatusOutput::Status::OFF)
-  : ApplicationModule(owner, name, description, tags), initialValue(initialStatus) {}
+  struct StatusGenerator : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  ctk::StatusOutput status{this, getName(), ""};
+    StatusGenerator(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
+        const std::unordered_set<std::string>& tags = {},
+        ctk::StatusOutput::Status initialStatus = ctk::StatusOutput::Status::OFF)
+    : ApplicationModule(owner, name, description, tags), initialValue(initialStatus) {}
 
-  ctk::StatusOutput::Status initialValue;
+    ctk::StatusOutput status{this, getName(), ""};
 
-  void prepare() override {
-    status = initialValue;
-    status.write();
-  }
-  void mainLoop() override {}
-};
+    ctk::StatusOutput::Status initialValue;
 
-/**********************************************************************************************************************/
-
-struct StatusWithMessageGenerator : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  StatusWithMessageGenerator(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
-      const std::unordered_set<std::string>& tags = {},
-      ctk::StatusOutput::Status initialStatus = ctk::StatusOutput::Status::OFF)
-  : ApplicationModule(owner, name, description, tags), initialValue(initialStatus) {}
-
-  ctk::StatusWithMessage status{this, getName(), ""};
-
-  ctk::StatusOutput::Status initialValue;
-
-  void prepare() override {
-    if(initialValue == ctk::StatusOutput::Status::OK) {
-      status.writeOk();
+    void prepare() override {
+      status = initialValue;
+      status.write();
     }
-    else {
-      status.write(initialValue, getDescription());
-    }
-  }
-  void mainLoop() override {}
-};
-
-/**********************************************************************************************************************/
-
-struct TestApplication : ctk::Application {
-  TestApplication() : Application("testApp") {}
-  ~TestApplication() override { shutdown(); }
-
-  StatusGenerator s{this, "s", "Status"};
-
-  struct OuterGroup : ctk::ModuleGroup {
-    using ctk::ModuleGroup::ModuleGroup;
-
-    StatusGenerator s1{this, "s1", "Status 1"};
-    StatusGenerator s2{this, "s2", "Status 2"};
-
-    struct InnerGroup : ctk::ModuleGroup {
-      using ctk::ModuleGroup::ModuleGroup;
-      StatusGenerator s{this, "s", "Status"};
-      StatusGenerator deep{this, "deep", "Status"};
-    };
-    InnerGroup innerGroup1{this, "InnerGroup1", ""};
-    InnerGroup innerGroup2{this, "InnerGroup2", ""};
-
-  } outerGroup{this, "OuterGroup", ""};
-
-  ctk::StatusAggregator aggregator{
-      this, "Aggregated/status", "aggregated status description", ctk::StatusAggregator::PriorityMode::fwko};
-};
-
-/**********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testSingleNoTags) {
-  std::cout << "testSingleNoTags" << std::endl;
-
-  TestApplication app;
-  ctk::TestFacility test(app);
-
-  auto status = test.getScalar<int>("/Aggregated/status");
-
-  test.runApplication();
-
-  // check that statuses on different levels are correctly aggregated
-  auto check = [&](auto& var) {
-    var = ctk::StatusOutput::Status::OK;
-    var.write();
-    test.stepApplication();
-    BOOST_CHECK(status.readNonBlocking() == true);
-    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
-    var = ctk::StatusOutput::Status::OFF;
-    var.write();
-    test.stepApplication();
-    BOOST_CHECK(status.readNonBlocking() == true);
-    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OFF));
+    void mainLoop() override {}
   };
-  check(app.s.status);
-  check(app.outerGroup.s1.status);
-  check(app.outerGroup.s2.status);
-  check(app.outerGroup.innerGroup1.s.status);
-  check(app.outerGroup.innerGroup1.deep.status);
-  check(app.outerGroup.innerGroup2.s.status);
-  check(app.outerGroup.innerGroup2.deep.status);
-}
 
-/**********************************************************************************************************************/
+  /**********************************************************************************************************************/
 
-BOOST_AUTO_TEST_CASE(testDataValidity) {
-  std::cout << "testDataValidity" << std::endl;
+  struct StatusWithMessageGenerator : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  TestApplication app;
-  ctk::TestFacility test(app);
+    StatusWithMessageGenerator(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
+        const std::unordered_set<std::string>& tags = {},
+        ctk::StatusOutput::Status initialStatus = ctk::StatusOutput::Status::OFF)
+    : ApplicationModule(owner, name, description, tags), initialValue(initialStatus) {}
 
-  auto status = test.getScalar<int>("/Aggregated/status");
+    ctk::StatusWithMessage status{this, getName(), ""};
 
-  test.runApplication();
+    ctk::StatusOutput::Status initialValue;
 
-  app.s.incrementDataFaultCounter();
-  app.s.status = ctk::StatusOutput::Status::OK;
-  app.s.status.write();
-  test.stepApplication();
-  BOOST_CHECK(status.readNonBlocking() == true);
-  BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
-  app.s.status = ctk::StatusOutput::Status::OFF;
-  app.s.status.write();
-  test.stepApplication();
-  BOOST_CHECK(status.readNonBlocking() == true);
-  BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OFF));
-}
+    void prepare() override {
+      if(initialValue == ctk::StatusOutput::Status::OK) {
+        status.writeOk();
+      }
+      else {
+        status.write(initialValue, getDescription());
+      }
+    }
+    void mainLoop() override {}
+  };
 
-/**********************************************************************************************************************/
+  /**********************************************************************************************************************/
 
-struct TestPrioApplication : ctk::Application {
-  explicit TestPrioApplication(ctk::StatusOutput::Status theInitialValue)
-  : Application("testApp"), initialValue(theInitialValue) {}
-  ~TestPrioApplication() override { shutdown(); }
+  struct TestApplication : ctk::Application {
+    TestApplication() : Application("testApp") {}
+    ~TestApplication() override { shutdown(); }
 
-  ctk::StatusOutput::Status initialValue;
+    StatusGenerator s{this, "s", "Status"};
 
-  StatusGenerator s1{this, "sg1/internal", "Status 1", {}, initialValue};
-  StatusGenerator s2{this, "sg2/external", "Status 2", {}, initialValue};
+    struct OuterGroup : ctk::ModuleGroup {
+      using ctk::ModuleGroup::ModuleGroup;
 
-  ctk::StatusAggregator aggregator;
-};
+      StatusGenerator s1{this, "s1", "Status 1"};
+      StatusGenerator s2{this, "s2", "Status 2"};
 
-/**********************************************************************************************************************/
+      struct InnerGroup : ctk::ModuleGroup {
+        using ctk::ModuleGroup::ModuleGroup;
+        StatusGenerator s{this, "s", "Status"};
+        StatusGenerator deep{this, "deep", "Status"};
+      };
+      InnerGroup innerGroup1{this, "InnerGroup1", ""};
+      InnerGroup innerGroup2{this, "InnerGroup2", ""};
 
-BOOST_AUTO_TEST_CASE(testPriorities) {
-  std::cout << "testPriorities" << std::endl;
+    } outerGroup{this, "OuterGroup", ""};
 
-  // Define repeated check for a given priority mode
-  auto check = [&](ctk::StatusAggregator::PriorityMode mode, auto prio0, auto prio1, auto prio2, auto prio3,
-                   bool warnMixed01 = false) {
-    // create app with initial values set to lowest prio value
-    TestPrioApplication app(prio0);
+    ctk::StatusAggregator aggregator{
+        this, "Aggregated/status", "aggregated status description", ctk::StatusAggregator::PriorityMode::fwko};
+  };
 
-    app.aggregator = ctk::StatusAggregator{&app, "Aggregated/status", "aggregated status description", mode};
+  /**********************************************************************************************************************/
 
+  BOOST_AUTO_TEST_CASE(testSingleNoTags) {
+    std::cout << "testSingleNoTags" << std::endl;
+
+    TestApplication app;
     ctk::TestFacility test(app);
 
     auto status = test.getScalar<int>("/Aggregated/status");
 
     test.runApplication();
 
-    // check initial value
-    status.readNonBlocking(); // do not check return value, as it will only be written when changed
-    BOOST_CHECK_EQUAL(int(status), int(prio0));
-
-    // Define repeated check to test all combinations of two given values with different priority.
-    // This kind of a whitebox test. We know that
-    // - the first aggregates variable has a different code path
-    // - the code path depends on the VersionNumber, so the write order matters and we have to set the version number
-    auto subcheck = [&](auto lower, auto higher, bool writeS2First, bool warnMixed = false) {
-      StatusGenerator* first;
-      StatusGenerator* second;
-      if(writeS2First) {
-        first = &app.s2;
-        second = &app.s1;
-      }
-      else {
-        first = &app.s1;
-        second = &app.s2;
-      }
-      std::cout << int(lower) << " vs. " << int(higher) << std::endl;
-      first->status = lower;
-      first->setCurrentVersionNumber({});
-      first->status.write();
-      second->status = lower;
-      second->setCurrentVersionNumber({});
-      second->status.write();
+    // check that statuses on different levels are correctly aggregated
+    auto check = [&](auto& var) {
+      var = ctk::StatusOutput::Status::OK;
+      var.write();
       test.stepApplication();
-      status.readLatest();
-      BOOST_CHECK_EQUAL(int(status), int(lower));
-      first->status = lower;
-      first->setCurrentVersionNumber({});
-      first->status.write();
-      second->status = higher;
-      second->setCurrentVersionNumber({});
-      second->status.write();
+      BOOST_CHECK(status.readNonBlocking() == true);
+      BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
+      var = ctk::StatusOutput::Status::OFF;
+      var.write();
       test.stepApplication();
-      status.readLatest();
-      if(!warnMixed) {
-        BOOST_CHECK_EQUAL(int(status), int(higher));
-      }
-      else {
-        BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::WARNING));
-      }
-      first->status = higher;
-      first->setCurrentVersionNumber({});
-      first->status.write();
-      second->status = lower;
-      second->setCurrentVersionNumber({});
-      second->status.write();
-      test.stepApplication();
-      status.readLatest();
-      if(!warnMixed) {
-        BOOST_CHECK_EQUAL(int(status), int(higher));
-      }
-      else {
-        BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::WARNING));
-      }
-      first->status = higher;
-      first->setCurrentVersionNumber({});
-      first->status.write();
-      second->status = higher;
-      second->setCurrentVersionNumber({});
-      second->status.write();
-      test.stepApplication();
-      status.readLatest();
-      BOOST_CHECK_EQUAL(int(status), int(higher));
+      BOOST_CHECK(status.readNonBlocking() == true);
+      BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OFF));
     };
+    check(app.s.status);
+    check(app.outerGroup.s1.status);
+    check(app.outerGroup.s2.status);
+    check(app.outerGroup.innerGroup1.s.status);
+    check(app.outerGroup.innerGroup1.deep.status);
+    check(app.outerGroup.innerGroup2.s.status);
+    check(app.outerGroup.innerGroup2.deep.status);
+  }
 
-    // all prios against each other
-    auto runAllSubchecks = [&](bool writeS2First) {
-      subcheck(prio0, prio1, writeS2First, warnMixed01);
-      subcheck(prio0, prio2, writeS2First);
-      subcheck(prio0, prio3, writeS2First);
-      subcheck(prio1, prio2, writeS2First);
-      subcheck(prio1, prio3, writeS2First);
-      subcheck(prio2, prio3, writeS2First);
-    };
-    runAllSubchecks(false);
-    runAllSubchecks(true);
+  /**********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDataValidity) {
+    std::cout << "testDataValidity" << std::endl;
+
+    TestApplication app;
+    ctk::TestFacility test(app);
+
+    auto status = test.getScalar<int>("/Aggregated/status");
+
+    test.runApplication();
+
+    app.s.incrementDataFaultCounter();
+    app.s.status = ctk::StatusOutput::Status::OK;
+    app.s.status.write();
+    test.stepApplication();
+    BOOST_CHECK(status.readNonBlocking() == true);
+    BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
+    app.s.status = ctk::StatusOutput::Status::OFF;
+    app.s.status.write();
+    test.stepApplication();
+    BOOST_CHECK(status.readNonBlocking() == true);
+    BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OFF));
+  }
+
+  /**********************************************************************************************************************/
+
+  struct TestPrioApplication : ctk::Application {
+    explicit TestPrioApplication(ctk::StatusOutput::Status theInitialValue)
+    : Application("testApp"), initialValue(theInitialValue) {}
+    ~TestPrioApplication() override { shutdown(); }
+
+    ctk::StatusOutput::Status initialValue;
+
+    StatusGenerator s1{this, "sg1/internal", "Status 1", {}, initialValue};
+    StatusGenerator s2{this, "sg2/external", "Status 2", {}, initialValue};
+
+    ctk::StatusAggregator aggregator;
   };
 
-  // check all priority modes
-  std::cout << "PriorityMode::fwko" << std::endl;
-  check(ctk::StatusAggregator::PriorityMode::fwko, ctk::StatusOutput::Status::OFF, ctk::StatusOutput::Status::OK,
-      ctk::StatusOutput::Status::WARNING, ctk::StatusOutput::Status::FAULT);
-  std::cout << "PriorityMode::fwok" << std::endl;
-  check(ctk::StatusAggregator::PriorityMode::fwok, ctk::StatusOutput::Status::OK, ctk::StatusOutput::Status::OFF,
-      ctk::StatusOutput::Status::WARNING, ctk::StatusOutput::Status::FAULT);
-  std::cout << "PriorityMode::ofwk" << std::endl;
-  check(ctk::StatusAggregator::PriorityMode::ofwk, ctk::StatusOutput::Status::OK, ctk::StatusOutput::Status::WARNING,
-      ctk::StatusOutput::Status::FAULT, ctk::StatusOutput::Status::OFF);
-  std::cout << "PriorityMode::fw_warn_mixed" << std::endl;
-  check(ctk::StatusAggregator::PriorityMode::fw_warn_mixed, ctk::StatusOutput::Status::OFF,
-      ctk::StatusOutput::Status::OK, ctk::StatusOutput::Status::WARNING, ctk::StatusOutput::Status::FAULT, true);
-}
+  /**********************************************************************************************************************/
 
-/**********************************************************************************************************************/
+  BOOST_AUTO_TEST_CASE(testPriorities) {
+    std::cout << "testPriorities" << std::endl;
 
-BOOST_AUTO_TEST_CASE(testCustomMixedWarnMessage) {
-  std::cout << "testCustomMixedWarnMessage" << std::endl;
+    // Define repeated check for a given priority mode
+    auto check = [&](ctk::StatusAggregator::PriorityMode mode, auto prio0, auto prio1, auto prio2, auto prio3,
+                     bool warnMixed01 = false) {
+      // create app with initial values set to lowest prio value
+      TestPrioApplication app(prio0);
 
-  const std::string customMessage1{"My custom warn mixed message"};
+      app.aggregator = ctk::StatusAggregator{&app, "Aggregated/status", "aggregated status description", mode};
 
-  TestPrioApplication app(ctk::StatusOutput::Status::OK);
-  app.aggregator = ctk::StatusAggregator{&app, "Aggregated/status", "aggregated status description",
-      ctk::StatusAggregator::PriorityMode::fw_warn_mixed, {}, {}, customMessage1};
+      ctk::TestFacility test(app);
 
-  ctk::TestFacility test(app);
-  test.runApplication();
+      auto status = test.getScalar<int>("/Aggregated/status");
 
-  auto statusMessage = test.getScalar<std::string>("/Aggregated/status_message");
+      test.runApplication();
 
-  // check test pre-condition: No message when OK.
-  BOOST_TEST(std::string(statusMessage) == "");
+      // check initial value
+      status.readNonBlocking(); // do not check return value, as it will only be written when changed
+      BOOST_CHECK_EQUAL(int(status), int(prio0));
 
-  app.s1.setCurrentVersionNumber({});
-  app.s1.status.setAndWrite(int(ctk::StatusOutput::Status::OFF));
-  test.stepApplication();
-  BOOST_TEST(statusMessage.readAndGet() == customMessage1);
+      // Define repeated check to test all combinations of two given values with different priority.
+      // This kind of a whitebox test. We know that
+      // - the first aggregates variable has a different code path
+      // - the code path depends on the VersionNumber, so the write order matters and we have to set the version number
+      auto subcheck = [&](auto lower, auto higher, bool writeS2First, bool warnMixed = false) {
+        StatusGenerator* first;
+        StatusGenerator* second;
+        if(writeS2First) {
+          first = &app.s2;
+          second = &app.s1;
+        }
+        else {
+          first = &app.s1;
+          second = &app.s2;
+        }
+        std::cout << int(lower) << " vs. " << int(higher) << std::endl;
+        first->status = lower;
+        first->setCurrentVersionNumber({});
+        first->status.write();
+        second->status = lower;
+        second->setCurrentVersionNumber({});
+        second->status.write();
+        test.stepApplication();
+        status.readLatest();
+        BOOST_CHECK_EQUAL(int(status), int(lower));
+        first->status = lower;
+        first->setCurrentVersionNumber({});
+        first->status.write();
+        second->status = higher;
+        second->setCurrentVersionNumber({});
+        second->status.write();
+        test.stepApplication();
+        status.readLatest();
+        if(!warnMixed) {
+          BOOST_CHECK_EQUAL(int(status), int(higher));
+        }
+        else {
+          BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::WARNING));
+        }
+        first->status = higher;
+        first->setCurrentVersionNumber({});
+        first->status.write();
+        second->status = lower;
+        second->setCurrentVersionNumber({});
+        second->status.write();
+        test.stepApplication();
+        status.readLatest();
+        if(!warnMixed) {
+          BOOST_CHECK_EQUAL(int(status), int(higher));
+        }
+        else {
+          BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::WARNING));
+        }
+        first->status = higher;
+        first->setCurrentVersionNumber({});
+        first->status.write();
+        second->status = higher;
+        second->setCurrentVersionNumber({});
+        second->status.write();
+        test.stepApplication();
+        status.readLatest();
+        BOOST_CHECK_EQUAL(int(status), int(higher));
+      };
 
-  // Change custom message at run time
-  const std::string customMessage2{"Another warn mixed message"};
-  app.aggregator.setWarnMixedMessage(customMessage2);
+      // all prios against each other
+      auto runAllSubchecks = [&](bool writeS2First) {
+        subcheck(prio0, prio1, writeS2First, warnMixed01);
+        subcheck(prio0, prio2, writeS2First);
+        subcheck(prio0, prio3, writeS2First);
+        subcheck(prio1, prio2, writeS2First);
+        subcheck(prio1, prio3, writeS2First);
+        subcheck(prio2, prio3, writeS2First);
+      };
+      runAllSubchecks(false);
+      runAllSubchecks(true);
+    };
 
-  app.s1.setCurrentVersionNumber({});
-  app.s1.status.setAndWrite(int(ctk::StatusOutput::Status::OFF));
-  test.stepApplication();
-  BOOST_TEST(statusMessage.readAndGet() == customMessage2);
-}
+    // check all priority modes
+    std::cout << "PriorityMode::fwko" << std::endl;
+    check(ctk::StatusAggregator::PriorityMode::fwko, ctk::StatusOutput::Status::OFF, ctk::StatusOutput::Status::OK,
+        ctk::StatusOutput::Status::WARNING, ctk::StatusOutput::Status::FAULT);
+    std::cout << "PriorityMode::fwok" << std::endl;
+    check(ctk::StatusAggregator::PriorityMode::fwok, ctk::StatusOutput::Status::OK, ctk::StatusOutput::Status::OFF,
+        ctk::StatusOutput::Status::WARNING, ctk::StatusOutput::Status::FAULT);
+    std::cout << "PriorityMode::ofwk" << std::endl;
+    check(ctk::StatusAggregator::PriorityMode::ofwk, ctk::StatusOutput::Status::OK, ctk::StatusOutput::Status::WARNING,
+        ctk::StatusOutput::Status::FAULT, ctk::StatusOutput::Status::OFF);
+    std::cout << "PriorityMode::fw_warn_mixed" << std::endl;
+    check(ctk::StatusAggregator::PriorityMode::fw_warn_mixed, ctk::StatusOutput::Status::OFF,
+        ctk::StatusOutput::Status::OK, ctk::StatusOutput::Status::WARNING, ctk::StatusOutput::Status::FAULT, true);
+  }
 
-/**********************************************************************************************************************/
+  /**********************************************************************************************************************/
 
-struct TestApplication2Levels : ctk::Application {
-  TestApplication2Levels() : Application("testApp") {}
-  ~TestApplication2Levels() override { shutdown(); }
+  BOOST_AUTO_TEST_CASE(testCustomMixedWarnMessage) {
+    std::cout << "testCustomMixedWarnMessage" << std::endl;
 
-  StatusGenerator s{this, "s", "Status"};
+    const std::string customMessage1{"My custom warn mixed message"};
 
-  struct OuterGroup : ctk::ModuleGroup {
-    using ctk::ModuleGroup::ModuleGroup;
+    TestPrioApplication app(ctk::StatusOutput::Status::OK);
+    app.aggregator = ctk::StatusAggregator{&app, "Aggregated/status", "aggregated status description",
+        ctk::StatusAggregator::PriorityMode::fw_warn_mixed, {}, {}, customMessage1};
 
-    // Set one of the inputs for the extraAggregator to fault, which has no effect, since one other is OFF which is
-    // prioritised. If the top-level aggregator would wrongly aggregate this input directly, it would go to FAULT.
-    StatusGenerator s1{this, "s1", "Status 1", {}, ctk::StatusOutput::Status::FAULT};
+    ctk::TestFacility test(app);
+    test.runApplication();
 
-    StatusGenerator s2{this, "s2", "Status 2"};
+    auto statusMessage = test.getScalar<std::string>("/Aggregated/status_message");
 
-    ctk::StatusAggregator extraAggregator{
-        this, "/Aggregated/extraStatus", "aggregated status description", ctk::StatusAggregator::PriorityMode::ofwk};
+    // check test pre-condition: No message when OK.
+    BOOST_TEST(std::string(statusMessage) == "");
 
-  } outerGroup{this, "OuterGroup", ""};
+    app.s1.setCurrentVersionNumber({});
+    app.s1.status.setAndWrite(int(ctk::StatusOutput::Status::OFF));
+    test.stepApplication();
+    BOOST_TEST(statusMessage.readAndGet() == customMessage1);
 
-  ctk::StatusAggregator aggregator{
-      this, "Aggregated/status", "aggregated status description", ctk::StatusAggregator::PriorityMode::fwko};
-};
+    // Change custom message at run time
+    const std::string customMessage2{"Another warn mixed message"};
+    app.aggregator.setWarnMixedMessage(customMessage2);
 
-///**********************************************************************************************************************/
+    app.s1.setCurrentVersionNumber({});
+    app.s1.status.setAndWrite(int(ctk::StatusOutput::Status::OFF));
+    test.stepApplication();
+    BOOST_TEST(statusMessage.readAndGet() == customMessage2);
+  }
 
-BOOST_AUTO_TEST_CASE(testTwoLevels) {
-  std::cout << "testTwoLevels" << std::endl << std::endl << std::endl;
-  TestApplication2Levels app;
+  /**********************************************************************************************************************/
 
-  ctk::TestFacility test(app);
+  struct TestApplication2Levels : ctk::Application {
+    TestApplication2Levels() : Application("testApp") {}
+    ~TestApplication2Levels() override { shutdown(); }
 
-  auto status = test.getScalar<int>("/Aggregated/status");
-  auto extraStatus = test.getScalar<int>("/Aggregated/extraStatus");
+    StatusGenerator s{this, "s", "Status"};
 
-  test.runApplication();
+    struct OuterGroup : ctk::ModuleGroup {
+      using ctk::ModuleGroup::ModuleGroup;
 
-  // check the initial values
-  extraStatus.readLatest();
-  BOOST_CHECK_EQUAL(int(extraStatus), int(ctk::StatusOutput::Status::OFF));
-  status.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OFF));
+      // Set one of the inputs for the extraAggregator to fault, which has no effect, since one other is OFF which is
+      // prioritised. If the top-level aggregator would wrongly aggregate this input directly, it would go to FAULT.
+      StatusGenerator s1{this, "s1", "Status 1", {}, ctk::StatusOutput::Status::FAULT};
 
-  // change status which goes directly into the upper aggregator
-  app.s.status = ctk::StatusOutput::Status::OK;
-  app.s.status.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
-  app.s.status = ctk::StatusOutput::Status::OFF;
-  app.s.status.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OFF));
+      StatusGenerator s2{this, "s2", "Status 2"};
 
-  // change status which goes into the lower aggregator (then the FAULT of s1 will win)
-  app.outerGroup.s2.status = ctk::StatusOutput::Status::OK;
-  app.outerGroup.s2.status.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::FAULT));
-  app.outerGroup.s2.status = ctk::StatusOutput::Status::OFF;
-  app.outerGroup.s2.status.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OFF));
-}
+      ctk::StatusAggregator extraAggregator{
+          this, "/Aggregated/extraStatus", "aggregated status description", ctk::StatusAggregator::PriorityMode::ofwk};
 
-/**********************************************************************************************************************/
+    } outerGroup{this, "OuterGroup", ""};
 
-struct TestApplicationTags : ctk::Application {
-  TestApplicationTags() : Application("testApp") {}
-  ~TestApplicationTags() override { shutdown(); }
+    ctk::StatusAggregator aggregator{
+        this, "Aggregated/status", "aggregated status description", ctk::StatusAggregator::PriorityMode::fwko};
+  };
 
-  struct OuterGroup : ctk::ModuleGroup {
-    using ctk::ModuleGroup::ModuleGroup;
+  ///**********************************************************************************************************************/
 
-    StatusGenerator sA{this, "sA", "Status 1", ctk::TAGS{"A"}, ctk::StatusOutput::Status::WARNING};
-    StatusGenerator sAB{this, "sAB", "Status 2", {"A", "B"}, ctk::StatusOutput::Status::OFF};
+  BOOST_AUTO_TEST_CASE(testTwoLevels) {
+    std::cout << "testTwoLevels" << std::endl << std::endl << std::endl;
+    TestApplication2Levels app;
 
-    // First level of aggregation: Input and output tags are identical
+    ctk::TestFacility test(app);
+
+    auto status = test.getScalar<int>("/Aggregated/status");
+    auto extraStatus = test.getScalar<int>("/Aggregated/extraStatus");
+
+    test.runApplication();
+
+    // check the initial values
+    extraStatus.readLatest();
+    BOOST_CHECK_EQUAL(int(extraStatus), int(ctk::StatusOutput::Status::OFF));
+    status.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OFF));
+
+    // change status which goes directly into the upper aggregator
+    app.s.status = ctk::StatusOutput::Status::OK;
+    app.s.status.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
+    app.s.status = ctk::StatusOutput::Status::OFF;
+    app.s.status.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OFF));
+
+    // change status which goes into the lower aggregator (then the FAULT of s1 will win)
+    app.outerGroup.s2.status = ctk::StatusOutput::Status::OK;
+    app.outerGroup.s2.status.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::FAULT));
+    app.outerGroup.s2.status = ctk::StatusOutput::Status::OFF;
+    app.outerGroup.s2.status.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OFF));
+  }
+
+  /**********************************************************************************************************************/
+
+  struct TestApplicationTags : ctk::Application {
+    TestApplicationTags() : Application("testApp") {}
+    ~TestApplicationTags() override { shutdown(); }
+
+    struct OuterGroup : ctk::ModuleGroup {
+      using ctk::ModuleGroup::ModuleGroup;
+
+      StatusGenerator sA{this, "sA", "Status 1", ctk::TAGS{"A"}, ctk::StatusOutput::Status::WARNING};
+      StatusGenerator sAB{this, "sAB", "Status 2", {"A", "B"}, ctk::StatusOutput::Status::OFF};
+
+      // First level of aggregation: Input and output tags are identical
+      ctk::StatusAggregator aggregateA{
+          this, "aggregateA", "aggregated status description", ctk::StatusAggregator::PriorityMode::fwko, {"A"}, {"A"}};
+      ctk::StatusAggregator aggregateB{
+          this, "aggregateB", "aggregated status description", ctk::StatusAggregator::PriorityMode::fwko, {"B"}, {"B"}};
+
+    } group{this, "Group", ""};
+
+    // Use other priority mode here to make sure only the aggregators are aggregated, not the generators
     ctk::StatusAggregator aggregateA{
-        this, "aggregateA", "aggregated status description", ctk::StatusAggregator::PriorityMode::fwko, {"A"}, {"A"}};
+        this, "aggregateA", "aggregated status description", ctk::StatusAggregator::PriorityMode::ofwk, {"A"}};
     ctk::StatusAggregator aggregateB{
-        this, "aggregateB", "aggregated status description", ctk::StatusAggregator::PriorityMode::fwko, {"B"}, {"B"}};
-
-  } group{this, "Group", ""};
-
-  // Use other priority mode here to make sure only the aggregators are aggregated, not the generators
-  ctk::StatusAggregator aggregateA{
-      this, "aggregateA", "aggregated status description", ctk::StatusAggregator::PriorityMode::ofwk, {"A"}};
-  ctk::StatusAggregator aggregateB{
-      this, "aggregateB", "aggregated status description", ctk::StatusAggregator::PriorityMode::ofwk, {"B"}};
-  ctk::StatusAggregator aggregateAll{
-      this, "aggregateAll", "aggregated status description", ctk::StatusAggregator::PriorityMode::fw_warn_mixed};
-};
-
-/**********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testTags) {
-  std::cout << "testTags" << std::endl;
-
-  TestApplicationTags app;
-  ctk::TestFacility test(app);
-
-  auto aggregateA = test.getScalar<int>("/aggregateA");
-  auto aggregateB = test.getScalar<int>("/aggregateB");
-  auto aggregateAll = test.getScalar<int>("/aggregateAll");
-  auto Group_aggregateA = test.getScalar<int>("/Group/aggregateA");
-  auto Group_aggregateB = test.getScalar<int>("/Group/aggregateB");
-
-  test.runApplication();
-
-  // check initial values
-  aggregateA.readLatest();
-  aggregateB.readLatest();
-  aggregateAll.readLatest();
-  Group_aggregateA.readLatest();
-  Group_aggregateB.readLatest();
-  BOOST_CHECK_EQUAL(int(aggregateA), int(ctk::StatusOutput::Status::WARNING));
-  BOOST_CHECK_EQUAL(int(aggregateB), int(ctk::StatusOutput::Status::OFF));
-  BOOST_CHECK_EQUAL(int(aggregateAll), int(ctk::StatusOutput::Status::WARNING));
-  BOOST_CHECK_EQUAL(int(Group_aggregateA), int(ctk::StatusOutput::Status::WARNING));
-  BOOST_CHECK_EQUAL(int(Group_aggregateB), int(ctk::StatusOutput::Status::OFF));
-
-  app.group.sAB.status = ctk::StatusOutput::Status::FAULT;
-  app.group.sAB.status.write();
-
-  test.stepApplication();
-
-  // change value tagged with 'A' and 'B', affecting all aggregators to highest priority value, so it is visible
-  // everywhere
-  aggregateA.readLatest();
-  aggregateB.readLatest();
-  aggregateAll.readLatest();
-  Group_aggregateA.readLatest();
-  Group_aggregateB.readLatest();
-  BOOST_CHECK_EQUAL(int(aggregateA), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(int(aggregateB), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(int(aggregateAll), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(int(Group_aggregateA), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(int(Group_aggregateB), int(ctk::StatusOutput::Status::FAULT));
-}
-
-/**********************************************************************************************************************/
-
-struct TestApplicationAggregatorTags : ctk::Application {
-  TestApplicationAggregatorTags() : Application("testApp") {}
-  ~TestApplicationAggregatorTags() override { shutdown(); }
-
-  struct OuterGroup : ctk::ModuleGroup {
-    using ctk::ModuleGroup::ModuleGroup;
-
-    StatusGenerator sA{this, "sA", "Status A", ctk::TAGS{"A"}};
-    StatusGenerator sB1{this, "sB1", "Status B1", ctk::TAGS{"B"}};
-    StatusGenerator sB2{this, "sB2", "Status B2", ctk::TAGS{"B"}};
-    StatusGenerator sC{this, "sC", "Status C", ctk::TAGS{"C"}};
-
-    ctk::StatusAggregator aggregateA{
-        this, "aggregatedA", "", ctk::StatusAggregator::PriorityMode::fwko, {"A"}, {"AGG_A"}};
-    //  Same input and output tag. When aggregating tag "B" the status outputs themselves shoudl not be taken again.
-    ctk::StatusAggregator aggregateB{this, "aggregatedB", "", ctk::StatusAggregator::PriorityMode::fwko, {"B"}, {"B"}};
-
-    // Missing: Test of multiple aggregation tags. Currently only one tag is allowed due to the missing
-    // design decision whether multiple tags should be a logical AND or OR (#13256).
-  } group{this, "Group", ""};
-
-  // Does not aggregate an aggregator
-  ctk::StatusAggregator aggregateA{this, "aggA", "", ctk::StatusAggregator::PriorityMode::fwko, {"A"}};
-  // Aggregates the A aggregator
-  ctk::StatusAggregator aggAggA{this, "aggAggA", "", ctk::StatusAggregator::PriorityMode::fwko, {"AGG_A"}};
-  // Aggregates the B aggregator
-  ctk::StatusAggregator aggAggB{this, "aggAggB", "", ctk::StatusAggregator::PriorityMode::fwko, {"B"}};
-};
-
-/**********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testAggregatorTags) {
-  std::cout << "testAggregatorTags" << std::endl;
-
-  TestApplicationAggregatorTags app;
-  ctk::TestFacility test(app);
-
-  auto checkForName = [](auto& accessors, std::string name) {
-    return std::any_of(accessors.begin(), accessors.end(), [&name](auto acc) { return acc.getName() == name; });
+        this, "aggregateB", "aggregated status description", ctk::StatusAggregator::PriorityMode::ofwk, {"B"}};
+    ctk::StatusAggregator aggregateAll{
+        this, "aggregateAll", "aggregated status description", ctk::StatusAggregator::PriorityMode::fw_warn_mixed};
   };
 
-  auto accessorsAggA = app.aggregateA.getAccessorListRecursive();
-  // One aggregated input ("sA") + plus 3 inputs/outputs from the aggregator itself
-  // "aggregatedA" is not used because the tag "A" is its input. The output tag is "AGG_A"
-  BOOST_TEST(accessorsAggA.size() == 4);
-  BOOST_CHECK(checkForName(accessorsAggA, "sA"));
-  BOOST_CHECK(!checkForName(accessorsAggA, "aggregatedA"));
+  /**********************************************************************************************************************/
 
-  auto accessorsAggAggA = app.aggAggA.getAccessorListRecursive();
-  // One aggregated input ("aggregatedA") + according status message + plus 3 inputs/outputs from the aggregator itself
-  // "sA" is not used because the tag "A" is its input. The output tag is "AGG_A"
-  BOOST_TEST(accessorsAggAggA.size() == 5);
-  BOOST_CHECK(checkForName(accessorsAggAggA, "aggregatedA"));
-  BOOST_CHECK(!checkForName(accessorsAggAggA, "sA"));
+  BOOST_AUTO_TEST_CASE(testTags) {
+    std::cout << "testTags" << std::endl;
 
-  auto accessorsAggAggB = app.aggAggB.getAccessorListRecursive();
-  // One aggregated input ("aggregatedB") + according status message + plus 3 inputs/outputs from the aggregator itself
-  // "sB1" and "sB2" are not used because their input is already aggregated.
-  BOOST_TEST(accessorsAggAggB.size() == 5);
-  BOOST_CHECK(checkForName(accessorsAggAggB, "aggregatedB"));
-  BOOST_CHECK(!checkForName(accessorsAggAggB, "sB1"));
-  BOOST_CHECK(!checkForName(accessorsAggAggB, "sB2"));
-}
+    TestApplicationTags app;
+    ctk::TestFacility test(app);
 
-/**********************************************************************************************************************/
+    auto aggregateA = test.getScalar<int>("/aggregateA");
+    auto aggregateB = test.getScalar<int>("/aggregateB");
+    auto aggregateAll = test.getScalar<int>("/aggregateAll");
+    auto Group_aggregateA = test.getScalar<int>("/Group/aggregateA");
+    auto Group_aggregateB = test.getScalar<int>("/Group/aggregateB");
 
-struct TestApplicationMessage : ctk::Application {
-  TestApplicationMessage() : Application("testApp") {}
-  ~TestApplicationMessage() override { shutdown(); }
+    test.runApplication();
 
-  StatusGenerator s{this, "s", "Status", {}, ctk::StatusOutput::Status::OK};
+    // check initial values
+    aggregateA.readLatest();
+    aggregateB.readLatest();
+    aggregateAll.readLatest();
+    Group_aggregateA.readLatest();
+    Group_aggregateB.readLatest();
+    BOOST_CHECK_EQUAL(int(aggregateA), int(ctk::StatusOutput::Status::WARNING));
+    BOOST_CHECK_EQUAL(int(aggregateB), int(ctk::StatusOutput::Status::OFF));
+    BOOST_CHECK_EQUAL(int(aggregateAll), int(ctk::StatusOutput::Status::WARNING));
+    BOOST_CHECK_EQUAL(int(Group_aggregateA), int(ctk::StatusOutput::Status::WARNING));
+    BOOST_CHECK_EQUAL(int(Group_aggregateB), int(ctk::StatusOutput::Status::OFF));
 
-  struct OuterGroup : ctk::ModuleGroup {
-    using ctk::ModuleGroup::ModuleGroup;
+    app.group.sAB.status = ctk::StatusOutput::Status::FAULT;
+    app.group.sAB.status.write();
 
-    StatusGenerator s1{this, "s1", "Status 1", {}, ctk::StatusOutput::Status::OK};
+    test.stepApplication();
 
-    StatusWithMessageGenerator s2{this, "s2", "Status 2", {}, ctk::StatusOutput::Status::OK};
+    // change value tagged with 'A' and 'B', affecting all aggregators to highest priority value, so it is visible
+    // everywhere
+    aggregateA.readLatest();
+    aggregateB.readLatest();
+    aggregateAll.readLatest();
+    Group_aggregateA.readLatest();
+    Group_aggregateB.readLatest();
+    BOOST_CHECK_EQUAL(int(aggregateA), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(int(aggregateB), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(int(aggregateAll), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(int(Group_aggregateA), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(int(Group_aggregateB), int(ctk::StatusOutput::Status::FAULT));
+  }
 
-    ctk::StatusAggregator extraAggregator{
-        this, "/Aggregated/extraStatus", "aggregated status description", ctk::StatusAggregator::PriorityMode::ofwk};
+  /**********************************************************************************************************************/
 
-  } outerGroup{this, "OuterGroup", ""};
+  struct TestApplicationAggregatorTags : ctk::Application {
+    TestApplicationAggregatorTags() : Application("testApp") {}
+    ~TestApplicationAggregatorTags() override { shutdown(); }
 
-  ctk::StatusAggregator aggregator{
-      this, "Aggregated/status", "aggregated status description", ctk::StatusAggregator::PriorityMode::fwko};
-};
+    struct OuterGroup : ctk::ModuleGroup {
+      using ctk::ModuleGroup::ModuleGroup;
 
-/**********************************************************************************************************************/
+      StatusGenerator sA{this, "sA", "Status A", ctk::TAGS{"A"}};
+      StatusGenerator sB1{this, "sB1", "Status B1", ctk::TAGS{"B"}};
+      StatusGenerator sB2{this, "sB2", "Status B2", ctk::TAGS{"B"}};
+      StatusGenerator sC{this, "sC", "Status C", ctk::TAGS{"C"}};
 
-// test behavior for status+string:
-// test that status aggregator always has a message output and hands it over to next status aggregator
-BOOST_AUTO_TEST_CASE(testStatusMessage) {
-  std::cout << "testStatusMessage" << std::endl;
-  TestApplicationMessage app;
+      ctk::StatusAggregator aggregateA{
+          this, "aggregatedA", "", ctk::StatusAggregator::PriorityMode::fwko, {"A"}, {"AGG_A"}};
+      //  Same input and output tag. When aggregating tag "B" the status outputs themselves shoudl not be taken again.
+      ctk::StatusAggregator aggregateB{
+          this, "aggregatedB", "", ctk::StatusAggregator::PriorityMode::fwko, {"B"}, {"B"}};
 
-  ctk::TestFacility test(app);
+      // Missing: Test of multiple aggregation tags. Currently only one tag is allowed due to the missing
+      // design decision whether multiple tags should be a logical AND or OR (#13256).
+    } group{this, "Group", ""};
 
-  auto status = test.getScalar<int>("/Aggregated/status");
-  auto statusMessage = test.getScalar<std::string>("/Aggregated/status_message");
-  auto innerStatus = test.getScalar<int>("/Aggregated/extraStatus");
-  auto innerStatusMessage = test.getScalar<std::string>("/Aggregated/extraStatus_message");
+    // Does not aggregate an aggregator
+    ctk::StatusAggregator aggregateA{this, "aggA", "", ctk::StatusAggregator::PriorityMode::fwko, {"A"}};
+    // Aggregates the A aggregator
+    ctk::StatusAggregator aggAggA{this, "aggAggA", "", ctk::StatusAggregator::PriorityMode::fwko, {"AGG_A"}};
+    // Aggregates the B aggregator
+    ctk::StatusAggregator aggAggB{this, "aggAggB", "", ctk::StatusAggregator::PriorityMode::fwko, {"B"}};
+  };
 
-  test.runApplication();
+  /**********************************************************************************************************************/
 
-  // check the initial values
-  innerStatus.readLatest();
-  BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::OK));
-  innerStatusMessage.readLatest();
-  BOOST_CHECK_EQUAL(std::string(innerStatusMessage), "");
-  status.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
-  statusMessage.readLatest();
-  BOOST_CHECK_EQUAL(std::string(statusMessage), "");
+  BOOST_AUTO_TEST_CASE(testAggregatorTags) {
+    std::cout << "testAggregatorTags" << std::endl;
 
-  // check normal status (without message) going to fault
-  app.outerGroup.s1.status = ctk::StatusOutput::Status::FAULT;
-  app.outerGroup.s1.status.write();
-  test.stepApplication();
-  status.readLatest();
-  statusMessage.readLatest();
-  innerStatus.readLatest();
-  innerStatusMessage.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::FAULT));
-  std::string faultString1 = "/OuterGroup/s1/s1 switched to FAULT";
-  BOOST_CHECK_EQUAL(std::string(statusMessage), faultString1);
-  BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(std::string(innerStatusMessage), faultString1);
+    TestApplicationAggregatorTags app;
+    ctk::TestFacility test(app);
 
-  // go back to OK
-  app.outerGroup.s1.status = ctk::StatusOutput::Status::OK;
-  app.outerGroup.s1.status.write();
-  test.stepApplication();
-  status.readLatest();
-  statusMessage.readLatest();
-  innerStatus.readLatest();
-  innerStatusMessage.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
-  BOOST_CHECK_EQUAL(std::string(statusMessage), "");
-  BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::OK));
-  BOOST_CHECK_EQUAL(std::string(innerStatusMessage), "");
+    auto checkForName = [](auto& accessors, std::string name) {
+      return std::any_of(accessors.begin(), accessors.end(), [&name](auto acc) { return acc.getName() == name; });
+    };
 
-  // check StatusWithMessage going to fault
-  std::string faultString2 = "Status 2 at fault";
-  app.outerGroup.s2.setCurrentVersionNumber({});
-  app.outerGroup.s2.status.write(ctk::StatusOutput::Status::FAULT, faultString2);
-  test.stepApplication();
-  status.readLatest();
-  statusMessage.readLatest();
-  innerStatus.readLatest();
-  innerStatusMessage.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(std::string(statusMessage), faultString2);
-  BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(std::string(innerStatusMessage), faultString2);
+    auto accessorsAggA = app.aggregateA.getAccessorListRecursive();
+    // One aggregated input ("sA") + plus 3 inputs/outputs from the aggregator itself
+    // "aggregatedA" is not used because the tag "A" is its input. The output tag is "AGG_A"
+    BOOST_TEST(accessorsAggA.size() == 4);
+    BOOST_CHECK(checkForName(accessorsAggA, "sA"));
+    BOOST_CHECK(!checkForName(accessorsAggA, "aggregatedA"));
 
-  // set normal status to fault, too, to see the right message "wins" (first message should stay)
-  app.outerGroup.s1.setCurrentVersionNumber({});
-  app.outerGroup.s1.status = ctk::StatusOutput::Status::FAULT;
-  app.outerGroup.s1.status.write();
-  test.stepApplication();
-  status.readLatest();
-  statusMessage.readLatest();
-  innerStatus.readLatest();
-  innerStatusMessage.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(std::string(statusMessage), faultString2);
-  BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(std::string(innerStatusMessage), faultString2);
+    auto accessorsAggAggA = app.aggAggA.getAccessorListRecursive();
+    // One aggregated input ("aggregatedA") + according status message + plus 3 inputs/outputs from the aggregator
+    // itself "sA" is not used because the tag "A" is its input. The output tag is "AGG_A"
+    BOOST_TEST(accessorsAggAggA.size() == 5);
+    BOOST_CHECK(checkForName(accessorsAggAggA, "aggregatedA"));
+    BOOST_CHECK(!checkForName(accessorsAggAggA, "sA"));
 
-  // go back to OK
-  app.outerGroup.s1.setCurrentVersionNumber({});
-  app.outerGroup.s1.status = ctk::StatusOutput::Status::OK;
-  app.outerGroup.s1.status.write();
-  app.outerGroup.s2.setCurrentVersionNumber({});
-  app.outerGroup.s2.status.writeOk();
-  test.stepApplication();
-  status.readLatest();
-  statusMessage.readLatest();
-  innerStatus.readLatest();
-  innerStatusMessage.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
-  BOOST_CHECK_EQUAL(std::string(statusMessage), "");
-  BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::OK));
-  BOOST_CHECK_EQUAL(std::string(innerStatusMessage), "");
+    auto accessorsAggAggB = app.aggAggB.getAccessorListRecursive();
+    // One aggregated input ("aggregatedB") + according status message + plus 3 inputs/outputs from the aggregator
+    // itself "sB1" and "sB2" are not used because their input is already aggregated.
+    BOOST_TEST(accessorsAggAggB.size() == 5);
+    BOOST_CHECK(checkForName(accessorsAggAggB, "aggregatedB"));
+    BOOST_CHECK(!checkForName(accessorsAggAggB, "sB1"));
+    BOOST_CHECK(!checkForName(accessorsAggAggB, "sB2"));
+  }
 
-  // set both status to fault in alternate order (compared to before), again the first message should "win"
-  app.outerGroup.s1.setCurrentVersionNumber({});
-  app.outerGroup.s1.status = ctk::StatusOutput::Status::FAULT;
-  app.outerGroup.s1.status.write();
-  app.outerGroup.s2.setCurrentVersionNumber({});
-  app.outerGroup.s2.status.write(ctk::StatusOutput::Status::FAULT, faultString2);
-  test.stepApplication();
-  status.readLatest();
-  statusMessage.readLatest();
-  innerStatus.readLatest();
-  innerStatusMessage.readLatest();
-  BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(std::string(statusMessage), faultString1);
-  BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::FAULT));
-  BOOST_CHECK_EQUAL(std::string(innerStatusMessage), faultString1);
-}
+  /**********************************************************************************************************************/
 
-/**********************************************************************************************************************/
+  struct TestApplicationMessage : ctk::Application {
+    TestApplicationMessage() : Application("testApp") {}
+    ~TestApplicationMessage() override { shutdown(); }
+
+    StatusGenerator s{this, "s", "Status", {}, ctk::StatusOutput::Status::OK};
+
+    struct OuterGroup : ctk::ModuleGroup {
+      using ctk::ModuleGroup::ModuleGroup;
+
+      StatusGenerator s1{this, "s1", "Status 1", {}, ctk::StatusOutput::Status::OK};
+
+      StatusWithMessageGenerator s2{this, "s2", "Status 2", {}, ctk::StatusOutput::Status::OK};
+
+      ctk::StatusAggregator extraAggregator{
+          this, "/Aggregated/extraStatus", "aggregated status description", ctk::StatusAggregator::PriorityMode::ofwk};
+
+    } outerGroup{this, "OuterGroup", ""};
+
+    ctk::StatusAggregator aggregator{
+        this, "Aggregated/status", "aggregated status description", ctk::StatusAggregator::PriorityMode::fwko};
+  };
+
+  /**********************************************************************************************************************/
+
+  // test behavior for status+string:
+  // test that status aggregator always has a message output and hands it over to next status aggregator
+  BOOST_AUTO_TEST_CASE(testStatusMessage) {
+    std::cout << "testStatusMessage" << std::endl;
+    TestApplicationMessage app;
+
+    ctk::TestFacility test(app);
+
+    auto status = test.getScalar<int>("/Aggregated/status");
+    auto statusMessage = test.getScalar<std::string>("/Aggregated/status_message");
+    auto innerStatus = test.getScalar<int>("/Aggregated/extraStatus");
+    auto innerStatusMessage = test.getScalar<std::string>("/Aggregated/extraStatus_message");
+
+    test.runApplication();
+
+    // check the initial values
+    innerStatus.readLatest();
+    BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::OK));
+    innerStatusMessage.readLatest();
+    BOOST_CHECK_EQUAL(std::string(innerStatusMessage), "");
+    status.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
+    statusMessage.readLatest();
+    BOOST_CHECK_EQUAL(std::string(statusMessage), "");
+
+    // check normal status (without message) going to fault
+    app.outerGroup.s1.status = ctk::StatusOutput::Status::FAULT;
+    app.outerGroup.s1.status.write();
+    test.stepApplication();
+    status.readLatest();
+    statusMessage.readLatest();
+    innerStatus.readLatest();
+    innerStatusMessage.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::FAULT));
+    std::string faultString1 = "/OuterGroup/s1/s1 switched to FAULT";
+    BOOST_CHECK_EQUAL(std::string(statusMessage), faultString1);
+    BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(std::string(innerStatusMessage), faultString1);
+
+    // go back to OK
+    app.outerGroup.s1.status = ctk::StatusOutput::Status::OK;
+    app.outerGroup.s1.status.write();
+    test.stepApplication();
+    status.readLatest();
+    statusMessage.readLatest();
+    innerStatus.readLatest();
+    innerStatusMessage.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
+    BOOST_CHECK_EQUAL(std::string(statusMessage), "");
+    BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::OK));
+    BOOST_CHECK_EQUAL(std::string(innerStatusMessage), "");
+
+    // check StatusWithMessage going to fault
+    std::string faultString2 = "Status 2 at fault";
+    app.outerGroup.s2.setCurrentVersionNumber({});
+    app.outerGroup.s2.status.write(ctk::StatusOutput::Status::FAULT, faultString2);
+    test.stepApplication();
+    status.readLatest();
+    statusMessage.readLatest();
+    innerStatus.readLatest();
+    innerStatusMessage.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(std::string(statusMessage), faultString2);
+    BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(std::string(innerStatusMessage), faultString2);
+
+    // set normal status to fault, too, to see the right message "wins" (first message should stay)
+    app.outerGroup.s1.setCurrentVersionNumber({});
+    app.outerGroup.s1.status = ctk::StatusOutput::Status::FAULT;
+    app.outerGroup.s1.status.write();
+    test.stepApplication();
+    status.readLatest();
+    statusMessage.readLatest();
+    innerStatus.readLatest();
+    innerStatusMessage.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(std::string(statusMessage), faultString2);
+    BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(std::string(innerStatusMessage), faultString2);
+
+    // go back to OK
+    app.outerGroup.s1.setCurrentVersionNumber({});
+    app.outerGroup.s1.status = ctk::StatusOutput::Status::OK;
+    app.outerGroup.s1.status.write();
+    app.outerGroup.s2.setCurrentVersionNumber({});
+    app.outerGroup.s2.status.writeOk();
+    test.stepApplication();
+    status.readLatest();
+    statusMessage.readLatest();
+    innerStatus.readLatest();
+    innerStatusMessage.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::OK));
+    BOOST_CHECK_EQUAL(std::string(statusMessage), "");
+    BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::OK));
+    BOOST_CHECK_EQUAL(std::string(innerStatusMessage), "");
+
+    // set both status to fault in alternate order (compared to before), again the first message should "win"
+    app.outerGroup.s1.setCurrentVersionNumber({});
+    app.outerGroup.s1.status = ctk::StatusOutput::Status::FAULT;
+    app.outerGroup.s1.status.write();
+    app.outerGroup.s2.setCurrentVersionNumber({});
+    app.outerGroup.s2.status.write(ctk::StatusOutput::Status::FAULT, faultString2);
+    test.stepApplication();
+    status.readLatest();
+    statusMessage.readLatest();
+    innerStatus.readLatest();
+    innerStatusMessage.readLatest();
+    BOOST_CHECK_EQUAL(int(status), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(std::string(statusMessage), faultString1);
+    BOOST_CHECK_EQUAL(int(innerStatus), int(ctk::StatusOutput::Status::FAULT));
+    BOOST_CHECK_EQUAL(std::string(innerStatusMessage), faultString1);
+  }
+
+  /**********************************************************************************************************************/
+
+} // namespace Tests::testStatusAggregator

--- a/tests/executables_src/testStatusMonitor.cc
+++ b/tests/executables_src/testStatusMonitor.cc
@@ -12,938 +12,948 @@
 #include <boost/mpl/list.hpp>
 #include <boost/test/included/unit_test.hpp>
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testStatusMonitor {
 
-/*********************************************************************************************************************/
-/* Test dummy application for the Monitors ************************************************************************/
-/*********************************************************************************************************************/
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
-template<typename T>
-struct TestApplication : public ctk::Application {
-  TestApplication() : Application("testSuite") {}
-  ~TestApplication() override { shutdown(); }
+  /*********************************************************************************************************************/
+  /* Test dummy application for the Monitors ************************************************************************/
+  /*********************************************************************************************************************/
 
-  T monitor{this, "/input/path", "/output/path", "/parameters", "Now this is a nice monitor...",
-      ctk::TAGS{"MON_OUTPUT"}, ctk::TAGS{"MON_PARAMS"}};
-};
+  template<typename T>
+  struct TestApplication : public ctk::Application {
+    TestApplication() : Application("testSuite") {}
+    ~TestApplication() override { shutdown(); }
 
-/*********************************************************************************************************************/
-/* Test generic functionality of the Monitors ************************************************************************/
-/*********************************************************************************************************************/
+    T monitor{this, "/input/path", "/output/path", "/parameters", "Now this is a nice monitor...",
+        ctk::TAGS{"MON_OUTPUT"}, ctk::TAGS{"MON_PARAMS"}};
+  };
 
-BOOST_AUTO_TEST_CASE(testMaxMonitor) {
-  std::cout << "testMaxMonitor" << std::endl;
-  TestApplication<ctk::MaxMonitor<double_t>> app;
+  /*********************************************************************************************************************/
+  /* Test generic functionality of the Monitors ************************************************************************/
+  /*********************************************************************************************************************/
 
-  // check that the reserved StatusOutput tag is present at the output, required for StatusAggregator integration
-  auto tags = ctk::VariableNetworkNode(app.monitor.status).getTags();
-  BOOST_CHECK(tags.find(ctk::StatusOutput::tagStatusOutput) != tags.end());
+  BOOST_AUTO_TEST_CASE(testMaxMonitor) {
+    std::cout << "testMaxMonitor" << std::endl;
+    TestApplication<ctk::MaxMonitor<double_t>> app;
 
-  ctk::TestFacility test(app);
-  test.runApplication();
-  // app.cs.dump();
+    // check that the reserved StatusOutput tag is present at the output, required for StatusAggregator integration
+    auto tags = ctk::VariableNetworkNode(app.monitor.status).getTags();
+    BOOST_CHECK(tags.find(ctk::StatusOutput::tagStatusOutput) != tags.end());
 
-  auto warning = test.getScalar<double_t>(std::string("/parameters/upperWarningThreshold"));
-  warning = 50.0;
-  warning.write();
-  test.stepApplication();
-
-  auto fault = test.getScalar<double_t>(std::string("/parameters/upperFaultThreshold"));
-  fault = 60.0;
-  fault.write();
-  test.stepApplication();
-
-  auto watch = test.getScalar<double_t>(std::string("/input/path"));
-  watch = 40.0;
-  watch.write();
-  test.stepApplication();
-
-  auto status = test.getScalar<int32_t>(std::string("/output/path"));
-  status.readLatest();
-
-  // should be in OK state.
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  //   //just below the warning level
-  watch = 49.99;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // drop in a disable test.
-  auto disable = test.getScalar<ChimeraTK::Boolean>("/parameters/disable");
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // slightly above at the upper warning threshold (exact is not good due to rounding errors in floats/doubles)
-  watch = 50.01;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // drop in a disable test.
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // just below the fault threshold,. still warning
-  watch = 59.99;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // slightly above at the upper fault threshold (exact is not good due to rounding errors in floats/doubles)
-  watch = 60.01;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // drop in a disable test.
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // increase well above the upper fault level
-  watch = 65;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // now check that changing the status is updated correctly if we change the limits
-
-  // increase fault value greater than watch
-  fault = 68;
-  fault.write();
-  test.stepApplication();
-  status.readLatest();
-  // should be in WARNING state.
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // increase warning value greater than watch
-  warning = 66;
-  warning.write();
-  test.stepApplication();
-  status.readLatest();
-  // should be in OK state.
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // Set the upper fault limit below the upper warning limit and below the current temperature. The warning is not
-  // active, but the fault. Although this is not a reasonable configuration the fault limit must superseed the warning
-  // and the status has to be fault.
-  fault = 60;
-  fault.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // check that the tags are applied correctly
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("upperFaultThreshold") == app.monitor.faultThreshold);
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("upperWarningThreshold") == app.monitor.warningThreshold);
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("disable") == app.monitor.disable);
-  // BOOST_CHECK(app.findTag("MON_OUTPUT")["output"]("path") == app.monitor.status);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testMinMonitor) {
-  std::cout << "testMinMonitor" << std::endl;
-
-  TestApplication<ctk::MinMonitor<uint>> app;
-
-  // check that the reserved StatusOutput tag is present at the output, required for StatusAggregator integration
-  auto tags = ctk::VariableNetworkNode(app.monitor.status).getTags();
-  BOOST_CHECK(tags.find(ctk::StatusOutput::tagStatusOutput) != tags.end());
-
-  ctk::TestFacility test(app);
-  test.runApplication();
-  // app.dumpConnections();
-
-  auto warning = test.getScalar<uint>(std::string("/parameters/lowerWarningThreshold"));
-  warning = 40;
-  warning.write();
-  test.stepApplication();
-
-  auto fault = test.getScalar<uint>(std::string("/parameters/lowerFaultThreshold"));
-  fault = 30;
-  fault.write();
-  test.stepApplication();
-
-  auto watch = test.getScalar<uint>(std::string("/input/path"));
-  watch = 45;
-  watch.write();
-  test.stepApplication();
-
-  auto status = test.getScalar<int32_t>(std::string("/output/path"));
-  status.readLatest();
-
-  // should be in OK state.
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // just abow the lower warning limit
-  watch = 41;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // drop in a disable test.
-  auto disable = test.getScalar<ChimeraTK::Boolean>("/parameters/disable");
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // exactly at the lower warning limit
-  watch = 40;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // drop in a disable test.
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // just above the lower fault limit
-  watch = 31;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // exactly at the lower fault limit (only well defined for int)
-  watch = 30;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // drop in a disable test.
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // way bellow the lower fault limit
-  watch = 12;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // move the temperature back to the good range and check that the status updates correctly when changing the limits
-  watch = 41;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // change upper warning limit
-  warning = 42;
-  warning.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // rise the temperature above the lower warning limit
-  watch = 43;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // Set the lower fault limit above the lower warning limit. The warning is not active, but the fault.
-  // Although this is not a reasonable configuration the fault limit must superseed the warning and the status has to be fault.
-  fault = 44;
-  fault.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // check that the tags are applied correctly
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("lowerFaultThreshold") == app.monitor.faultThreshold);
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("lowerWarningThreshold") == app.monitor.warningThreshold);
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("disable") == app.monitor.disable);
-  // BOOST_CHECK(app.findTag("MON_OUTPUT")["output"]("path") == app.monitor.status);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testRangeMonitor) {
-  std::cout << "testRangeMonitor" << std::endl;
-  TestApplication<ctk::RangeMonitor<int>> app;
-
-  // check that the reserved StatusOutput tag is present at the output, required for StatusAggregator integration
-  auto tags = ctk::VariableNetworkNode(app.monitor.status).getTags();
-  BOOST_CHECK(tags.find(ctk::StatusOutput::tagStatusOutput) != tags.end());
-
-  ctk::TestFacility test(app);
-  test.runApplication();
-  // app.dumpConnections();
-
-  auto warningUpperLimit = test.getScalar<int>(std::string("/parameters/upperWarningThreshold"));
-  warningUpperLimit = 50;
-  warningUpperLimit.write();
-  test.stepApplication();
-
-  auto warningLowerLimit = test.getScalar<int>(std::string("/parameters/lowerWarningThreshold"));
-  warningLowerLimit = 40;
-  warningLowerLimit.write();
-  test.stepApplication();
-
-  auto faultUpperLimit = test.getScalar<int>(std::string("/parameters/upperFaultThreshold"));
-  faultUpperLimit = 60;
-  faultUpperLimit.write();
-  test.stepApplication();
-
-  auto faultLowerLimit = test.getScalar<int>(std::string("/parameters/lowerFaultThreshold"));
-  faultLowerLimit = 30;
-  faultLowerLimit.write();
-  test.stepApplication();
-
-  // start with a good value
-  auto watch = test.getScalar<int>(std::string("/input/path"));
-  watch = 45;
-  watch.write();
-  test.stepApplication();
-
-  auto status = test.getScalar<int32_t>(std::string("/output/path"));
-  status.readLatest();
-
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // just below the warning level
-  watch = 49;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // drop in a disable test.
-  auto disable = test.getScalar<ChimeraTK::Boolean>("/parameters/disable");
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // exactly at the upper warning threshold (only well defined for int)
-  watch = 50;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // drop in a disable test.
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // just below the fault threshold,. still warning
-  watch = 59;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // exactly at the upper warning threshold (only well defined for int)
-  watch = 60;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // drop in a disable test.
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // increase well above the upper fault level
-  watch = 65;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // back to ok, just abow the lower warning limit
-  watch = 41;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // exactly at the lower warning limit
-  watch = 40;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // just above the lower fault limit
-  watch = 31;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // exactly at the lower fault limit (only well defined for int)
-  watch = 30;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // way bellow the lower fault limit
-  watch = 12;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // Put the value back to the good range, then check that chaning the threshold also updated the status
-  watch = 49;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // change upper warning limit
-  warningUpperLimit = 48;
-  warningUpperLimit.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // lower the temperature below the upper warning limit
-  watch = 47;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // Set the upper fault limit below the upper warning limit. The warning is not active, but the fault.
-  // Although this is not a reasonable configuration the fault limit must superseed the warning and the status has to be fault.
-  faultUpperLimit = 46;
-  faultUpperLimit.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // move the temperature back to the good range and repeat for the lower limits
-  watch = 41;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // change upper warning limit
-  warningLowerLimit = 42;
-  warningLowerLimit.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-
-  // rise the temperature above the lower warning limit
-  watch = 43;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // Set the lower fault limit above the lower warning limit. The warning is not active, but the fault.
-  // Although this is not a reasonable configuration the fault limit must superseed the warning and the status has to be fault.
-  faultLowerLimit = 44;
-  faultLowerLimit.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // check that the tags are applied correctly
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("lowerFaultThreshold") == app.monitor.faultLowerThreshold);
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("lowerWarningThreshold") == app.monitor.warningLowerThreshold);
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("upperFaultThreshold") == app.monitor.faultUpperThreshold);
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("upperWarningThreshold") == app.monitor.warningUpperThreshold);
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("disable") == app.monitor.disable);
-  // BOOST_CHECK(app.findTag("MON_OUTPUT")["output"]("path") == app.monitor.status);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testExactMonitor) {
-  std::cout << "testExactMonitor" << std::endl;
-  TestApplication<ctk::ExactMonitor<int64_t>> app;
-
-  // check that the reserved StatusOutput tag is present at the output, required for StatusAggregator integration
-  auto tags = ctk::VariableNetworkNode(app.monitor.status).getTags();
-  BOOST_CHECK(tags.find(ctk::StatusOutput::tagStatusOutput) != tags.end());
-
-  ctk::TestFacility test(app);
-  test.runApplication();
-  // app.dumpConnections();
-
-  auto requiredValue = test.getScalar<int64_t>(std::string("/parameters/requiredValue"));
-  requiredValue = 409;
-  requiredValue.write();
-  test.stepApplication();
-
-  auto watch = test.getScalar<int64_t>(std::string("/input/path"));
-  watch = 409;
-  watch.write();
-  test.stepApplication();
-
-  auto status = test.getScalar<int32_t>(std::string("/output/path"));
-  status.readLatest();
-
-  // should be in OK state.
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // drop in a disable test.
-  auto disable = test.getScalar<ChimeraTK::Boolean>("/parameters/disable");
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // set watch value different than required value
-  watch = 414;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  // should be in FAULT state.
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // drop in a disable test.
-  disable = true;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-
-  disable = false;
-  disable.write();
-  test.stepApplication();
-  status.readLatest();
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  watch = 409;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  // should be in OK state.
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // set requiredValue value different than watch value
-  requiredValue = 413;
-  requiredValue.write();
-  test.stepApplication();
-  status.readLatest();
-  // should be in WARNING state.
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-
-  // set requiredValue value equals to watch value
-  requiredValue = 409;
-  requiredValue.write();
-  test.stepApplication();
-  status.readLatest();
-  // should be in WARNING state.
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-
-  // check that the tags are applied correctly
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("requiredValue") == app.monitor.requiredValue);
-  // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("disable") == app.monitor.disable);
-  // BOOST_CHECK(app.findTag("MON_OUTPUT")["output"]("path") == app.monitor.status);
-}
-
-/*********************************************************************************************************************/
-/* Test initial value propagation for the Monitors *******************************************************************/
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testMaxMonitorInitialValuePropagation) {
-  std::cout << "testMaxMonitorInitialValuePropagation" << std::endl;
-
-  {
-    TestApplication<ctk::MaxMonitor<float_t>> app;
     ctk::TestFacility test(app);
-    test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 60.0);
-    test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 50.0);
-    test.setScalarDefault<float_t>("/input/path", 45.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
     test.runApplication();
+    // app.cs.dump();
 
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+    auto warning = test.getScalar<double_t>(std::string("/parameters/upperWarningThreshold"));
+    warning = 50.0;
+    warning.write();
+    test.stepApplication();
+
+    auto fault = test.getScalar<double_t>(std::string("/parameters/upperFaultThreshold"));
+    fault = 60.0;
+    fault.write();
+    test.stepApplication();
+
+    auto watch = test.getScalar<double_t>(std::string("/input/path"));
+    watch = 40.0;
+    watch.write();
+    test.stepApplication();
+
+    auto status = test.getScalar<int32_t>(std::string("/output/path"));
+    status.readLatest();
+
+    // should be in OK state.
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    //   //just below the warning level
+    watch = 49.99;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // drop in a disable test.
+    auto disable = test.getScalar<ChimeraTK::Boolean>("/parameters/disable");
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // slightly above at the upper warning threshold (exact is not good due to rounding errors in floats/doubles)
+    watch = 50.01;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // drop in a disable test.
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // just below the fault threshold,. still warning
+    watch = 59.99;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // slightly above at the upper fault threshold (exact is not good due to rounding errors in floats/doubles)
+    watch = 60.01;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // drop in a disable test.
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // increase well above the upper fault level
+    watch = 65;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // now check that changing the status is updated correctly if we change the limits
+
+    // increase fault value greater than watch
+    fault = 68;
+    fault.write();
+    test.stepApplication();
+    status.readLatest();
+    // should be in WARNING state.
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // increase warning value greater than watch
+    warning = 66;
+    warning.write();
+    test.stepApplication();
+    status.readLatest();
+    // should be in OK state.
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // Set the upper fault limit below the upper warning limit and below the current temperature. The warning is not
+    // active, but the fault. Although this is not a reasonable configuration the fault limit must superseed the warning
+    // and the status has to be fault.
+    fault = 60;
+    fault.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // check that the tags are applied correctly
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("upperFaultThreshold") == app.monitor.faultThreshold);
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("upperWarningThreshold") == app.monitor.warningThreshold);
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("disable") == app.monitor.disable);
+    // BOOST_CHECK(app.findTag("MON_OUTPUT")["output"]("path") == app.monitor.status);
   }
-  {
-    TestApplication<ctk::MaxMonitor<float_t>> app;
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testMinMonitor) {
+    std::cout << "testMinMonitor" << std::endl;
+
+    TestApplication<ctk::MinMonitor<uint>> app;
+
+    // check that the reserved StatusOutput tag is present at the output, required for StatusAggregator integration
+    auto tags = ctk::VariableNetworkNode(app.monitor.status).getTags();
+    BOOST_CHECK(tags.find(ctk::StatusOutput::tagStatusOutput) != tags.end());
+
     ctk::TestFacility test(app);
-    test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 60.0);
-    test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 50.0);
-    test.setScalarDefault<float_t>("/input/path", 55.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
     test.runApplication();
+    // app.dumpConnections();
 
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+    auto warning = test.getScalar<uint>(std::string("/parameters/lowerWarningThreshold"));
+    warning = 40;
+    warning.write();
+    test.stepApplication();
+
+    auto fault = test.getScalar<uint>(std::string("/parameters/lowerFaultThreshold"));
+    fault = 30;
+    fault.write();
+    test.stepApplication();
+
+    auto watch = test.getScalar<uint>(std::string("/input/path"));
+    watch = 45;
+    watch.write();
+    test.stepApplication();
+
+    auto status = test.getScalar<int32_t>(std::string("/output/path"));
+    status.readLatest();
+
+    // should be in OK state.
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // just abow the lower warning limit
+    watch = 41;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // drop in a disable test.
+    auto disable = test.getScalar<ChimeraTK::Boolean>("/parameters/disable");
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // exactly at the lower warning limit
+    watch = 40;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // drop in a disable test.
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // just above the lower fault limit
+    watch = 31;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // exactly at the lower fault limit (only well defined for int)
+    watch = 30;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // drop in a disable test.
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // way bellow the lower fault limit
+    watch = 12;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // move the temperature back to the good range and check that the status updates correctly when changing the limits
+    watch = 41;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // change upper warning limit
+    warning = 42;
+    warning.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // rise the temperature above the lower warning limit
+    watch = 43;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // Set the lower fault limit above the lower warning limit. The warning is not active, but the fault.
+    // Although this is not a reasonable configuration the fault limit must superseed the warning and the status has to be fault.
+    fault = 44;
+    fault.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // check that the tags are applied correctly
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("lowerFaultThreshold") == app.monitor.faultThreshold);
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("lowerWarningThreshold") == app.monitor.warningThreshold);
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("disable") == app.monitor.disable);
+    // BOOST_CHECK(app.findTag("MON_OUTPUT")["output"]("path") == app.monitor.status);
   }
-  {
-    TestApplication<ctk::MaxMonitor<float_t>> app;
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testRangeMonitor) {
+    std::cout << "testRangeMonitor" << std::endl;
+    TestApplication<ctk::RangeMonitor<int>> app;
+
+    // check that the reserved StatusOutput tag is present at the output, required for StatusAggregator integration
+    auto tags = ctk::VariableNetworkNode(app.monitor.status).getTags();
+    BOOST_CHECK(tags.find(ctk::StatusOutput::tagStatusOutput) != tags.end());
+
     ctk::TestFacility test(app);
-    test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 60.0);
-    test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 50.0);
-    test.setScalarDefault<float_t>("/input/path", 55.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", true);
-
     test.runApplication();
+    // app.dumpConnections();
 
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+    auto warningUpperLimit = test.getScalar<int>(std::string("/parameters/upperWarningThreshold"));
+    warningUpperLimit = 50;
+    warningUpperLimit.write();
+    test.stepApplication();
+
+    auto warningLowerLimit = test.getScalar<int>(std::string("/parameters/lowerWarningThreshold"));
+    warningLowerLimit = 40;
+    warningLowerLimit.write();
+    test.stepApplication();
+
+    auto faultUpperLimit = test.getScalar<int>(std::string("/parameters/upperFaultThreshold"));
+    faultUpperLimit = 60;
+    faultUpperLimit.write();
+    test.stepApplication();
+
+    auto faultLowerLimit = test.getScalar<int>(std::string("/parameters/lowerFaultThreshold"));
+    faultLowerLimit = 30;
+    faultLowerLimit.write();
+    test.stepApplication();
+
+    // start with a good value
+    auto watch = test.getScalar<int>(std::string("/input/path"));
+    watch = 45;
+    watch.write();
+    test.stepApplication();
+
+    auto status = test.getScalar<int32_t>(std::string("/output/path"));
+    status.readLatest();
+
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // just below the warning level
+    watch = 49;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // drop in a disable test.
+    auto disable = test.getScalar<ChimeraTK::Boolean>("/parameters/disable");
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // exactly at the upper warning threshold (only well defined for int)
+    watch = 50;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // drop in a disable test.
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // just below the fault threshold,. still warning
+    watch = 59;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // exactly at the upper warning threshold (only well defined for int)
+    watch = 60;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // drop in a disable test.
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // increase well above the upper fault level
+    watch = 65;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // back to ok, just abow the lower warning limit
+    watch = 41;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // exactly at the lower warning limit
+    watch = 40;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // just above the lower fault limit
+    watch = 31;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // exactly at the lower fault limit (only well defined for int)
+    watch = 30;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // way bellow the lower fault limit
+    watch = 12;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // Put the value back to the good range, then check that chaning the threshold also updated the status
+    watch = 49;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // change upper warning limit
+    warningUpperLimit = 48;
+    warningUpperLimit.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // lower the temperature below the upper warning limit
+    watch = 47;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // Set the upper fault limit below the upper warning limit. The warning is not active, but the fault.
+    // Although this is not a reasonable configuration the fault limit must superseed the warning and the status has to be fault.
+    faultUpperLimit = 46;
+    faultUpperLimit.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // move the temperature back to the good range and repeat for the lower limits
+    watch = 41;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // change upper warning limit
+    warningLowerLimit = 42;
+    warningLowerLimit.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+
+    // rise the temperature above the lower warning limit
+    watch = 43;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // Set the lower fault limit above the lower warning limit. The warning is not active, but the fault.
+    // Although this is not a reasonable configuration the fault limit must superseed the warning and the status has to be fault.
+    faultLowerLimit = 44;
+    faultLowerLimit.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // check that the tags are applied correctly
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("lowerFaultThreshold") == app.monitor.faultLowerThreshold);
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("lowerWarningThreshold") ==
+    //     app.monitor.warningLowerThreshold);
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("upperFaultThreshold") == app.monitor.faultUpperThreshold);
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("upperWarningThreshold") ==
+    //     app.monitor.warningUpperThreshold);
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("disable") == app.monitor.disable);
+    // BOOST_CHECK(app.findTag("MON_OUTPUT")["output"]("path") == app.monitor.status);
   }
-  {
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testExactMonitor) {
+    std::cout << "testExactMonitor" << std::endl;
+    TestApplication<ctk::ExactMonitor<int64_t>> app;
+
+    // check that the reserved StatusOutput tag is present at the output, required for StatusAggregator integration
+    auto tags = ctk::VariableNetworkNode(app.monitor.status).getTags();
+    BOOST_CHECK(tags.find(ctk::StatusOutput::tagStatusOutput) != tags.end());
+
+    ctk::TestFacility test(app);
+    test.runApplication();
+    // app.dumpConnections();
+
+    auto requiredValue = test.getScalar<int64_t>(std::string("/parameters/requiredValue"));
+    requiredValue = 409;
+    requiredValue.write();
+    test.stepApplication();
+
+    auto watch = test.getScalar<int64_t>(std::string("/input/path"));
+    watch = 409;
+    watch.write();
+    test.stepApplication();
+
+    auto status = test.getScalar<int32_t>(std::string("/output/path"));
+    status.readLatest();
+
+    // should be in OK state.
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // drop in a disable test.
+    auto disable = test.getScalar<ChimeraTK::Boolean>("/parameters/disable");
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // set watch value different than required value
+    watch = 414;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    // should be in FAULT state.
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // drop in a disable test.
+    disable = true;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+
+    disable = false;
+    disable.write();
+    test.stepApplication();
+    status.readLatest();
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    watch = 409;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    // should be in OK state.
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // set requiredValue value different than watch value
+    requiredValue = 413;
+    requiredValue.write();
+    test.stepApplication();
+    status.readLatest();
+    // should be in WARNING state.
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+
+    // set requiredValue value equals to watch value
+    requiredValue = 409;
+    requiredValue.write();
+    test.stepApplication();
+    status.readLatest();
+    // should be in WARNING state.
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+
+    // check that the tags are applied correctly
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("requiredValue") == app.monitor.requiredValue);
+    // BOOST_CHECK(app.findTag("MON_PARAMS")["parameters"]("disable") == app.monitor.disable);
+    // BOOST_CHECK(app.findTag("MON_OUTPUT")["output"]("path") == app.monitor.status);
+  }
+
+  /*********************************************************************************************************************/
+  /* Test initial value propagation for the Monitors *******************************************************************/
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testMaxMonitorInitialValuePropagation) {
+    std::cout << "testMaxMonitorInitialValuePropagation" << std::endl;
+
+    {
+      TestApplication<ctk::MaxMonitor<float_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 60.0);
+      test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 50.0);
+      test.setScalarDefault<float_t>("/input/path", 45.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+    }
+    {
+      TestApplication<ctk::MaxMonitor<float_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 60.0);
+      test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 50.0);
+      test.setScalarDefault<float_t>("/input/path", 55.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(
+          test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+    }
+    {
+      TestApplication<ctk::MaxMonitor<float_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 60.0);
+      test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 50.0);
+      test.setScalarDefault<float_t>("/input/path", 55.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", true);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+    }
+    {
+      TestApplication<ctk::MaxMonitor<double_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<double_t>("/parameters/upperFaultThreshold", 60.0);
+      test.setScalarDefault<double_t>("/parameters/upperWarningThreshold", 50.0);
+      test.setScalarDefault<double_t>("/input/path", 65.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testMinMonitorInitialValuePropagation) {
+    std::cout << "testMinMonitorInitialValuePropagation" << std::endl;
+
+    {
+      TestApplication<ctk::MinMonitor<double_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<double_t>("/parameters/lowerFaultThreshold", 50.0);
+      test.setScalarDefault<double_t>("/parameters/lowerWarningThreshold", 60.0);
+      test.setScalarDefault<double_t>("/input/path", 65.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+    }
+    {
+      TestApplication<ctk::MinMonitor<float_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<float_t>("/parameters/lowerFaultThreshold", 50.0);
+      test.setScalarDefault<float_t>("/parameters/lowerWarningThreshold", 60.0);
+      test.setScalarDefault<float_t>("/input/path", 55.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(
+          test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+    }
+    {
+      TestApplication<ctk::MinMonitor<float_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<float_t>("/parameters/lowerFaultThreshold", 50.0);
+      test.setScalarDefault<float_t>("/parameters/lowerWarningThreshold", 60.0);
+      test.setScalarDefault<float_t>("/input/path", 55.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", true);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+    }
+    {
+      TestApplication<ctk::MinMonitor<int32_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<int32_t>("/parameters/lowerFaultThreshold", 50);
+      test.setScalarDefault<int32_t>("/parameters/lowerWarningThreshold", 60);
+      test.setScalarDefault<int32_t>("/input/path", 45);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testRangeMonitorInitialValuePropagation) {
+    std::cout << "testRangeMonitorInitialValuePropagation" << std::endl;
+    // each {} defines new application and test facility
+    {
+      TestApplication<ctk::RangeMonitor<double_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<double_t>("/parameters/upperFaultThreshold", 80.0);
+      test.setScalarDefault<double_t>("/parameters/upperWarningThreshold", 70.0);
+      test.setScalarDefault<double_t>("/parameters/lowerWarningThreshold", 60.0);
+      test.setScalarDefault<double_t>("/parameters/lowerFaultThreshold", 50.0);
+      test.setScalarDefault<double_t>("/input/path", 65.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+    }
+    {
+      TestApplication<ctk::RangeMonitor<float_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 80.0);
+      test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 70.0);
+      test.setScalarDefault<float_t>("/parameters/lowerWarningThreshold", 60.0);
+      test.setScalarDefault<float_t>("/parameters/lowerFaultThreshold", 50.0);
+      test.setScalarDefault<float_t>("/input/path", 75.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(
+          test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+    }
+    {
+      TestApplication<ctk::RangeMonitor<float_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 80.0);
+      test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 70.0);
+      test.setScalarDefault<float_t>("/parameters/lowerWarningThreshold", 60.0);
+      test.setScalarDefault<float_t>("/parameters/lowerFaultThreshold", 50.0);
+      test.setScalarDefault<float_t>("/input/path", 55.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(
+          test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+    }
+    {
+      TestApplication<ctk::RangeMonitor<float_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 80.0);
+      test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 70.0);
+      test.setScalarDefault<float_t>("/parameters/lowerWarningThreshold", 60.0);
+      test.setScalarDefault<float_t>("/parameters/lowerFaultThreshold", 50.0);
+      test.setScalarDefault<float_t>("/input/path", 55.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", true);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+    }
+    {
+      TestApplication<ctk::RangeMonitor<int32_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<int32_t>("/parameters/upperFaultThreshold", 80);
+      test.setScalarDefault<int32_t>("/parameters/upperWarningThreshold", 70);
+      test.setScalarDefault<int32_t>("/parameters/lowerWarningThreshold", 60);
+      test.setScalarDefault<int32_t>("/parameters/lowerFaultThreshold", 50);
+      test.setScalarDefault<int32_t>("/input/path", 85);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+    }
+    {
+      TestApplication<ctk::RangeMonitor<int32_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<int32_t>("/parameters/upperFaultThreshold", 80);
+      test.setScalarDefault<int32_t>("/parameters/upperWarningThreshold", 70);
+      test.setScalarDefault<int32_t>("/parameters/lowerWarningThreshold", 60);
+      test.setScalarDefault<int32_t>("/parameters/lowerFaultThreshold", 50);
+      test.setScalarDefault<int32_t>("/input/path", 45);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+    }
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testExactMonitorInitialValuePropagation) {
+    std::cout << "testExactMonitorInitialValuePropagation" << std::endl;
+
+    {
+      TestApplication<ctk::ExactMonitor<double_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<double_t>("/parameters/requiredValue", 60.0);
+      test.setScalarDefault<double_t>("/input/path", 60.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+    }
+    {
+      TestApplication<ctk::ExactMonitor<float_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<float_t>("/parameters/requiredValue", 60.0);
+      test.setScalarDefault<float_t>("/input/path", 55.0);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", true);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
+    }
+    {
+      TestApplication<ctk::ExactMonitor<int32_t>> app;
+      ctk::TestFacility test(app);
+      test.setScalarDefault<int32_t>("/parameters/requiredValue", 60);
+      test.setScalarDefault<int32_t>("/input/path", 45);
+      test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
+
+      test.runApplication();
+
+      BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+    }
+  }
+
+  /*********************************************************************************************************************/
+  /* Test data validity propagation for the Monitors *******************************************************************/
+  /*********************************************************************************************************************/
+
+  /*
+   * Data validity is checked in base class of all monitors (MonitorBase) in method MonitorBase::setStatus only
+   * There is no need to test all types of monitors so we gonna use MaxMonitor
+   * */
+  BOOST_AUTO_TEST_CASE(testMonitorDataValidityPropagation) {
+    std::cout << "testMonitorDataValidityPropagation" << std::endl;
+
     TestApplication<ctk::MaxMonitor<double_t>> app;
     ctk::TestFacility test(app);
-    test.setScalarDefault<double_t>("/parameters/upperFaultThreshold", 60.0);
-    test.setScalarDefault<double_t>("/parameters/upperWarningThreshold", 50.0);
-    test.setScalarDefault<double_t>("/input/path", 65.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
 
     test.runApplication();
 
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+    auto fault = test.getScalar<double_t>("/parameters/upperFaultThreshold");
+    auto warning = test.getScalar<double_t>("/parameters/upperWarningThreshold");
+    auto watch = test.getScalar<double_t>("/input/path");
+    auto status = test.getScalar<int32_t>("/output/path");
+
+    fault = 60.0;
+    fault.write();
+    warning = 50.0;
+    warning.write();
+    watch = 40.0;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    // status is OK and data validity also
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+    BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
+
+    watch.setDataValidity(ctk::DataValidity::faulty);
+    watch.write();
+    test.stepApplication();
+    // status is not changed as watch is the same, data validity is changed -> test condition: getDataValidity() !=
+    // lastStatusValidity
+    BOOST_CHECK(status.readLatest());
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
+    // StatusOutput by default does not propagate DataValidity=fault (behaviour was changed!)
+    BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
+
+    watch = 55.0;
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    // status is changed, data validity is not changed -> test condition: status.value != newStatus
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
+    BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
+
+    watch = 70.0;
+    watch.setDataValidity(ctk::DataValidity::ok);
+    watch.write();
+    test.stepApplication();
+    status.readLatest();
+    // status is changed, data validity is changed -> test condition: status.value != newStatus
+    BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
+    BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
+
+    watch = 75.0;
+    watch.setDataValidity(ctk::DataValidity::ok);
+    watch.write();
+    test.stepApplication();
+    // status is not changed, data validity is not changed -> test that there is no new value of status
+    BOOST_CHECK(status.readLatest() == false);
   }
-}
 
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testMinMonitorInitialValuePropagation) {
-  std::cout << "testMinMonitorInitialValuePropagation" << std::endl;
-
-  {
-    TestApplication<ctk::MinMonitor<double_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<double_t>("/parameters/lowerFaultThreshold", 50.0);
-    test.setScalarDefault<double_t>("/parameters/lowerWarningThreshold", 60.0);
-    test.setScalarDefault<double_t>("/input/path", 65.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-  }
-  {
-    TestApplication<ctk::MinMonitor<float_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<float_t>("/parameters/lowerFaultThreshold", 50.0);
-    test.setScalarDefault<float_t>("/parameters/lowerWarningThreshold", 60.0);
-    test.setScalarDefault<float_t>("/input/path", 55.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-  }
-  {
-    TestApplication<ctk::MinMonitor<float_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<float_t>("/parameters/lowerFaultThreshold", 50.0);
-    test.setScalarDefault<float_t>("/parameters/lowerWarningThreshold", 60.0);
-    test.setScalarDefault<float_t>("/input/path", 55.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", true);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-  }
-  {
-    TestApplication<ctk::MinMonitor<int32_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<int32_t>("/parameters/lowerFaultThreshold", 50);
-    test.setScalarDefault<int32_t>("/parameters/lowerWarningThreshold", 60);
-    test.setScalarDefault<int32_t>("/input/path", 45);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testRangeMonitorInitialValuePropagation) {
-  std::cout << "testRangeMonitorInitialValuePropagation" << std::endl;
-  // each {} defines new application and test facility
-  {
-    TestApplication<ctk::RangeMonitor<double_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<double_t>("/parameters/upperFaultThreshold", 80.0);
-    test.setScalarDefault<double_t>("/parameters/upperWarningThreshold", 70.0);
-    test.setScalarDefault<double_t>("/parameters/lowerWarningThreshold", 60.0);
-    test.setScalarDefault<double_t>("/parameters/lowerFaultThreshold", 50.0);
-    test.setScalarDefault<double_t>("/input/path", 65.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-  }
-  {
-    TestApplication<ctk::RangeMonitor<float_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 80.0);
-    test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 70.0);
-    test.setScalarDefault<float_t>("/parameters/lowerWarningThreshold", 60.0);
-    test.setScalarDefault<float_t>("/parameters/lowerFaultThreshold", 50.0);
-    test.setScalarDefault<float_t>("/input/path", 75.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-  }
-  {
-    TestApplication<ctk::RangeMonitor<float_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 80.0);
-    test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 70.0);
-    test.setScalarDefault<float_t>("/parameters/lowerWarningThreshold", 60.0);
-    test.setScalarDefault<float_t>("/parameters/lowerFaultThreshold", 50.0);
-    test.setScalarDefault<float_t>("/input/path", 55.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-  }
-  {
-    TestApplication<ctk::RangeMonitor<float_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<float_t>("/parameters/upperFaultThreshold", 80.0);
-    test.setScalarDefault<float_t>("/parameters/upperWarningThreshold", 70.0);
-    test.setScalarDefault<float_t>("/parameters/lowerWarningThreshold", 60.0);
-    test.setScalarDefault<float_t>("/parameters/lowerFaultThreshold", 50.0);
-    test.setScalarDefault<float_t>("/input/path", 55.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", true);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-  }
-  {
-    TestApplication<ctk::RangeMonitor<int32_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<int32_t>("/parameters/upperFaultThreshold", 80);
-    test.setScalarDefault<int32_t>("/parameters/upperWarningThreshold", 70);
-    test.setScalarDefault<int32_t>("/parameters/lowerWarningThreshold", 60);
-    test.setScalarDefault<int32_t>("/parameters/lowerFaultThreshold", 50);
-    test.setScalarDefault<int32_t>("/input/path", 85);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-  }
-  {
-    TestApplication<ctk::RangeMonitor<int32_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<int32_t>("/parameters/upperFaultThreshold", 80);
-    test.setScalarDefault<int32_t>("/parameters/upperWarningThreshold", 70);
-    test.setScalarDefault<int32_t>("/parameters/lowerWarningThreshold", 60);
-    test.setScalarDefault<int32_t>("/parameters/lowerFaultThreshold", 50);
-    test.setScalarDefault<int32_t>("/input/path", 45);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-  }
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testExactMonitorInitialValuePropagation) {
-  std::cout << "testExactMonitorInitialValuePropagation" << std::endl;
-
-  {
-    TestApplication<ctk::ExactMonitor<double_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<double_t>("/parameters/requiredValue", 60.0);
-    test.setScalarDefault<double_t>("/input/path", 60.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-  }
-  {
-    TestApplication<ctk::ExactMonitor<float_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<float_t>("/parameters/requiredValue", 60.0);
-    test.setScalarDefault<float_t>("/input/path", 55.0);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", true);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::OFF));
-  }
-  {
-    TestApplication<ctk::ExactMonitor<int32_t>> app;
-    ctk::TestFacility test(app);
-    test.setScalarDefault<int32_t>("/parameters/requiredValue", 60);
-    test.setScalarDefault<int32_t>("/input/path", 45);
-    test.setScalarDefault<ChimeraTK::Boolean>("/parameters/disable", false);
-
-    test.runApplication();
-
-    BOOST_TEST(test.readScalar<int32_t>("/output/path") == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-  }
-}
-
-/*********************************************************************************************************************/
-/* Test data validity propagation for the Monitors *******************************************************************/
-/*********************************************************************************************************************/
-
-/*
- * Data validity is checked in base class of all monitors (MonitorBase) in method MonitorBase::setStatus only
- * There is no need to test all types of monitors so we gonna use MaxMonitor
- * */
-BOOST_AUTO_TEST_CASE(testMonitorDataValidityPropagation) {
-  std::cout << "testMonitorDataValidityPropagation" << std::endl;
-
-  TestApplication<ctk::MaxMonitor<double_t>> app;
-  ctk::TestFacility test(app);
-
-  test.runApplication();
-
-  auto fault = test.getScalar<double_t>("/parameters/upperFaultThreshold");
-  auto warning = test.getScalar<double_t>("/parameters/upperWarningThreshold");
-  auto watch = test.getScalar<double_t>("/input/path");
-  auto status = test.getScalar<int32_t>("/output/path");
-
-  fault = 60.0;
-  fault.write();
-  warning = 50.0;
-  warning.write();
-  watch = 40.0;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  // status is OK and data validity also
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-  BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
-
-  watch.setDataValidity(ctk::DataValidity::faulty);
-  watch.write();
-  test.stepApplication();
-  // status is not changed as watch is the same, data validity is changed -> test condition: getDataValidity() !=
-  // lastStatusValidity
-  BOOST_CHECK(status.readLatest());
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::OK));
-  // StatusOutput by default does not propagate DataValidity=fault (behaviour was changed!)
-  BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
-
-  watch = 55.0;
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  // status is changed, data validity is not changed -> test condition: status.value != newStatus
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::WARNING));
-  BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
-
-  watch = 70.0;
-  watch.setDataValidity(ctk::DataValidity::ok);
-  watch.write();
-  test.stepApplication();
-  status.readLatest();
-  // status is changed, data validity is changed -> test condition: status.value != newStatus
-  BOOST_CHECK(status == static_cast<int>(ChimeraTK::StatusOutput::Status::FAULT));
-  BOOST_CHECK(status.dataValidity() == ctk::DataValidity::ok);
-
-  watch = 75.0;
-  watch.setDataValidity(ctk::DataValidity::ok);
-  watch.write();
-  test.stepApplication();
-  // status is not changed, data validity is not changed -> test that there is no new value of status
-  BOOST_CHECK(status.readLatest() == false);
-}
+} // namespace Tests::testStatusMonitor

--- a/tests/executables_src/testTestFacilities.cc
+++ b/tests/executables_src/testTestFacilities.cc
@@ -21,8 +21,10 @@
 //#undef BOOST_NO_EXCEPTIONS
 #include <boost/thread/barrier.hpp>
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testTestFacilities {
+
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
 #define CHECK_TIMEOUT(condition, maxMilliseconds)                                                                      \
   {                                                                                                                    \
@@ -35,949 +37,952 @@ namespace ctk = ChimeraTK;
     }                                                                                                                  \
   }
 
-constexpr std::string_view dummySdm{"(dummy?map=test_readonly.map)"};
+  constexpr std::string_view dummySdm{"(dummy?map=test_readonly.map)"};
 
-/*********************************************************************************************************************/
-/* the BlockingReadTestModule blockingly reads its input in the main loop and writes the result to its output */
+  /*********************************************************************************************************************/
+  /* the BlockingReadTestModule blockingly reads its input in the main loop and writes the result to its output */
 
-struct BlockingReadTestModule : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
+  struct BlockingReadTestModule : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  ctk::ScalarPushInput<int32_t> someInput{this, "/value", "cm", "This is just some input for testing"};
-  ctk::ScalarOutput<int32_t> someOutput{this, "someOutput", "cm", "Description"};
+    ctk::ScalarPushInput<int32_t> someInput{this, "/value", "cm", "This is just some input for testing"};
+    ctk::ScalarOutput<int32_t> someOutput{this, "someOutput", "cm", "Description"};
 
-  void mainLoop() override {
-    while(true) {
-      int32_t val = someInput;
-      someOutput = val;
-      usleep(10000); // wait some extra time to make sure we are really blocking
-                     // the test procedure thread
-      someOutput.write();
-      someInput.read(); // read at the end to propagate the initial value
+    void mainLoop() override {
+      while(true) {
+        int32_t val = someInput;
+        someOutput = val;
+        usleep(10000); // wait some extra time to make sure we are really blocking
+                       // the test procedure thread
+        someOutput.write();
+        someInput.read(); // read at the end to propagate the initial value
+      }
     }
-  }
-};
-
-/*********************************************************************************************************************/
-/* the ReadAnyTestModule calls readAny on a bunch of inputs and outputs some information on the received data */
-
-struct ReadAnyTestModule : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  struct Inputs : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarPushInput<int32_t> v1{this, "v1", "cm", "Input 1 for testing"};
-    ctk::ScalarPushInput<int32_t> v2{this, "/REG2", "cm", "Input 2 for testing"};
-    ctk::ScalarPushInput<int32_t> v3{this, "v3", "cm", "Input 3 for testing"};
-    ctk::ScalarPushInput<int32_t> v4{this, "v4", "cm", "Input 4 for testing"};
   };
-  Inputs inputs{this, "inputs", "A group of inputs"};
-  ctk::ScalarOutput<int32_t> value{this, "/value", "cm", "The last value received from any of the inputs"};
-  ctk::ScalarOutput<uint32_t> index{
-      this, "index", "", "The index (1..4) of the input where the last value was received"};
 
-  void prepare() override {
-    incrementDataFaultCounter(); // force all outputs  to invalid
-    writeAll();
-    decrementDataFaultCounter(); // validity according to input validity
-  }
+  /*********************************************************************************************************************/
+  /* the ReadAnyTestModule calls readAny on a bunch of inputs and outputs some information on the received data */
 
-  void mainLoop() override {
-    auto group = inputs.readAnyGroup();
-    while(true) {
-      auto justRead = group.readAny();
-      if(inputs.v1.getId() == justRead) {
-        index = 1;
-        value = int32_t(inputs.v1);
-      }
-      else if(inputs.v2.getId() == justRead) {
-        index = 2;
-        value = int32_t(inputs.v2);
-      }
-      else if(inputs.v3.getId() == justRead) {
-        index = 3;
-        value = int32_t(inputs.v3);
-      }
-      else if(inputs.v4.getId() == justRead) {
-        index = 4;
-        value = int32_t(inputs.v4);
-      }
-      else {
-        index = 0;
-        value = 0;
-      }
-      usleep(10000); // wait some extra time to make sure we are really blocking
-                     // the test procedure thread
-      index.write();
-      value.write();
+  struct ReadAnyTestModule : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+
+    struct Inputs : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarPushInput<int32_t> v1{this, "v1", "cm", "Input 1 for testing"};
+      ctk::ScalarPushInput<int32_t> v2{this, "/REG2", "cm", "Input 2 for testing"};
+      ctk::ScalarPushInput<int32_t> v3{this, "v3", "cm", "Input 3 for testing"};
+      ctk::ScalarPushInput<int32_t> v4{this, "v4", "cm", "Input 4 for testing"};
+    };
+    Inputs inputs{this, "inputs", "A group of inputs"};
+    ctk::ScalarOutput<int32_t> value{this, "/value", "cm", "The last value received from any of the inputs"};
+    ctk::ScalarOutput<uint32_t> index{
+        this, "index", "", "The index (1..4) of the input where the last value was received"};
+
+    void prepare() override {
+      incrementDataFaultCounter(); // force all outputs  to invalid
+      writeAll();
+      decrementDataFaultCounter(); // validity according to input validity
     }
-  }
-};
 
-/*********************************************************************************************************************/
-/* the PollingReadModule is designed to test poll-type transfers (even mixed with push-type) */
-
-struct PollingReadModule : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  ctk::ScalarPushInput<int32_t> push{this, "push", "cm", "A push-type input"};
-  ctk::ScalarPushInput<int32_t> push2{this, "push2", "cm", "A second push-type input"};
-  ctk::ScalarPollInput<int32_t> poll{this, "poll", "cm", "A poll-type input"};
-
-  ctk::ScalarOutput<int32_t> valuePush{this, "valuePush", "cm", "The last value received for 'push'"};
-  ctk::ScalarOutput<int32_t> valuePoll{this, "valuePoll", "cm", "The last value received for 'poll'"};
-  ctk::ScalarOutput<int32_t> state{this, "state", "", "State of the test mainLoop"};
-
-  void prepare() override {
-    incrementDataFaultCounter(); // foce all outputs  to invalid
-    writeAll();
-    decrementDataFaultCounter(); // validity according to input validity
-  }
-
-  void mainLoop() override {
-    while(true) {
-      push.read();
-      poll.read();
-      valuePush = int32_t(push);
-      valuePoll = int32_t(poll);
-      valuePoll.write();
-      valuePush.write();
-      state = 1;
-      state.write();
-
-      push2.read();
-      push.readNonBlocking();
-      poll.read();
-      valuePush = int32_t(push);
-      valuePoll = int32_t(poll);
-      valuePoll.write();
-      valuePush.write();
-      state = 2;
-      state.write();
-
-      push2.read();
-      push.readLatest();
-      poll.read();
-      valuePush = int32_t(push);
-      valuePoll = int32_t(poll);
-      valuePoll.write();
-      valuePush.write();
-      state = 3;
-      state.write();
+    void mainLoop() override {
+      auto group = inputs.readAnyGroup();
+      while(true) {
+        auto justRead = group.readAny();
+        if(inputs.v1.getId() == justRead) {
+          index = 1;
+          value = int32_t(inputs.v1);
+        }
+        else if(inputs.v2.getId() == justRead) {
+          index = 2;
+          value = int32_t(inputs.v2);
+        }
+        else if(inputs.v3.getId() == justRead) {
+          index = 3;
+          value = int32_t(inputs.v3);
+        }
+        else if(inputs.v4.getId() == justRead) {
+          index = 4;
+          value = int32_t(inputs.v4);
+        }
+        else {
+          index = 0;
+          value = 0;
+        }
+        usleep(10000); // wait some extra time to make sure we are really blocking
+                       // the test procedure thread
+        index.write();
+        value.write();
+      }
     }
-  }
-};
+  };
 
-/*********************************************************************************************************************/
-/* the PollingThroughFanoutsModule is designed to test poll-type transfers in combination with FanOuts */
+  /*********************************************************************************************************************/
+  /* the PollingReadModule is designed to test poll-type transfers (even mixed with push-type) */
 
-struct PollingThroughFanoutsModule : ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-  ctk::ScalarPushInput<int> push1{this, "push1", "", ""};
-  ctk::ScalarPollInput<int> poll1{this, "poll1", "", ""};
-  ctk::ScalarPollInput<int> poll2{this, "poll2", "", ""};
-  ctk::ScalarOutput<int> out1{this, "out1", "", ""};
-  ctk::ScalarOutput<int> out2{this, "out2", "", ""};
+  struct PollingReadModule : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  std::mutex mForChecking;
-  bool hasRead{false};
+    ctk::ScalarPushInput<int32_t> push{this, "push", "cm", "A push-type input"};
+    ctk::ScalarPushInput<int32_t> push2{this, "push2", "cm", "A second push-type input"};
+    ctk::ScalarPollInput<int32_t> poll{this, "poll", "cm", "A poll-type input"};
 
-  void prepare() override { writeAll(); }
+    ctk::ScalarOutput<int32_t> valuePush{this, "valuePush", "cm", "The last value received for 'push'"};
+    ctk::ScalarOutput<int32_t> valuePoll{this, "valuePoll", "cm", "The last value received for 'poll'"};
+    ctk::ScalarOutput<int32_t> state{this, "state", "", "State of the test mainLoop"};
 
-  void run() override { ApplicationModule::run(); }
-
-  void mainLoop() override {
-    while(true) {
-      push1.read();
-
-      std::unique_lock<std::mutex> lock(mForChecking);
-      hasRead = true;
-      poll1.read();
-      poll2.read();
-      usleep(1000); // give try_lock() in tests a chance to fail if testable mode lock would not work
+    void prepare() override {
+      incrementDataFaultCounter(); // foce all outputs  to invalid
+      writeAll();
+      decrementDataFaultCounter(); // validity according to input validity
     }
-  }
-};
 
-/*********************************************************************************************************************/
-/* test that no TestableModeAccessorDecorator is used if the testable mode is not enabled */
+    void mainLoop() override {
+      while(true) {
+        push.read();
+        poll.read();
+        valuePush = int32_t(push);
+        valuePoll = int32_t(poll);
+        valuePoll.write();
+        valuePush.write();
+        state = 1;
+        state.write();
 
-struct TestNoDecoratorApplication : public ctk::Application {
-  TestNoDecoratorApplication() : Application("testApplication") {}
-  ~TestNoDecoratorApplication() override { shutdown(); }
+        push2.read();
+        push.readNonBlocking();
+        poll.read();
+        valuePush = int32_t(push);
+        valuePoll = int32_t(poll);
+        valuePoll.write();
+        valuePush.write();
+        state = 2;
+        state.write();
 
-  BlockingReadTestModule blockingReadTestModule{this, "blockingReadTestModule", "Module for testing blocking read"};
-  ReadAnyTestModule readAnyTestModule{this, "readAnyTestModule", "Module for testing readAny()"};
-};
+        push2.read();
+        push.readLatest();
+        poll.read();
+        valuePush = int32_t(push);
+        valuePoll = int32_t(poll);
+        valuePoll.write();
+        valuePush.write();
+        state = 3;
+        state.write();
+      }
+    }
+  };
 
-BOOST_AUTO_TEST_CASE(testNoDecorator) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testNoDecorator" << std::endl;
+  /*********************************************************************************************************************/
+  /* the PollingThroughFanoutsModule is designed to test poll-type transfers in combination with FanOuts */
 
-  TestNoDecoratorApplication app;
+  struct PollingThroughFanoutsModule : ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+    ctk::ScalarPushInput<int> push1{this, "push1", "", ""};
+    ctk::ScalarPollInput<int> poll1{this, "poll1", "", ""};
+    ctk::ScalarPollInput<int> poll2{this, "poll2", "", ""};
+    ctk::ScalarOutput<int> out1{this, "out1", "", ""};
+    ctk::ScalarOutput<int> out2{this, "out2", "", ""};
 
-  auto pvManagers = ctk::createPVManager();
-  app.setPVManager(pvManagers.second);
+    std::mutex mForChecking;
+    bool hasRead{false};
 
-  app.initialise();
-  app.run();
+    void prepare() override { writeAll(); }
 
-  // check if we got the decorator for the input
-  auto hlinput = app.blockingReadTestModule.someInput.getHighLevelImplElement();
-  BOOST_CHECK(boost::dynamic_pointer_cast<ctk::detail::TestableMode::AccessorDecorator<int32_t>>(hlinput) == nullptr);
+    void run() override { ApplicationModule::run(); }
 
-  // check that we did not get the decorator for the output
-  auto hloutput = app.blockingReadTestModule.someOutput.getHighLevelImplElement();
-  BOOST_CHECK(boost::dynamic_pointer_cast<ctk::detail::TestableMode::AccessorDecorator<int32_t>>(hloutput) == nullptr);
-}
+    void mainLoop() override {
+      while(true) {
+        push1.read();
 
-/*********************************************************************************************************************/
-/* test blocking read in test mode */
+        std::unique_lock<std::mutex> lock(mForChecking);
+        hasRead = true;
+        poll1.read();
+        poll2.read();
+        usleep(1000); // give try_lock() in tests a chance to fail if testable mode lock would not work
+      }
+    }
+  };
 
-struct TestBlockingReadApplication : public ctk::Application {
-  TestBlockingReadApplication() : Application("testApplication") {}
-  ~TestBlockingReadApplication() override { shutdown(); }
+  /*********************************************************************************************************************/
+  /* test that no TestableModeAccessorDecorator is used if the testable mode is not enabled */
 
-  BlockingReadTestModule blockingReadTestModule{this, "blockingReadTestModule", "Module for testing blocking read"};
-};
+  struct TestNoDecoratorApplication : public ctk::Application {
+    TestNoDecoratorApplication() : Application("testApplication") {}
+    ~TestNoDecoratorApplication() override { shutdown(); }
 
-BOOST_AUTO_TEST_CASE(testBlockingRead) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testBlockingRead" << std::endl;
+    BlockingReadTestModule blockingReadTestModule{this, "blockingReadTestModule", "Module for testing blocking read"};
+    ReadAnyTestModule readAnyTestModule{this, "readAnyTestModule", "Module for testing readAny()"};
+  };
 
-  TestBlockingReadApplication app;
+  BOOST_AUTO_TEST_CASE(testNoDecorator) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testNoDecorator" << std::endl;
 
-  ctk::TestFacility test{app};
-  auto pvInput = test.getScalar<int32_t>("/value");
-  auto pvOutput = test.getScalar<int32_t>("/blockingReadTestModule/someOutput");
-  test.runApplication();
+    TestNoDecoratorApplication app;
 
-  // test blocking read when taking control in the test thread (note: the
-  // blocking read is executed in the app module!)
-  for(int i = 0; i < 5; ++i) {
-    pvInput = 120 + i;
-    pvInput.write();
-    usleep(10000);
-    BOOST_CHECK(pvOutput.readNonBlocking() == false);
-    test.stepApplication();
-    CHECK_TIMEOUT(pvOutput.readNonBlocking() == true, 10000);
-    int val = pvOutput;
-    BOOST_CHECK(val == 120 + i);
-  }
-}
+    auto pvManagers = ctk::createPVManager();
+    app.setPVManager(pvManagers.second);
 
-/*********************************************************************************************************************/
-/* test testReadAny in test mode */
+    app.initialise();
+    app.run();
 
-struct TestReadAnyApplication : public ctk::Application {
-  TestReadAnyApplication() : Application("testApplication") {}
-  ~TestReadAnyApplication() override { shutdown(); }
+    // check if we got the decorator for the input
+    auto hlinput = app.blockingReadTestModule.someInput.getHighLevelImplElement();
+    BOOST_CHECK(boost::dynamic_pointer_cast<ctk::detail::TestableMode::AccessorDecorator<int32_t>>(hlinput) == nullptr);
 
-  ReadAnyTestModule readAnyTestModule{this, "readAnyTestModule", "Module for testing readAny()"};
-};
-
-BOOST_AUTO_TEST_CASE(testReadAny) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testReadAny" << std::endl;
-
-  TestReadAnyApplication app;
-
-  ctk::TestFacility test{app};
-  auto value = test.getScalar<int32_t>("/value");
-  auto index = test.getScalar<uint32_t>("/readAnyTestModule/index");
-  auto v1 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v1");
-  auto v2 = test.getScalar<int32_t>("/REG2"); // just named irregularly, no device present!
-  auto v3 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v3");
-  auto v4 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v4");
-  test.runApplication();
-  // check that we don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // send something to v4
-  v4 = 66;
-  v4.write();
-
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // run the application and check that we got the expected result
-  test.stepApplication();
-  BOOST_CHECK(value.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK_EQUAL(value, 66);
-  BOOST_CHECK_EQUAL(index, 4);
-
-  // send something to v1
-  v1 = 33;
-  v1.write();
-
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // run the application and check that we got the expected result
-  test.stepApplication();
-  BOOST_CHECK(value.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK_EQUAL(value, 33);
-  BOOST_CHECK_EQUAL(index, 1);
-
-  // send something to v1 again
-  v1 = 34;
-  v1.write();
-
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // run the application and check that we got the expected result
-  test.stepApplication();
-
-  BOOST_CHECK(value.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK_EQUAL(value, 34);
-  BOOST_CHECK_EQUAL(index, 1);
-
-  // send something to v3
-  v3 = 40;
-  v3.write();
-
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // run the application and check that we got the expected result
-  test.stepApplication();
-  BOOST_CHECK(value.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK_EQUAL(value, 40);
-  BOOST_CHECK_EQUAL(index, 3);
-
-  // send something to v2
-  v2 = 50;
-  v2.write();
-
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // run the application and check that we got the expected result
-  test.stepApplication();
-  BOOST_CHECK(value.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK_EQUAL(value, 50);
-  BOOST_CHECK_EQUAL(index, 2);
-
-  // check that stepApplication() throws an exception if no input data is
-  // available
-  try {
-    test.stepApplication();
-    BOOST_ERROR("IllegalParameter exception expected.");
-  }
-  catch(ChimeraTK::logic_error&) {
+    // check that we did not get the decorator for the output
+    auto hloutput = app.blockingReadTestModule.someOutput.getHighLevelImplElement();
+    BOOST_CHECK(
+        boost::dynamic_pointer_cast<ctk::detail::TestableMode::AccessorDecorator<int32_t>>(hloutput) == nullptr);
   }
 
-  // check that we still don't receive anything anymore
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
+  /*********************************************************************************************************************/
+  /* test blocking read in test mode */
 
-  // send something to v1 a 3rd time
-  v1 = 35;
-  v1.write();
+  struct TestBlockingReadApplication : public ctk::Application {
+    TestBlockingReadApplication() : Application("testApplication") {}
+    ~TestBlockingReadApplication() override { shutdown(); }
 
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
+    BlockingReadTestModule blockingReadTestModule{this, "blockingReadTestModule", "Module for testing blocking read"};
+  };
 
-  // run the application and check that we got the expected result
-  test.stepApplication();
-  BOOST_CHECK(value.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK_EQUAL(value, 35);
-  BOOST_CHECK_EQUAL(index, 1);
-}
+  BOOST_AUTO_TEST_CASE(testBlockingRead) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testBlockingRead" << std::endl;
 
-/*********************************************************************************************************************/
-/* test the interplay of multiple chained modules and their threads in test mode
- */
-
-struct TestChaniedModulesApplication : public ctk::Application {
-  TestChaniedModulesApplication() : Application("testApplication") {}
-  ~TestChaniedModulesApplication() override { shutdown(); }
-
-  BlockingReadTestModule blockingReadTestModule{this, "blockingReadTestModule", "Module for testing blocking read"};
-  ReadAnyTestModule readAnyTestModule{this, "readAnyTestModule", "Module for testing readAny()"};
-};
-
-BOOST_AUTO_TEST_CASE(testChainedModules) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testChainedModules" << std::endl;
-
-  TestChaniedModulesApplication app;
-
-  ctk::TestFacility test{app};
-  auto value = test.getScalar<int32_t>("/blockingReadTestModule/someOutput");
-  auto index = test.getScalar<uint32_t>("/readAnyTestModule/index");
-  auto v1 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v1");
-  auto v2 = test.getScalar<int32_t>("/REG2"); // just named irregularly, no device present!
-  auto v3 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v3");
-  auto v4 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v4");
-  test.runApplication();
-
-  // check that we don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // send something to v2
-  v2 = 11;
-  v2.write();
-
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // run the application and check that we got the expected result
-  test.stepApplication();
-  BOOST_CHECK(value.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK(value == 11);
-  BOOST_CHECK(index == 2);
-
-  // send something to v3
-  v3 = 12;
-  v3.write();
-
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // run the application and check that we got the expected result
-  test.stepApplication();
-  BOOST_CHECK(value.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK(value == 12);
-  BOOST_CHECK(index == 3);
-
-  // send something to v3 again
-  v3 = 13;
-  v3.write();
-
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // run the application and check that we got the expected result
-  test.stepApplication();
-  BOOST_CHECK(value.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK(value == 13);
-  BOOST_CHECK(index == 3);
-
-  // check that stepApplication() throws an exception if no input data is
-  // available
-  try {
-    test.stepApplication();
-    BOOST_ERROR("IllegalParameter exception expected.");
-  }
-  catch(ChimeraTK::logic_error&) {
-  }
-
-  // check that we still don't receive anything anymore
-  usleep(10000);
-  BOOST_CHECK(value.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-}
-
-/*********************************************************************************************************************/
-/* test combination with trigger */
-
-struct TestWithTriggerApplication : public ctk::Application {
-  TestWithTriggerApplication() : Application("testApplication") {}
-  ~TestWithTriggerApplication() override { shutdown(); }
-
-  ctk::DeviceModule dev{this, dummySdm.data(), "/trigger"};
-  BlockingReadTestModule blockingReadTestModule{this, "blockingReadTestModule", "Module for testing blocking read"};
-  ReadAnyTestModule readAnyTestModule{this, "readAnyTestModule", "Module for testing readAny()"};
-};
-
-BOOST_AUTO_TEST_CASE(testWithTrigger) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testWithTrigger" << std::endl;
-
-  TestWithTriggerApplication app;
-
-  ctk::TestFacility test{app};
-  ctk::Device dev;
-  dev.open(dummySdm.data());
-  auto valueFromBlocking = test.getScalar<int32_t>("/blockingReadTestModule/someOutput");
-  auto index = test.getScalar<uint32_t>("/readAnyTestModule/index");
-  auto trigger = test.getVoid("/trigger");
-  auto v2 = dev.getScalarRegisterAccessor<int32_t>("/REG2.DUMMY_WRITEABLE");
-  test.runApplication();
-
-  // check that we don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(valueFromBlocking.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // send something to v2 and send the trigger
-  v2 = 11;
-  v2.write();
-  trigger.write();
-
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(valueFromBlocking.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // run the application and check that we got the expected result
-  test.stepApplication();
-  BOOST_CHECK(valueFromBlocking.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK(valueFromBlocking == 11);
-  BOOST_CHECK(index == 2);
-
-  // again send something to v2 and send the trigger
-  v2 = 22;
-  v2.write();
-  trigger.write();
-
-  // check that we still don't receive anything yet
-  usleep(10000);
-  BOOST_CHECK(valueFromBlocking.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-
-  // run the application and check that we got the expected result
-  test.stepApplication();
-  BOOST_CHECK(valueFromBlocking.readNonBlocking() == true);
-  BOOST_CHECK(index.readNonBlocking() == true);
-  BOOST_CHECK(valueFromBlocking == 22);
-  BOOST_CHECK(index == 2);
-
-  // check that stepApplication() throws an exception if no input data is
-  // available
-  try {
-    test.stepApplication();
-    BOOST_ERROR("IllegalParameter exception expected.");
-  }
-  catch(ChimeraTK::logic_error&) {
-  }
-
-  // check that we still don't receive anything anymore
-  usleep(10000);
-  BOOST_CHECK(valueFromBlocking.readNonBlocking() == false);
-  //  BOOST_CHECK(valueFromAsync.readNonBlocking() == false);
-  BOOST_CHECK(index.readNonBlocking() == false);
-}
-
-/*********************************************************************************************************************/
-/* test convenience read functions */
-
-struct TestConvenienceReadApplication : public ctk::Application {
-  TestConvenienceReadApplication() : Application("testApplication") {}
-  ~TestConvenienceReadApplication() override { shutdown(); }
-
-  BlockingReadTestModule blockingReadTestModule{this, "blockingReadTestModule", "Module for testing blocking read"};
-};
-
-BOOST_AUTO_TEST_CASE(testConvenienceRead) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testConvenienceRead" << std::endl;
-
-  TestConvenienceReadApplication app;
-
-  ctk::TestFacility test{app};
-  test.runApplication();
-
-  // test blocking read when taking control in the test thread (note: the blocking read is executed in the app module!)
-  for(int i = 0; i < 5; ++i) {
-    test.writeScalar<int32_t>("/value", 120 + i);
-    test.stepApplication();
-    CHECK_TIMEOUT(test.readScalar<int32_t>("/blockingReadTestModule/someOutput") == 120 + i, 10000);
-  }
-
-  // same with array function (still a scalar variable behind, but this does not matter)
-  for(int i = 0; i < 5; ++i) {
-    std::vector<int32_t> myValue{120 + i};
-    test.writeArray<int32_t>("/value", myValue);
-    test.stepApplication();
-    CHECK_TIMEOUT(
-        test.readArray<int32_t>("/blockingReadTestModule/someOutput") == std::vector<int32_t>{120 + i}, 10000);
-  }
-}
-
-/*********************************************************************************************************************/
-/* test poll-type transfers mixed with push-type */
-
-struct TestPollingApplication : public ctk::Application {
-  TestPollingApplication() : Application("testApplication") {}
-  ~TestPollingApplication() override { shutdown(); }
-
-  PollingReadModule pollingReadModule{this, "pollingReadModule", "Module for testing poll-type transfers"};
-};
-
-BOOST_AUTO_TEST_CASE(testPolling) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testPolling" << std::endl;
-
-  TestPollingApplication app; // app.pollingReadModule.connectTo(app.cs);
-
-  ctk::TestFacility test{app};
-  test.runApplication();
-
-  auto pv_push = test.getScalar<int32_t>("/pollingReadModule/push");
-  auto pv_push2 = test.getScalar<int32_t>("/pollingReadModule/push2");
-  auto pv_poll = test.getScalar<int32_t>("/pollingReadModule/poll");
-  auto pv_valuePush = test.getScalar<int32_t>("/pollingReadModule/valuePush");
-  auto pv_valuePoll = test.getScalar<int32_t>("/pollingReadModule/valuePoll");
-  auto pv_state = test.getScalar<int>("/pollingReadModule/state");
-
-  // write values to 'push' and 'poll' and check result
-  pv_push = 120;
-  pv_push.write();
-  pv_poll = 42;
-  pv_poll.write();
-  test.stepApplication();
-  pv_valuePoll.read();
-  pv_valuePush.read();
-  pv_state.read();
-  BOOST_CHECK_EQUAL((int32_t)pv_valuePoll, 42);
-  BOOST_CHECK_EQUAL((int32_t)pv_valuePush, 120);
-  BOOST_CHECK_EQUAL((int32_t)pv_state, 1);
-
-  // this time the application gets triggered by push2, push is read
-  // non-blockingly (single value only)
-  pv_push = 22;
-  pv_push.write();
-  pv_poll = 44;
-  pv_poll.write();
-  pv_poll = 45;
-  pv_poll.write();
-  pv_push2.write();
-  test.stepApplication();
-  pv_valuePoll.read();
-  pv_valuePush.read();
-  pv_state.read();
-  BOOST_CHECK_EQUAL((int32_t)pv_valuePoll, 45);
-  BOOST_CHECK_EQUAL((int32_t)pv_valuePush, 22);
-  BOOST_CHECK_EQUAL((int32_t)pv_state, 2);
-
-  // this time the application gets triggered by push2, push is read with
-  // readLatest()
-  pv_push = 24;
-  pv_push.write();
-  pv_poll = 46;
-  pv_poll.write();
-  pv_push2.write();
-  test.stepApplication();
-  pv_valuePoll.read();
-  pv_valuePush.read();
-  pv_state.read();
-  BOOST_CHECK_EQUAL((int32_t)pv_valuePoll, 46);
-  BOOST_CHECK_EQUAL((int32_t)pv_valuePush, 24);
-  BOOST_CHECK_EQUAL((int32_t)pv_state, 3);
-
-  // provoke internal queue overflow in poll-type variable (should not make any difference)
-  pv_push = 25;
-  pv_push.write();
-  for(int i = 0; i < 10; ++i) {
-    pv_poll = 50 + i;
-  }
-  pv_poll.write();
-  pv_push2.write();
-  test.stepApplication();
-  pv_valuePoll.read();
-  pv_valuePush.read();
-  pv_state.read();
-  BOOST_CHECK_EQUAL((int32_t)pv_valuePoll, 59);
-  BOOST_CHECK_EQUAL((int32_t)pv_valuePush, 25);
-  BOOST_CHECK_EQUAL((int32_t)pv_state, 1);
-}
-
-/*********************************************************************************************************************/
-/* test poll-type transfers in combination with various FanOuts */
-
-struct TestPollingThroughFanOutsApplication : public ctk::Application {
-  TestPollingThroughFanOutsApplication() : Application("AnotherTestApplication") {}
-  ~TestPollingThroughFanOutsApplication() override { shutdown(); }
-
-  ctk::DeviceModule dev{this, dummySdm.data(), "/fakeTriggerToSatisfyUnusedRegister"};
-  PollingThroughFanoutsModule m1{this, "m1", ""};
-  PollingThroughFanoutsModule m2{this, "m2", ""};
-};
-
-BOOST_AUTO_TEST_CASE(testPollingThroughFanOuts) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testPollingThroughFanOuts" << std::endl;
-
-  // Case 1: FeedingFanOut
-  // ---------------------
-  {
-    TestPollingThroughFanOutsApplication app;
-    app.debugMakeConnections();
-    // app.getTestableMode().setEnableDebug();
-
-    app.m2.poll1 = {&app.m2, "/m1/out1", "", ""};
-    app.m2.poll2 = {&app.m2, "/m1/out1", "", ""};
-    app.m2.push1 = {&app.m2, "/m1/out2", "", ""};
-
-    std::unique_lock<std::mutex> lk1(app.m1.mForChecking, std::defer_lock);
-    std::unique_lock<std::mutex> lk2(app.m2.mForChecking, std::defer_lock);
+    TestBlockingReadApplication app;
 
     ctk::TestFacility test{app};
-
+    auto pvInput = test.getScalar<int32_t>("/value");
+    auto pvOutput = test.getScalar<int32_t>("/blockingReadTestModule/someOutput");
     test.runApplication();
 
-    // test single value
-    BOOST_REQUIRE(lk1.try_lock());
-    app.m1.out1 = 123;
-    app.m1.out1.write();
-    app.m1.out2.write();
-    lk1.unlock();
+    // test blocking read when taking control in the test thread (note: the
+    // blocking read is executed in the app module!)
+    for(int i = 0; i < 5; ++i) {
+      pvInput = 120 + i;
+      pvInput.write();
+      usleep(10000);
+      BOOST_CHECK(pvOutput.readNonBlocking() == false);
+      test.stepApplication();
+      CHECK_TIMEOUT(pvOutput.readNonBlocking() == true, 10000);
+      int val = pvOutput;
+      BOOST_CHECK(val == 120 + i);
+    }
+  }
 
+  /*********************************************************************************************************************/
+  /* test testReadAny in test mode */
+
+  struct TestReadAnyApplication : public ctk::Application {
+    TestReadAnyApplication() : Application("testApplication") {}
+    ~TestReadAnyApplication() override { shutdown(); }
+
+    ReadAnyTestModule readAnyTestModule{this, "readAnyTestModule", "Module for testing readAny()"};
+  };
+
+  BOOST_AUTO_TEST_CASE(testReadAny) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testReadAny" << std::endl;
+
+    TestReadAnyApplication app;
+
+    ctk::TestFacility test{app};
+    auto value = test.getScalar<int32_t>("/value");
+    auto index = test.getScalar<uint32_t>("/readAnyTestModule/index");
+    auto v1 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v1");
+    auto v2 = test.getScalar<int32_t>("/REG2"); // just named irregularly, no device present!
+    auto v3 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v3");
+    auto v4 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v4");
+    test.runApplication();
+    // check that we don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // send something to v4
+    v4 = 66;
+    v4.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
+    test.stepApplication();
+    BOOST_CHECK(value.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK_EQUAL(value, 66);
+    BOOST_CHECK_EQUAL(index, 4);
+
+    // send something to v1
+    v1 = 33;
+    v1.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
+    test.stepApplication();
+    BOOST_CHECK(value.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK_EQUAL(value, 33);
+    BOOST_CHECK_EQUAL(index, 1);
+
+    // send something to v1 again
+    v1 = 34;
+    v1.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
     test.stepApplication();
 
-    BOOST_REQUIRE(lk2.try_lock());
-    BOOST_CHECK_EQUAL(app.m2.poll1, 123);
-    BOOST_CHECK_EQUAL(app.m2.poll2, 123);
-    lk2.unlock();
+    BOOST_CHECK(value.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK_EQUAL(value, 34);
+    BOOST_CHECK_EQUAL(index, 1);
 
-    // test queue overrun
-    BOOST_REQUIRE(lk1.try_lock());
+    // send something to v3
+    v3 = 40;
+    v3.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
+    test.stepApplication();
+    BOOST_CHECK(value.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK_EQUAL(value, 40);
+    BOOST_CHECK_EQUAL(index, 3);
+
+    // send something to v2
+    v2 = 50;
+    v2.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
+    test.stepApplication();
+    BOOST_CHECK(value.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK_EQUAL(value, 50);
+    BOOST_CHECK_EQUAL(index, 2);
+
+    // check that stepApplication() throws an exception if no input data is
+    // available
+    try {
+      test.stepApplication();
+      BOOST_ERROR("IllegalParameter exception expected.");
+    }
+    catch(ChimeraTK::logic_error&) {
+    }
+
+    // check that we still don't receive anything anymore
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // send something to v1 a 3rd time
+    v1 = 35;
+    v1.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
+    test.stepApplication();
+    BOOST_CHECK(value.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK_EQUAL(value, 35);
+    BOOST_CHECK_EQUAL(index, 1);
+  }
+
+  /*********************************************************************************************************************/
+  /* test the interplay of multiple chained modules and their threads in test mode
+   */
+
+  struct TestChaniedModulesApplication : public ctk::Application {
+    TestChaniedModulesApplication() : Application("testApplication") {}
+    ~TestChaniedModulesApplication() override { shutdown(); }
+
+    BlockingReadTestModule blockingReadTestModule{this, "blockingReadTestModule", "Module for testing blocking read"};
+    ReadAnyTestModule readAnyTestModule{this, "readAnyTestModule", "Module for testing readAny()"};
+  };
+
+  BOOST_AUTO_TEST_CASE(testChainedModules) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testChainedModules" << std::endl;
+
+    TestChaniedModulesApplication app;
+
+    ctk::TestFacility test{app};
+    auto value = test.getScalar<int32_t>("/blockingReadTestModule/someOutput");
+    auto index = test.getScalar<uint32_t>("/readAnyTestModule/index");
+    auto v1 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v1");
+    auto v2 = test.getScalar<int32_t>("/REG2"); // just named irregularly, no device present!
+    auto v3 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v3");
+    auto v4 = test.getScalar<int32_t>("/readAnyTestModule/inputs/v4");
+    test.runApplication();
+
+    // check that we don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // send something to v2
+    v2 = 11;
+    v2.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
+    test.stepApplication();
+    BOOST_CHECK(value.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK(value == 11);
+    BOOST_CHECK(index == 2);
+
+    // send something to v3
+    v3 = 12;
+    v3.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
+    test.stepApplication();
+    BOOST_CHECK(value.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK(value == 12);
+    BOOST_CHECK(index == 3);
+
+    // send something to v3 again
+    v3 = 13;
+    v3.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
+    test.stepApplication();
+    BOOST_CHECK(value.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK(value == 13);
+    BOOST_CHECK(index == 3);
+
+    // check that stepApplication() throws an exception if no input data is
+    // available
+    try {
+      test.stepApplication();
+      BOOST_ERROR("IllegalParameter exception expected.");
+    }
+    catch(ChimeraTK::logic_error&) {
+    }
+
+    // check that we still don't receive anything anymore
+    usleep(10000);
+    BOOST_CHECK(value.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+  }
+
+  /*********************************************************************************************************************/
+  /* test combination with trigger */
+
+  struct TestWithTriggerApplication : public ctk::Application {
+    TestWithTriggerApplication() : Application("testApplication") {}
+    ~TestWithTriggerApplication() override { shutdown(); }
+
+    ctk::DeviceModule dev{this, dummySdm.data(), "/trigger"};
+    BlockingReadTestModule blockingReadTestModule{this, "blockingReadTestModule", "Module for testing blocking read"};
+    ReadAnyTestModule readAnyTestModule{this, "readAnyTestModule", "Module for testing readAny()"};
+  };
+
+  BOOST_AUTO_TEST_CASE(testWithTrigger) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testWithTrigger" << std::endl;
+
+    TestWithTriggerApplication app;
+
+    ctk::TestFacility test{app};
+    ctk::Device dev;
+    dev.open(dummySdm.data());
+    auto valueFromBlocking = test.getScalar<int32_t>("/blockingReadTestModule/someOutput");
+    auto index = test.getScalar<uint32_t>("/readAnyTestModule/index");
+    auto trigger = test.getVoid("/trigger");
+    auto v2 = dev.getScalarRegisterAccessor<int32_t>("/REG2.DUMMY_WRITEABLE");
+    test.runApplication();
+
+    // check that we don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(valueFromBlocking.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // send something to v2 and send the trigger
+    v2 = 11;
+    v2.write();
+    trigger.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(valueFromBlocking.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
+    test.stepApplication();
+    BOOST_CHECK(valueFromBlocking.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK(valueFromBlocking == 11);
+    BOOST_CHECK(index == 2);
+
+    // again send something to v2 and send the trigger
+    v2 = 22;
+    v2.write();
+    trigger.write();
+
+    // check that we still don't receive anything yet
+    usleep(10000);
+    BOOST_CHECK(valueFromBlocking.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+
+    // run the application and check that we got the expected result
+    test.stepApplication();
+    BOOST_CHECK(valueFromBlocking.readNonBlocking() == true);
+    BOOST_CHECK(index.readNonBlocking() == true);
+    BOOST_CHECK(valueFromBlocking == 22);
+    BOOST_CHECK(index == 2);
+
+    // check that stepApplication() throws an exception if no input data is
+    // available
+    try {
+      test.stepApplication();
+      BOOST_ERROR("IllegalParameter exception expected.");
+    }
+    catch(ChimeraTK::logic_error&) {
+    }
+
+    // check that we still don't receive anything anymore
+    usleep(10000);
+    BOOST_CHECK(valueFromBlocking.readNonBlocking() == false);
+    //  BOOST_CHECK(valueFromAsync.readNonBlocking() == false);
+    BOOST_CHECK(index.readNonBlocking() == false);
+  }
+
+  /*********************************************************************************************************************/
+  /* test convenience read functions */
+
+  struct TestConvenienceReadApplication : public ctk::Application {
+    TestConvenienceReadApplication() : Application("testApplication") {}
+    ~TestConvenienceReadApplication() override { shutdown(); }
+
+    BlockingReadTestModule blockingReadTestModule{this, "blockingReadTestModule", "Module for testing blocking read"};
+  };
+
+  BOOST_AUTO_TEST_CASE(testConvenienceRead) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testConvenienceRead" << std::endl;
+
+    TestConvenienceReadApplication app;
+
+    ctk::TestFacility test{app};
+    test.runApplication();
+
+    // test blocking read when taking control in the test thread (note: the blocking read is executed in the app module!)
+    for(int i = 0; i < 5; ++i) {
+      test.writeScalar<int32_t>("/value", 120 + i);
+      test.stepApplication();
+      CHECK_TIMEOUT(test.readScalar<int32_t>("/blockingReadTestModule/someOutput") == 120 + i, 10000);
+    }
+
+    // same with array function (still a scalar variable behind, but this does not matter)
+    for(int i = 0; i < 5; ++i) {
+      std::vector<int32_t> myValue{120 + i};
+      test.writeArray<int32_t>("/value", myValue);
+      test.stepApplication();
+      CHECK_TIMEOUT(
+          test.readArray<int32_t>("/blockingReadTestModule/someOutput") == std::vector<int32_t>{120 + i}, 10000);
+    }
+  }
+
+  /*********************************************************************************************************************/
+  /* test poll-type transfers mixed with push-type */
+
+  struct TestPollingApplication : public ctk::Application {
+    TestPollingApplication() : Application("testApplication") {}
+    ~TestPollingApplication() override { shutdown(); }
+
+    PollingReadModule pollingReadModule{this, "pollingReadModule", "Module for testing poll-type transfers"};
+  };
+
+  BOOST_AUTO_TEST_CASE(testPolling) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testPolling" << std::endl;
+
+    TestPollingApplication app; // app.pollingReadModule.connectTo(app.cs);
+
+    ctk::TestFacility test{app};
+    test.runApplication();
+
+    auto pv_push = test.getScalar<int32_t>("/pollingReadModule/push");
+    auto pv_push2 = test.getScalar<int32_t>("/pollingReadModule/push2");
+    auto pv_poll = test.getScalar<int32_t>("/pollingReadModule/poll");
+    auto pv_valuePush = test.getScalar<int32_t>("/pollingReadModule/valuePush");
+    auto pv_valuePoll = test.getScalar<int32_t>("/pollingReadModule/valuePoll");
+    auto pv_state = test.getScalar<int>("/pollingReadModule/state");
+
+    // write values to 'push' and 'poll' and check result
+    pv_push = 120;
+    pv_push.write();
+    pv_poll = 42;
+    pv_poll.write();
+    test.stepApplication();
+    pv_valuePoll.read();
+    pv_valuePush.read();
+    pv_state.read();
+    BOOST_CHECK_EQUAL((int32_t)pv_valuePoll, 42);
+    BOOST_CHECK_EQUAL((int32_t)pv_valuePush, 120);
+    BOOST_CHECK_EQUAL((int32_t)pv_state, 1);
+
+    // this time the application gets triggered by push2, push is read
+    // non-blockingly (single value only)
+    pv_push = 22;
+    pv_push.write();
+    pv_poll = 44;
+    pv_poll.write();
+    pv_poll = 45;
+    pv_poll.write();
+    pv_push2.write();
+    test.stepApplication();
+    pv_valuePoll.read();
+    pv_valuePush.read();
+    pv_state.read();
+    BOOST_CHECK_EQUAL((int32_t)pv_valuePoll, 45);
+    BOOST_CHECK_EQUAL((int32_t)pv_valuePush, 22);
+    BOOST_CHECK_EQUAL((int32_t)pv_state, 2);
+
+    // this time the application gets triggered by push2, push is read with
+    // readLatest()
+    pv_push = 24;
+    pv_push.write();
+    pv_poll = 46;
+    pv_poll.write();
+    pv_push2.write();
+    test.stepApplication();
+    pv_valuePoll.read();
+    pv_valuePush.read();
+    pv_state.read();
+    BOOST_CHECK_EQUAL((int32_t)pv_valuePoll, 46);
+    BOOST_CHECK_EQUAL((int32_t)pv_valuePush, 24);
+    BOOST_CHECK_EQUAL((int32_t)pv_state, 3);
+
+    // provoke internal queue overflow in poll-type variable (should not make any difference)
+    pv_push = 25;
+    pv_push.write();
     for(int i = 0; i < 10; ++i) {
-      app.m1.out1 = 191 + i;
+      pv_poll = 50 + i;
+    }
+    pv_poll.write();
+    pv_push2.write();
+    test.stepApplication();
+    pv_valuePoll.read();
+    pv_valuePush.read();
+    pv_state.read();
+    BOOST_CHECK_EQUAL((int32_t)pv_valuePoll, 59);
+    BOOST_CHECK_EQUAL((int32_t)pv_valuePush, 25);
+    BOOST_CHECK_EQUAL((int32_t)pv_state, 1);
+  }
+
+  /*********************************************************************************************************************/
+  /* test poll-type transfers in combination with various FanOuts */
+
+  struct TestPollingThroughFanOutsApplication : public ctk::Application {
+    TestPollingThroughFanOutsApplication() : Application("AnotherTestApplication") {}
+    ~TestPollingThroughFanOutsApplication() override { shutdown(); }
+
+    ctk::DeviceModule dev{this, dummySdm.data(), "/fakeTriggerToSatisfyUnusedRegister"};
+    PollingThroughFanoutsModule m1{this, "m1", ""};
+    PollingThroughFanoutsModule m2{this, "m2", ""};
+  };
+
+  BOOST_AUTO_TEST_CASE(testPollingThroughFanOuts) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testPollingThroughFanOuts" << std::endl;
+
+    // Case 1: FeedingFanOut
+    // ---------------------
+    {
+      TestPollingThroughFanOutsApplication app;
+      app.debugMakeConnections();
+      // app.getTestableMode().setEnableDebug();
+
+      app.m2.poll1 = {&app.m2, "/m1/out1", "", ""};
+      app.m2.poll2 = {&app.m2, "/m1/out1", "", ""};
+      app.m2.push1 = {&app.m2, "/m1/out2", "", ""};
+
+      std::unique_lock<std::mutex> lk1(app.m1.mForChecking, std::defer_lock);
+      std::unique_lock<std::mutex> lk2(app.m2.mForChecking, std::defer_lock);
+
+      ctk::TestFacility test{app};
+
+      test.runApplication();
+
+      // test single value
+      BOOST_REQUIRE(lk1.try_lock());
+      app.m1.out1 = 123;
       app.m1.out1.write();
       app.m1.out2.write();
+      lk1.unlock();
+
+      test.stepApplication();
+
+      BOOST_REQUIRE(lk2.try_lock());
+      BOOST_CHECK_EQUAL(app.m2.poll1, 123);
+      BOOST_CHECK_EQUAL(app.m2.poll2, 123);
+      lk2.unlock();
+
+      // test queue overrun
+      BOOST_REQUIRE(lk1.try_lock());
+      for(int i = 0; i < 10; ++i) {
+        app.m1.out1 = 191 + i;
+        app.m1.out1.write();
+        app.m1.out2.write();
+      }
+      lk1.unlock();
+
+      test.stepApplication();
+
+      BOOST_REQUIRE(lk2.try_lock());
+      BOOST_CHECK_EQUAL(app.m2.poll1, 200);
+      BOOST_CHECK_EQUAL(app.m2.poll2, 200);
+      lk2.unlock();
     }
-    lk1.unlock();
 
-    test.stepApplication();
+    // Case 2: ConsumingFanOut
+    // -----------------------
+    {
+      TestPollingThroughFanOutsApplication app;
+      app.m1.poll1 = {&app.m1, "/REG1", "", ""};
+      app.m2.push1 = {&app.m2, "/REG1", "", ""};
+      // app.dev("REG1") >> app.m1.poll1 >> app.m2.push1;
 
-    BOOST_REQUIRE(lk2.try_lock());
-    BOOST_CHECK_EQUAL(app.m2.poll1, 200);
-    BOOST_CHECK_EQUAL(app.m2.poll2, 200);
-    lk2.unlock();
+      std::unique_lock<std::mutex> lk1(app.m1.mForChecking, std::defer_lock);
+      std::unique_lock<std::mutex> lk2(app.m2.mForChecking, std::defer_lock);
+
+      ctk::Device dev(dummySdm.data());
+      auto reg1 = dev.getScalarRegisterAccessor<int>("REG1.DUMMY_WRITEABLE");
+
+      ctk::TestFacility test{app};
+      test.runApplication();
+
+      reg1 = 42;
+      reg1.write();
+
+      BOOST_REQUIRE(lk1.try_lock());
+      app.m1.poll1.read();
+      BOOST_CHECK_EQUAL(app.m1.poll1, 42);
+      lk1.unlock();
+      BOOST_REQUIRE(lk2.try_lock());
+      BOOST_CHECK_NE(app.m2.push1, 42);
+      lk2.unlock();
+
+      test.stepApplication();
+
+      BOOST_REQUIRE(lk2.try_lock());
+      BOOST_CHECK_EQUAL(app.m2.push1, 42);
+      lk2.unlock();
+    }
+
+    // Case 3: ThreadedFanOut
+    // ----------------------
+    {
+      std::cout << "=== Case 3" << std::endl;
+      TestPollingThroughFanOutsApplication app;
+      std::cout << " HIER 1" << std::endl;
+      app.m1.poll2 = {&app.m1, "poll1", "", ""};
+      std::cout << " HIER 2" << std::endl;
+      app.m1.push1 = {&app.m1, "/m2/out2", "", ""};
+      std::cout << " HIER 3" << std::endl;
+
+      std::unique_lock<std::mutex> lk1(app.m1.mForChecking, std::defer_lock);
+      std::unique_lock<std::mutex> lk2(app.m2.mForChecking, std::defer_lock);
+
+      ctk::TestFacility test{app};
+
+      auto var = test.getScalar<int>("/m1/poll1");
+      app.getModel().writeGraphViz("testPollingThroughFanOuts.dot");
+      test.runApplication();
+
+      // test with single value
+      var = 666;
+      var.write();
+      BOOST_REQUIRE(lk2.try_lock());
+      app.m2.out2.write();
+      lk2.unlock();
+
+      test.stepApplication();
+
+      BOOST_REQUIRE(lk1.try_lock());
+      app.m1.poll1.read();
+      BOOST_CHECK_EQUAL(app.m1.poll1, 666);
+      app.m1.poll2.read();
+      BOOST_CHECK_EQUAL(app.m1.poll2, 666);
+      lk1.unlock();
+
+      // test with queue overrun
+      for(int i = 0; i < 10; ++i) {
+        var = 691 + i;
+        var.write();
+      }
+      BOOST_REQUIRE(lk2.try_lock());
+      app.m2.out2.write();
+      lk2.unlock();
+
+      test.stepApplication();
+
+      BOOST_REQUIRE(lk1.try_lock());
+      app.m1.poll1.read();
+      BOOST_CHECK_EQUAL(app.m1.poll1, 700);
+      app.m1.poll2.read();
+      BOOST_CHECK_EQUAL(app.m1.poll2, 700);
+      lk1.unlock();
+    }
   }
 
-  // Case 2: ConsumingFanOut
-  // -----------------------
-  {
-    TestPollingThroughFanOutsApplication app;
-    app.m1.poll1 = {&app.m1, "/REG1", "", ""};
-    app.m2.push1 = {&app.m2, "/REG1", "", ""};
-    // app.dev("REG1") >> app.m1.poll1 >> app.m2.push1;
+  /*********************************************************************************************************************/
+  /* test device variables */
 
-    std::unique_lock<std::mutex> lk1(app.m1.mForChecking, std::defer_lock);
-    std::unique_lock<std::mutex> lk2(app.m2.mForChecking, std::defer_lock);
+  struct TestDeviceApplication : public ctk::Application {
+    TestDeviceApplication() : Application("testApplication") {}
+    ~TestDeviceApplication() override { shutdown(); }
+
+    ctk::DeviceModule dev{this, dummySdm.data(), "/fakeTriggerToSatisfyUnusedRegister"};
+    PollingReadModule pollingReadModule{this, "pollingReadModule", "Module for testing poll-type transfers"};
+  };
+
+  BOOST_AUTO_TEST_CASE(testDevice) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testDevice" << std::endl;
+
+    TestDeviceApplication app;
+    app.pollingReadModule.poll = {&app.pollingReadModule, "/REG1", "cm", "A poll-type input"};
+
+    ctk::TestFacility test(app);
+    auto push = test.getScalar<int32_t>("/pollingReadModule/push");
+    auto push2 = test.getScalar<int32_t>("/pollingReadModule/push2");
+    auto valuePoll = test.getScalar<int32_t>("/pollingReadModule/valuePoll");
 
     ctk::Device dev(dummySdm.data());
-    auto reg1 = dev.getScalarRegisterAccessor<int>("REG1.DUMMY_WRITEABLE");
+    auto r1 = dev.getScalarRegisterAccessor<int32_t>("/REG1.DUMMY_WRITEABLE");
 
-    ctk::TestFacility test{app};
     test.runApplication();
 
-    reg1 = 42;
-    reg1.write();
-
-    BOOST_REQUIRE(lk1.try_lock());
-    app.m1.poll1.read();
-    BOOST_CHECK_EQUAL(app.m1.poll1, 42);
-    lk1.unlock();
-    BOOST_REQUIRE(lk2.try_lock());
-    BOOST_CHECK_NE(app.m2.push1, 42);
-    lk2.unlock();
-
+    // this is state 1 in PollingReadModule -> read()
+    r1 = 42;
+    r1.write();
+    push.write();
     test.stepApplication();
+    valuePoll.read();
+    BOOST_CHECK_EQUAL(valuePoll, 42);
 
-    BOOST_REQUIRE(lk2.try_lock());
-    BOOST_CHECK_EQUAL(app.m2.push1, 42);
-    lk2.unlock();
+    // this is state 2 in PollingReadModule -> readNonBlocking()
+    r1 = 43;
+    r1.write();
+    push2.write();
+    test.stepApplication();
+    valuePoll.read();
+    BOOST_CHECK_EQUAL(valuePoll, 43);
+
+    // this is state 2 in PollingReadModule -> readLatest()
+    r1 = 44;
+    r1.write();
+    push2.write();
+    test.stepApplication();
+    valuePoll.read();
+    BOOST_CHECK_EQUAL(valuePoll, 44);
   }
 
-  // Case 3: ThreadedFanOut
-  // ----------------------
-  {
-    std::cout << "=== Case 3" << std::endl;
-    TestPollingThroughFanOutsApplication app;
-    std::cout << " HIER 1" << std::endl;
-    app.m1.poll2 = {&app.m1, "poll1", "", ""};
-    std::cout << " HIER 2" << std::endl;
-    app.m1.push1 = {&app.m1, "/m2/out2", "", ""};
-    std::cout << " HIER 3" << std::endl;
+  /*********************************************************************************************************************/
+  /* test initial values (from control system variables) */
+
+  struct TestInitialApplication : public ctk::Application {
+    TestInitialApplication() : Application("AnotherTestApplication") {}
+    ~TestInitialApplication() override { shutdown(); }
+
+    PollingThroughFanoutsModule m1{this, "m1", ""};
+    PollingThroughFanoutsModule m2{this, "m2", ""};
+  };
+
+  BOOST_AUTO_TEST_CASE(testInitialValues) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testInitialValues" << std::endl;
+
+    TestInitialApplication app;
+    // app.findTag(".*").connectTo(app.cs);
 
     std::unique_lock<std::mutex> lk1(app.m1.mForChecking, std::defer_lock);
     std::unique_lock<std::mutex> lk2(app.m2.mForChecking, std::defer_lock);
 
     ctk::TestFacility test{app};
 
-    auto var = test.getScalar<int>("/m1/poll1");
-    app.getModel().writeGraphViz("testPollingThroughFanOuts.dot");
+    test.setScalarDefault<int>("/m1/push1", 42);
+    test.setScalarDefault<int>("/m1/poll1", 43);
+    test.setScalarDefault<int>("/m2/poll2", 44);
+
     test.runApplication();
 
-    // test with single value
-    var = 666;
-    var.write();
-    BOOST_REQUIRE(lk2.try_lock());
-    app.m2.out2.write();
-    lk2.unlock();
-
-    test.stepApplication();
-
     BOOST_REQUIRE(lk1.try_lock());
-    app.m1.poll1.read();
-    BOOST_CHECK_EQUAL(app.m1.poll1, 666);
-    app.m1.poll2.read();
-    BOOST_CHECK_EQUAL(app.m1.poll2, 666);
+    BOOST_CHECK(!app.m1.hasRead);
+    BOOST_CHECK_EQUAL(app.m1.push1, 42);
+    BOOST_CHECK_EQUAL(app.m1.poll1, 43);
+    BOOST_CHECK_EQUAL(app.m1.poll2, 0);
     lk1.unlock();
-
-    // test with queue overrun
-    for(int i = 0; i < 10; ++i) {
-      var = 691 + i;
-      var.write();
-    }
     BOOST_REQUIRE(lk2.try_lock());
-    app.m2.out2.write();
+    BOOST_CHECK(!app.m2.hasRead);
+    BOOST_CHECK_EQUAL(app.m2.push1, 0);
+    BOOST_CHECK_EQUAL(app.m2.poll1, 0);
+    BOOST_CHECK_EQUAL(app.m2.poll2, 44);
     lk2.unlock();
-
-    test.stepApplication();
-
-    BOOST_REQUIRE(lk1.try_lock());
-    app.m1.poll1.read();
-    BOOST_CHECK_EQUAL(app.m1.poll1, 700);
-    app.m1.poll2.read();
-    BOOST_CHECK_EQUAL(app.m1.poll2, 700);
-    lk1.unlock();
   }
-}
 
-/*********************************************************************************************************************/
-/* test device variables */
+  /*********************************************************************************************************************/
 
-struct TestDeviceApplication : public ctk::Application {
-  TestDeviceApplication() : Application("testApplication") {}
-  ~TestDeviceApplication() override { shutdown(); }
-
-  ctk::DeviceModule dev{this, dummySdm.data(), "/fakeTriggerToSatisfyUnusedRegister"};
-  PollingReadModule pollingReadModule{this, "pollingReadModule", "Module for testing poll-type transfers"};
-};
-
-BOOST_AUTO_TEST_CASE(testDevice) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testDevice" << std::endl;
-
-  TestDeviceApplication app;
-  app.pollingReadModule.poll = {&app.pollingReadModule, "/REG1", "cm", "A poll-type input"};
-
-  ctk::TestFacility test(app);
-  auto push = test.getScalar<int32_t>("/pollingReadModule/push");
-  auto push2 = test.getScalar<int32_t>("/pollingReadModule/push2");
-  auto valuePoll = test.getScalar<int32_t>("/pollingReadModule/valuePoll");
-
-  ctk::Device dev(dummySdm.data());
-  auto r1 = dev.getScalarRegisterAccessor<int32_t>("/REG1.DUMMY_WRITEABLE");
-
-  test.runApplication();
-
-  // this is state 1 in PollingReadModule -> read()
-  r1 = 42;
-  r1.write();
-  push.write();
-  test.stepApplication();
-  valuePoll.read();
-  BOOST_CHECK_EQUAL(valuePoll, 42);
-
-  // this is state 2 in PollingReadModule -> readNonBlocking()
-  r1 = 43;
-  r1.write();
-  push2.write();
-  test.stepApplication();
-  valuePoll.read();
-  BOOST_CHECK_EQUAL(valuePoll, 43);
-
-  // this is state 2 in PollingReadModule -> readLatest()
-  r1 = 44;
-  r1.write();
-  push2.write();
-  test.stepApplication();
-  valuePoll.read();
-  BOOST_CHECK_EQUAL(valuePoll, 44);
-}
-
-/*********************************************************************************************************************/
-/* test initial values (from control system variables) */
-
-struct TestInitialApplication : public ctk::Application {
-  TestInitialApplication() : Application("AnotherTestApplication") {}
-  ~TestInitialApplication() override { shutdown(); }
-
-  PollingThroughFanoutsModule m1{this, "m1", ""};
-  PollingThroughFanoutsModule m2{this, "m2", ""};
-};
-
-BOOST_AUTO_TEST_CASE(testInitialValues) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testInitialValues" << std::endl;
-
-  TestInitialApplication app;
-  // app.findTag(".*").connectTo(app.cs);
-
-  std::unique_lock<std::mutex> lk1(app.m1.mForChecking, std::defer_lock);
-  std::unique_lock<std::mutex> lk2(app.m2.mForChecking, std::defer_lock);
-
-  ctk::TestFacility test{app};
-
-  test.setScalarDefault<int>("/m1/push1", 42);
-  test.setScalarDefault<int>("/m1/poll1", 43);
-  test.setScalarDefault<int>("/m2/poll2", 44);
-
-  test.runApplication();
-
-  BOOST_REQUIRE(lk1.try_lock());
-  BOOST_CHECK(!app.m1.hasRead);
-  BOOST_CHECK_EQUAL(app.m1.push1, 42);
-  BOOST_CHECK_EQUAL(app.m1.poll1, 43);
-  BOOST_CHECK_EQUAL(app.m1.poll2, 0);
-  lk1.unlock();
-  BOOST_REQUIRE(lk2.try_lock());
-  BOOST_CHECK(!app.m2.hasRead);
-  BOOST_CHECK_EQUAL(app.m2.push1, 0);
-  BOOST_CHECK_EQUAL(app.m2.poll1, 0);
-  BOOST_CHECK_EQUAL(app.m2.poll2, 44);
-  lk2.unlock();
-}
-
-/*********************************************************************************************************************/
+} // namespace Tests::testTestFacilities

--- a/tests/executables_src/testTestFacility2.cc
+++ b/tests/executables_src/testTestFacility2.cc
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
 // SPDX-License-Identifier: LGPL-3.0-or-later
-#define BOOST_TEST_MODULE testTestFaciliy
+#define BOOST_TEST_MODULE testTestFaciliy2
 #include <boost/test/included/unit_test.hpp>
 using namespace boost::unit_test_framework;
 
@@ -9,56 +9,60 @@ using namespace boost::unit_test_framework;
 #include "ScalarAccessor.h"
 #include "TestFacility.h"
 
-namespace ctk = ChimeraTK;
+namespace Tests::testTestFaciliy2 {
 
-struct MyModule : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
+  namespace ctk = ChimeraTK;
 
-  ctk::ScalarPushInput<double> input{this, "/input", "", ""};
-  ctk::ScalarOutput<double> output{this, "/output", "", ""};
+  struct MyModule : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  void mainLoop() override {
-    std::cout << "starting main loop" << std::endl;
-    output = 2 * double(input);
-    output.write();
+    ctk::ScalarPushInput<double> input{this, "/input", "", ""};
+    ctk::ScalarOutput<double> output{this, "/output", "", ""};
 
-    while(true) {
-      input.read();
-      output = 3 * double(input);
+    void mainLoop() override {
+      std::cout << "starting main loop" << std::endl;
+      output = 2 * double(input);
       output.write();
+
+      while(true) {
+        input.read();
+        output = 3 * double(input);
+        output.write();
+      }
     }
+  };
+
+  /**********************************************************************************************************************/
+
+  struct TestApp : public ctk::Application {
+    TestApp() : Application("TestApp") {}
+    ~TestApp() override { shutdown(); }
+
+    MyModule myModule{this, "MyModule", ""};
+  };
+
+  /**********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testSumLimiter) {
+    TestApp theTestApp;
+    ChimeraTK::TestFacility testFacility(theTestApp);
+    testFacility.setScalarDefault<double>("/input", 25.);
+
+    testFacility.runApplication();
+
+    // at this point all main loops should have started, default values are processed and inputs waiting in read()
+
+    BOOST_CHECK_CLOSE(testFacility.readScalar<double>("/output"), 50., 0.001);
+
+    testFacility.writeScalar<double>("/input", 30.);
+    std::cout << "about to step" << std::endl;
+    // however, the main loop only starts in the first step.
+    testFacility.stepApplication();
+    std::cout << "step finished" << std::endl;
+
+    BOOST_CHECK_CLOSE(testFacility.readScalar<double>("/output"), 90., 0.001);
   }
-};
 
-/**********************************************************************************************************************/
+  /**********************************************************************************************************************/
 
-struct TestApp : public ctk::Application {
-  TestApp() : Application("TestApp") {}
-  ~TestApp() override { shutdown(); }
-
-  MyModule myModule{this, "MyModule", ""};
-};
-
-/**********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testSumLimiter) {
-  TestApp theTestApp;
-  ChimeraTK::TestFacility testFacility(theTestApp);
-  testFacility.setScalarDefault<double>("/input", 25.);
-
-  testFacility.runApplication();
-
-  // at this point all main loops should have started, default values are processed and inputs waiting in read()
-
-  BOOST_CHECK_CLOSE(testFacility.readScalar<double>("/output"), 50., 0.001);
-
-  testFacility.writeScalar<double>("/input", 30.);
-  std::cout << "about to step" << std::endl;
-  // however, the main loop only starts in the first step.
-  testFacility.stepApplication();
-  std::cout << "step finished" << std::endl;
-
-  BOOST_CHECK_CLOSE(testFacility.readScalar<double>("/output"), 90., 0.001);
-}
-
-/**********************************************************************************************************************/
+} // namespace Tests::testTestFaciliy2

--- a/tests/executables_src/testTrigger.cc
+++ b/tests/executables_src/testTrigger.cc
@@ -25,46 +25,226 @@
 #include <boost/mpl/list.hpp>
 #include <boost/test/included/unit_test.hpp>
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testTrigger {
 
-/**********************************************************************************************************************/
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
-// Application that has one polling consumer for a polling provider
-// It should work without any trigger
-struct TestApp1 : ctk::Application {
-  TestApp1() : ctk::Application("testApp1") {}
-  ~TestApp1() override { shutdown(); }
+  /**********************************************************************************************************************/
 
-  struct : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
+  // Application that has one polling consumer for a polling provider
+  // It should work without any trigger
+  struct TestApp1 : ctk::Application {
+    TestApp1() : ctk::Application("testApp1") {}
+    ~TestApp1() override { shutdown(); }
 
-    ctk::ScalarPollInput<int> readBack{this, "/MyModule/readBack", "unit", "description"};
+    struct : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
 
-    // This is just here so that we do not need a trigger - otherwise it would be connected to a pushing CS consumer
-    // automatically which would require a trigger
-    ctk::ScalarPollInput<int> tests{this, "/Deeper/hierarchies/need/tests", "unit", "description"};
+      ctk::ScalarPollInput<int> readBack{this, "/MyModule/readBack", "unit", "description"};
 
-    ctk::VoidInput finger{this, "/finger", ""};
+      // This is just here so that we do not need a trigger - otherwise it would be connected to a pushing CS consumer
+      // automatically which would require a trigger
+      ctk::ScalarPollInput<int> tests{this, "/Deeper/hierarchies/need/tests", "unit", "description"};
 
-    void mainLoop() override {
-      while(true) {
-        readAll();
+      ctk::VoidInput finger{this, "/finger", ""};
+
+      void mainLoop() override {
+        while(true) {
+          readAll();
+        }
       }
+    } someModule{this, ".", ""};
+
+    ctk::SetDMapFilePath path{"test.dmap"};
+    ctk::DeviceModule dev;
+  };
+
+  BOOST_AUTO_TEST_CASE(testDev2AppWithPollTrigger) {
+    // TestApp1 should work without specifying any trigger
+    {
+      TestApp1 app;
+      app.dev = {&app, "Dummy0"};
+      ChimeraTK::TestFacility tf{app};
+      auto finger = tf.getVoid("/finger");
+      auto rb = tf.getScalar<int>("/MyModule/readBack");
+
+      tf.runApplication();
+
+      ctk::Device dev("Dummy0");
+      dev.open();
+      dev.write("MyModule/actuator", 1);
+
+      BOOST_TEST(rb.readNonBlocking() == false);
+      finger.write();
+      tf.stepApplication();
+      BOOST_TEST(rb.readNonBlocking() == true);
+      BOOST_TEST(rb == 1);
+
+      dev.write("MyModule/actuator", 10);
+      finger.write();
+      tf.stepApplication();
+      BOOST_TEST(rb.readNonBlocking() == true);
+      BOOST_TEST(rb == 10);
     }
-  } someModule{this, ".", ""};
 
-  ctk::SetDMapFilePath path{"test.dmap"};
-  ctk::DeviceModule dev;
-};
+    // TestApp1 should also work with any trigger, but the trigger should be ignored
+    {
+      TestApp1 app;
+      app.dev = {&app, "Dummy0", "/cs/tick"};
+      ChimeraTK::TestFacility tf{app};
+      auto tick = tf.getVoid("/cs/tick");
+      auto finger = tf.getVoid("/finger");
+      auto rb = tf.getScalar<int>("/MyModule/readBack");
 
-BOOST_AUTO_TEST_CASE(testDev2AppWithPollTrigger) {
-  // TestApp1 should work without specifying any trigger
-  {
-    TestApp1 app;
-    app.dev = {&app, "Dummy0"};
-    ChimeraTK::TestFacility tf{app};
-    auto finger = tf.getVoid("/finger");
+      tf.runApplication();
+
+      ctk::Device dev("Dummy0");
+      dev.open();
+      dev.write("MyModule/actuator", 2);
+
+      BOOST_TEST(rb.readNonBlocking() == false);
+      finger.write();
+      tf.stepApplication();
+      BOOST_TEST(rb.readNonBlocking() == true);
+      BOOST_TEST(rb == 2);
+
+      // Trigger device trigger - values should not change
+      tick.write();
+      tf.stepApplication();
+      BOOST_TEST(rb.readNonBlocking() == false);
+      BOOST_TEST(rb == 2);
+
+      dev.write("MyModule/actuator", 20);
+
+      // Trigger read-out of poll variables in main loop
+      finger.write();
+      tf.stepApplication();
+      BOOST_TEST(rb.readNonBlocking() == true);
+      BOOST_TEST(rb == 20);
+
+      // Trigger device trigger - values should not change
+      tick.write();
+      tf.stepApplication();
+      BOOST_TEST(rb.readNonBlocking() == false);
+      BOOST_TEST(rb == 20);
+    }
+  }
+
+  /**********************************************************************************************************************/
+
+  struct TestApp2 : ctk::Application {
+    TestApp2() : ctk::Application("testApp2") {}
+    ~TestApp2() override { shutdown(); }
+
+    struct : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
+
+      ctk::ScalarPushInput<int> readBack{this, "/MyModule/readBack", "unit", "description"};
+
+      void mainLoop() override {
+        while(true) {
+          readAll();
+        }
+      }
+    } someModule{this, ".", ""};
+
+    ctk::SetDMapFilePath path{"test.dmap"};
+    ctk::DeviceModule dev;
+  };
+
+  // Device that requires trigger, the trigger is 1:1 put into the CS
+  BOOST_AUTO_TEST_CASE(testDev2AppWithCsDirectTrigger) {
+    // TestApp2 should not work without specifying any trigger
+    {
+      TestApp2 app;
+      app.dev = {&app, "Dummy0"};
+      BOOST_CHECK_THROW(
+          {
+            app.initialise();
+            app.run();
+          },
+          ChimeraTK::logic_error);
+    }
+
+    // TestApp2 also works with a trigger. If the trigger is triggered, no data transfer should happen
+    {
+      TestApp2 app;
+      app.dev = {&app, "Dummy0", "/cs/trigger"};
+
+      ChimeraTK::TestFacility tf{app, true};
+      auto tick = tf.getVoid("/cs/trigger");
+      auto rb = tf.getScalar<int>("/MyModule/readBack");
+
+      tf.runApplication();
+
+      ctk::Device dev("Dummy0");
+      dev.open();
+      dev.write("MyModule/actuator", 1);
+
+      tick.write();
+      tf.stepApplication();
+
+      BOOST_TEST(rb.readNonBlocking() == true);
+      BOOST_TEST(rb == 1);
+
+      dev.write("MyModule/actuator", 12);
+      BOOST_TEST(rb.readNonBlocking() == false);
+      BOOST_TEST(rb == 1);
+
+      tick.write();
+      tf.stepApplication();
+      BOOST_TEST(rb.readNonBlocking() == true);
+      BOOST_TEST(rb == 12);
+    }
+  }
+
+  /**********************************************************************************************************************/
+
+  struct TestApp3 : ctk::Application {
+    TestApp3() : ctk::Application("testApp3") {}
+    ~TestApp3() override { shutdown(); }
+
+    struct : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
+
+      ctk::VoidInput tick{this, "/cs/trigger", "description"};
+      ctk::ScalarOutput<int> tock{this, "/tock", "", ""};
+
+      void mainLoop() override {
+        tock = 0;
+        while(true) {
+          tock.write();
+          tock++;
+          readAll();
+        }
+      }
+    } tock{this, ".", ""};
+
+    struct : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
+
+      ctk::ScalarPushInput<int> readBack{this, "/MyModule/readBack", "unit", "description"};
+      ctk::ScalarPollInput<int> tests{this, "/Deeper/hierarchies/need/tests", "unit", "description"};
+
+      void mainLoop() override {
+        while(true) {
+          readAll();
+        }
+      }
+    } someModule{this, ".", ""};
+
+    ctk::SetDMapFilePath path{"test.dmap"};
+    ctk::DeviceModule dev{this, "Dummy0", "/cs/trigger"};
+  };
+
+  // Device that requires trigger, the trigger is distributed in the Application as well
+  BOOST_AUTO_TEST_CASE(testDev2AppWithCsDistributedTrigger) {
+    TestApp3 app;
+
+    ChimeraTK::TestFacility tf{app, true};
+    auto tick = tf.getVoid("/cs/trigger");
+    auto tock = tf.getScalar<int>("/tock");
     auto rb = tf.getScalar<int>("/MyModule/readBack");
 
     tf.runApplication();
@@ -73,101 +253,136 @@ BOOST_AUTO_TEST_CASE(testDev2AppWithPollTrigger) {
     dev.open();
     dev.write("MyModule/actuator", 1);
 
-    BOOST_TEST(rb.readNonBlocking() == false);
-    finger.write();
+    tick.write();
     tf.stepApplication();
+
+    BOOST_TEST(tock.readNonBlocking() == true);
+    BOOST_TEST(tock == 1);
     BOOST_TEST(rb.readNonBlocking() == true);
     BOOST_TEST(rb == 1);
 
-    dev.write("MyModule/actuator", 10);
-    finger.write();
+    dev.write("MyModule/actuator", 12);
+    BOOST_TEST(tock.readNonBlocking() == false);
+    BOOST_TEST(tock == 1);
+    BOOST_TEST(rb.readNonBlocking() == false);
+    BOOST_TEST(rb == 1);
+
+    tick.write();
     tf.stepApplication();
+    BOOST_TEST(tock.readNonBlocking() == true);
+    BOOST_TEST(tock == 2);
     BOOST_TEST(rb.readNonBlocking() == true);
-    BOOST_TEST(rb == 10);
+    BOOST_TEST(rb == 12);
   }
 
-  // TestApp1 should also work with any trigger, but the trigger should be ignored
-  {
-    TestApp1 app;
-    app.dev = {&app, "Dummy0", "/cs/tick"};
-    ChimeraTK::TestFacility tf{app};
-    auto tick = tf.getVoid("/cs/tick");
-    auto finger = tf.getVoid("/finger");
-    auto rb = tf.getScalar<int>("/MyModule/readBack");
+  /**********************************************************************************************************************/
 
-    tf.runApplication();
+  struct TestApp4 : ctk::Application {
+    TestApp4() : ctk::Application("testApp4") {}
+    ~TestApp4() override { shutdown(); }
+
+    struct : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
+
+      ctk::ScalarPushInput<float> singed32{this, "/Device/signed32", "unit", "description"};
+
+      void mainLoop() override {
+        while(true) {
+          readAll();
+        }
+      }
+    } someOtherModule{this, ".", ""};
+
+    struct : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
+
+      ctk::ScalarPushInput<int> readBack{this, "/MyModule/readBack", "unit", "description"};
+      ctk::ScalarPollInput<int> tests{this, "/Deeper/hierarchies/need/tests", "unit", "description"};
+
+      void mainLoop() override {
+        while(true) {
+          readAll();
+        }
+      }
+    } someModule{this, ".", ""};
+
+    ctk::SetDMapFilePath path{"test.dmap"};
+    ctk::DeviceModule dev{this, "Dummy0", "/cs/trigger"};
+    ctk::DeviceModule dev2{this, "Dummy1Mapped", "/cs/trigger"};
+  };
+
+  // Two devices using the same trigger
+  BOOST_AUTO_TEST_CASE(testDev2App1Trigger2Devices) {
+    TestApp4 app;
+
+    ChimeraTK::TestFacility tf{app, true};
+    auto tick = tf.getVoid("/cs/trigger");
+    auto f = tf.getScalar<float>("/Device/signed32");
+    auto rb = tf.getScalar<int>("/MyModule/readBack");
 
     ctk::Device dev("Dummy0");
     dev.open();
+
+    ctk::Device dev2("Dummy1");
+    dev2.open();
+    dev2.write("FixedPoint/value", 12.4);
+
+    tf.runApplication();
+
+    dev.write("MyModule/actuator", 1);
+
+    BOOST_TEST(f.readNonBlocking() == false);
+    BOOST_TEST(rb.readNonBlocking() == false);
+
+    tick.write();
+    tf.stepApplication();
+    BOOST_TEST(f.readNonBlocking() == true);
+    BOOST_TEST(rb.readNonBlocking() == true);
+
+    BOOST_TEST((f - 12.4) < 0.01);
+    BOOST_TEST(rb == 1);
+
     dev.write("MyModule/actuator", 2);
+    dev2.write("FixedPoint/value", 24.8);
 
+    BOOST_TEST(f.readNonBlocking() == false);
     BOOST_TEST(rb.readNonBlocking() == false);
-    finger.write();
-    tf.stepApplication();
-    BOOST_TEST(rb.readNonBlocking() == true);
-    BOOST_TEST(rb == 2);
 
-    // Trigger device trigger - values should not change
     tick.write();
     tf.stepApplication();
-    BOOST_TEST(rb.readNonBlocking() == false);
-    BOOST_TEST(rb == 2);
-
-    dev.write("MyModule/actuator", 20);
-
-    // Trigger read-out of poll variables in main loop
-    finger.write();
-    tf.stepApplication();
+    BOOST_TEST(f.readNonBlocking() == true);
     BOOST_TEST(rb.readNonBlocking() == true);
-    BOOST_TEST(rb == 20);
 
-    // Trigger device trigger - values should not change
-    tick.write();
-    tf.stepApplication();
-    BOOST_TEST(rb.readNonBlocking() == false);
-    BOOST_TEST(rb == 20);
+    BOOST_TEST((f - 24.8) < 0.001);
+    BOOST_TEST(rb == 2);
   }
-}
 
-/**********************************************************************************************************************/
+  /**********************************************************************************************************************/
 
-struct TestApp2 : ctk::Application {
-  TestApp2() : ctk::Application("testApp2") {}
-  ~TestApp2() override { shutdown(); }
+  struct TestApp5 : ctk::Application {
+    TestApp5() : ctk::Application("testApp5") {}
+    ~TestApp5() override { shutdown(); }
 
-  struct : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
+    struct : ctk::ApplicationModule {
+      using ctk::ApplicationModule::ApplicationModule;
 
-    ctk::ScalarPushInput<int> readBack{this, "/MyModule/readBack", "unit", "description"};
+      ctk::VoidInput finger{this, "/finger", ""};
+      ctk::VoidOutput trigger{this, "/trigger", ""};
 
-    void mainLoop() override {
-      while(true) {
-        readAll();
+      void mainLoop() override {
+        while(true) {
+          readAll();
+          trigger.write();
+        }
       }
-    }
-  } someModule{this, ".", ""};
+    } someModule{this, ".", ""};
 
-  ctk::SetDMapFilePath path{"test.dmap"};
-  ctk::DeviceModule dev;
-};
+    ctk::SetDMapFilePath path{"test.dmap"};
+    ctk::DeviceModule dev;
+  };
 
-// Device that requires trigger, the trigger is 1:1 put into the CS
-BOOST_AUTO_TEST_CASE(testDev2AppWithCsDirectTrigger) {
-  // TestApp2 should not work without specifying any trigger
-  {
-    TestApp2 app;
-    app.dev = {&app, "Dummy0"};
-    BOOST_CHECK_THROW(
-        {
-          app.initialise();
-          app.run();
-        },
-        ChimeraTK::logic_error);
-  }
-
-  // TestApp2 also works with a trigger. If the trigger is triggered, no data transfer should happen
-  {
-    TestApp2 app;
+  BOOST_AUTO_TEST_CASE(testDev2CSCsTrigger) {
+    TestApp5 app;
     app.dev = {&app, "Dummy0", "/cs/trigger"};
 
     ChimeraTK::TestFacility tf{app, true};
@@ -195,407 +410,196 @@ BOOST_AUTO_TEST_CASE(testDev2AppWithCsDirectTrigger) {
     BOOST_TEST(rb.readNonBlocking() == true);
     BOOST_TEST(rb == 12);
   }
-}
 
-/**********************************************************************************************************************/
+  BOOST_AUTO_TEST_CASE(testDev2CSAppTrigger) {
+    TestApp5 app;
+    app.dev = {&app, "Dummy0", "/trigger"};
 
-struct TestApp3 : ctk::Application {
-  TestApp3() : ctk::Application("testApp3") {}
-  ~TestApp3() override { shutdown(); }
+    ChimeraTK::TestFacility tf{app, true};
+    auto tick = tf.getVoid("/finger");
+    auto rb = tf.getScalar<int>("/MyModule/readBack");
 
-  struct : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
+    tf.runApplication();
 
-    ctk::VoidInput tick{this, "/cs/trigger", "description"};
-    ctk::ScalarOutput<int> tock{this, "/tock", "", ""};
+    ctk::Device dev("Dummy0");
+    dev.open();
+    dev.write("MyModule/actuator", 1);
 
-    void mainLoop() override {
-      tock = 0;
-      while(true) {
-        tock.write();
-        tock++;
-        readAll();
-      }
-    }
-  } tock{this, ".", ""};
+    tick.write();
+    tf.stepApplication();
 
-  struct : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
+    BOOST_TEST(rb.readNonBlocking() == true);
+    BOOST_TEST(rb == 1);
 
-    ctk::ScalarPushInput<int> readBack{this, "/MyModule/readBack", "unit", "description"};
-    ctk::ScalarPollInput<int> tests{this, "/Deeper/hierarchies/need/tests", "unit", "description"};
+    dev.write("MyModule/actuator", 12);
+    BOOST_TEST(rb.readNonBlocking() == false);
+    BOOST_TEST(rb == 1);
 
-    void mainLoop() override {
-      while(true) {
-        readAll();
-      }
-    }
-  } someModule{this, ".", ""};
-
-  ctk::SetDMapFilePath path{"test.dmap"};
-  ctk::DeviceModule dev{this, "Dummy0", "/cs/trigger"};
-};
-
-// Device that requires trigger, the trigger is distributed in the Application as well
-BOOST_AUTO_TEST_CASE(testDev2AppWithCsDistributedTrigger) {
-  TestApp3 app;
-
-  ChimeraTK::TestFacility tf{app, true};
-  auto tick = tf.getVoid("/cs/trigger");
-  auto tock = tf.getScalar<int>("/tock");
-  auto rb = tf.getScalar<int>("/MyModule/readBack");
-
-  tf.runApplication();
-
-  ctk::Device dev("Dummy0");
-  dev.open();
-  dev.write("MyModule/actuator", 1);
-
-  tick.write();
-  tf.stepApplication();
-
-  BOOST_TEST(tock.readNonBlocking() == true);
-  BOOST_TEST(tock == 1);
-  BOOST_TEST(rb.readNonBlocking() == true);
-  BOOST_TEST(rb == 1);
-
-  dev.write("MyModule/actuator", 12);
-  BOOST_TEST(tock.readNonBlocking() == false);
-  BOOST_TEST(tock == 1);
-  BOOST_TEST(rb.readNonBlocking() == false);
-  BOOST_TEST(rb == 1);
-
-  tick.write();
-  tf.stepApplication();
-  BOOST_TEST(tock.readNonBlocking() == true);
-  BOOST_TEST(tock == 2);
-  BOOST_TEST(rb.readNonBlocking() == true);
-  BOOST_TEST(rb == 12);
-}
-
-/**********************************************************************************************************************/
-
-struct TestApp4 : ctk::Application {
-  TestApp4() : ctk::Application("testApp4") {}
-  ~TestApp4() override { shutdown(); }
-
-  struct : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
-
-    ctk::ScalarPushInput<float> singed32{this, "/Device/signed32", "unit", "description"};
-
-    void mainLoop() override {
-      while(true) {
-        readAll();
-      }
-    }
-  } someOtherModule{this, ".", ""};
-
-  struct : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
-
-    ctk::ScalarPushInput<int> readBack{this, "/MyModule/readBack", "unit", "description"};
-    ctk::ScalarPollInput<int> tests{this, "/Deeper/hierarchies/need/tests", "unit", "description"};
-
-    void mainLoop() override {
-      while(true) {
-        readAll();
-      }
-    }
-  } someModule{this, ".", ""};
-
-  ctk::SetDMapFilePath path{"test.dmap"};
-  ctk::DeviceModule dev{this, "Dummy0", "/cs/trigger"};
-  ctk::DeviceModule dev2{this, "Dummy1Mapped", "/cs/trigger"};
-};
-
-// Two devices using the same trigger
-BOOST_AUTO_TEST_CASE(testDev2App1Trigger2Devices) {
-  TestApp4 app;
-
-  ChimeraTK::TestFacility tf{app, true};
-  auto tick = tf.getVoid("/cs/trigger");
-  auto f = tf.getScalar<float>("/Device/signed32");
-  auto rb = tf.getScalar<int>("/MyModule/readBack");
-
-  ctk::Device dev("Dummy0");
-  dev.open();
-
-  ctk::Device dev2("Dummy1");
-  dev2.open();
-  dev2.write("FixedPoint/value", 12.4);
-
-  tf.runApplication();
-
-  dev.write("MyModule/actuator", 1);
-
-  BOOST_TEST(f.readNonBlocking() == false);
-  BOOST_TEST(rb.readNonBlocking() == false);
-
-  tick.write();
-  tf.stepApplication();
-  BOOST_TEST(f.readNonBlocking() == true);
-  BOOST_TEST(rb.readNonBlocking() == true);
-
-  BOOST_TEST((f - 12.4) < 0.01);
-  BOOST_TEST(rb == 1);
-
-  dev.write("MyModule/actuator", 2);
-  dev2.write("FixedPoint/value", 24.8);
-
-  BOOST_TEST(f.readNonBlocking() == false);
-  BOOST_TEST(rb.readNonBlocking() == false);
-
-  tick.write();
-  tf.stepApplication();
-  BOOST_TEST(f.readNonBlocking() == true);
-  BOOST_TEST(rb.readNonBlocking() == true);
-
-  BOOST_TEST((f - 24.8) < 0.001);
-  BOOST_TEST(rb == 2);
-}
-
-/**********************************************************************************************************************/
-
-struct TestApp5 : ctk::Application {
-  TestApp5() : ctk::Application("testApp5") {}
-  ~TestApp5() override { shutdown(); }
-
-  struct : ctk::ApplicationModule {
-    using ctk::ApplicationModule::ApplicationModule;
-
-    ctk::VoidInput finger{this, "/finger", ""};
-    ctk::VoidOutput trigger{this, "/trigger", ""};
-
-    void mainLoop() override {
-      while(true) {
-        readAll();
-        trigger.write();
-      }
-    }
-  } someModule{this, ".", ""};
-
-  ctk::SetDMapFilePath path{"test.dmap"};
-  ctk::DeviceModule dev;
-};
-
-BOOST_AUTO_TEST_CASE(testDev2CSCsTrigger) {
-  TestApp5 app;
-  app.dev = {&app, "Dummy0", "/cs/trigger"};
-
-  ChimeraTK::TestFacility tf{app, true};
-  auto tick = tf.getVoid("/cs/trigger");
-  auto rb = tf.getScalar<int>("/MyModule/readBack");
-
-  tf.runApplication();
-
-  ctk::Device dev("Dummy0");
-  dev.open();
-  dev.write("MyModule/actuator", 1);
-
-  tick.write();
-  tf.stepApplication();
-
-  BOOST_TEST(rb.readNonBlocking() == true);
-  BOOST_TEST(rb == 1);
-
-  dev.write("MyModule/actuator", 12);
-  BOOST_TEST(rb.readNonBlocking() == false);
-  BOOST_TEST(rb == 1);
-
-  tick.write();
-  tf.stepApplication();
-  BOOST_TEST(rb.readNonBlocking() == true);
-  BOOST_TEST(rb == 12);
-}
-
-BOOST_AUTO_TEST_CASE(testDev2CSAppTrigger) {
-  TestApp5 app;
-  app.dev = {&app, "Dummy0", "/trigger"};
-
-  ChimeraTK::TestFacility tf{app, true};
-  auto tick = tf.getVoid("/finger");
-  auto rb = tf.getScalar<int>("/MyModule/readBack");
-
-  tf.runApplication();
-
-  ctk::Device dev("Dummy0");
-  dev.open();
-  dev.write("MyModule/actuator", 1);
-
-  tick.write();
-  tf.stepApplication();
-
-  BOOST_TEST(rb.readNonBlocking() == true);
-  BOOST_TEST(rb == 1);
-
-  dev.write("MyModule/actuator", 12);
-  BOOST_TEST(rb.readNonBlocking() == false);
-  BOOST_TEST(rb == 1);
-
-  tick.write();
-  tf.stepApplication();
-  BOOST_TEST(rb.readNonBlocking() == true);
-  BOOST_TEST(rb == 12);
-}
-
-constexpr std::string_view dummySdm{"(TestTransferGroupDummy?map=test_readonly.map)"};
-
-// list of user types the accessors are tested with
-using test_types = boost::mpl::list<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, float, double>;
-
-/**********************************************************************************************************************/
-
-class TestTransferGroupDummy : public ChimeraTK::DummyBackend {
- public:
-  explicit TestTransferGroupDummy(const std::string& mapFileName) : DummyBackend(mapFileName) {}
-
-  // FIXME: This depends on the API from DeviceAccess. If this linter warning is fixed, code will not compile anymore
-  // NOLINTNEXTLINE(performance-unnecessary-value-param)
-  static boost::shared_ptr<DeviceBackend> createInstance(std::string, std::map<std::string, std::string> parameters) {
-    return boost::shared_ptr<DeviceBackend>(new TestTransferGroupDummy(parameters["map"]));
+    tick.write();
+    tf.stepApplication();
+    BOOST_TEST(rb.readNonBlocking() == true);
+    BOOST_TEST(rb == 12);
   }
 
-  void read(uint64_t bar, uint64_t address, int32_t* data, size_t sizeInBytes) override {
-    lastBar = bar;
-    lastAddress = address;
-    lastSizeInBytes = sizeInBytes;
-    numberOfTransfers++;
-    DummyBackend::read(bar, address, data, sizeInBytes);
+  constexpr std::string_view dummySdm{"(TestTransferGroupDummy?map=test_readonly.map)"};
+
+  // list of user types the accessors are tested with
+  using test_types = boost::mpl::list<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, float, double>;
+
+  /**********************************************************************************************************************/
+
+  class TestTransferGroupDummy : public ChimeraTK::DummyBackend {
+   public:
+    explicit TestTransferGroupDummy(const std::string& mapFileName) : DummyBackend(mapFileName) {}
+
+    // FIXME: This depends on the API from DeviceAccess. If this linter warning is fixed, code will not compile anymore
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    static boost::shared_ptr<DeviceBackend> createInstance(std::string, std::map<std::string, std::string> parameters) {
+      return boost::shared_ptr<DeviceBackend>(new TestTransferGroupDummy(parameters["map"]));
+    }
+
+    void read(uint64_t bar, uint64_t address, int32_t* data, size_t sizeInBytes) override {
+      lastBar = bar;
+      lastAddress = address;
+      lastSizeInBytes = sizeInBytes;
+      numberOfTransfers++;
+      DummyBackend::read(bar, address, data, sizeInBytes);
+    }
+
+    std::atomic<size_t> numberOfTransfers{0};
+    std::atomic<uint64_t> lastBar{};
+    std::atomic<uint64_t> lastAddress{};
+    std::atomic<size_t> lastSizeInBytes{};
+  };
+
+  /*********************************************************************************************************************/
+  /* the ApplicationModule for the test is a template of the user type */
+
+  struct TestModule : public ctk::ApplicationModule {
+    TestModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
+        const std::unordered_set<std::string>& tags = {})
+    : ApplicationModule(owner, name, description, tags), mainLoopStarted(2) {}
+
+    ctk::ScalarPushInput<int> consumingPush{this, "/REG1", "MV/m", "Description"};
+    ctk::ScalarPushInput<int> consumingPush2{this, "/REG2", "MV/m", "Description"};
+    ctk::ScalarPushInput<int> consumingPush3{this, "/REG3", "MV/m", "Description"};
+
+    ctk::ScalarOutput<int> theTrigger{this, "theTrigger", "MV/m", "Description"};
+
+    // We do not use testable mode for this test, so we need this barrier to synchronise to the beginning of the
+    // mainLoop(). This is required since the mainLoopWrapper accesses the module variables before the start of the
+    // mainLoop.
+    // execute this right after the Application::run():
+    //   app.testModule.mainLoopStarted.wait(); // make sure the module's mainLoop() is entered
+    boost::barrier mainLoopStarted;
+
+    void prepare() override {
+      incrementDataFaultCounter(); // force data to be flagged as faulty
+      writeAll();
+      decrementDataFaultCounter(); // data validity depends on inputs
+    }
+
+    void mainLoop() override {
+      std::cout << "Start of main loop" << std::endl;
+      mainLoopStarted.wait();
+      std::cout << "End of main loop" << std::endl;
+    }
+  };
+
+  /*********************************************************************************************************************/
+  /* dummy application */
+
+  struct TestApplication : public ctk::Application {
+    TestApplication() : Application("testSuite") {
+      ChimeraTK::BackendFactory::getInstance().registerBackendType(
+          "TestTransferGroupDummy", &TestTransferGroupDummy::createInstance);
+      dev2 = {this, dummySdm.data(), "/testModule/theTrigger"};
+    }
+    ~TestApplication() override { shutdown(); }
+
+    TestModule testModule{this, "testModule", "The test module"};
+    ctk::DeviceModule dev2;
+  };
+
+  /*********************************************************************************************************************/
+  /* test that multiple variables triggered by the same source are put into the
+   * same TransferGroup */
+
+  BOOST_AUTO_TEST_CASE(testTriggerTransferGroup) {
+    std::cout << "***************************************************************"
+                 "******************************************************"
+              << std::endl;
+    std::cout << "==> testTriggerTransferGroup" << std::endl;
+
+    ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
+
+    TestApplication app;
+    auto pvManagers = ctk::createPVManager();
+    app.setPVManager(pvManagers.second);
+
+    ChimeraTK::Device dev;
+    dev.open(dummySdm.data());
+    auto backend = boost::dynamic_pointer_cast<TestTransferGroupDummy>(
+        ChimeraTK::BackendFactory::getInstance().createBackend(dummySdm.data()));
+    BOOST_CHECK(backend != nullptr);
+
+    app.initialise();
+    app.run();
+    app.testModule.mainLoopStarted.wait(); // make sure the module's mainLoop() is entered
+
+    // initialise values
+    app.testModule.consumingPush = 0;
+    app.testModule.consumingPush2 = 0;
+    app.testModule.consumingPush3 = 0;
+    dev.write("/REG1.DUMMY_WRITEABLE", 11);
+    dev.write("/REG2.DUMMY_WRITEABLE", 22);
+    dev.write("/REG3.DUMMY_WRITEABLE", 33);
+
+    // from the initial value transfer
+    CHECK_TIMEOUT(backend->numberOfTransfers == 1, 10000);
+
+    // trigger the transfer
+    app.testModule.theTrigger.write();
+    CHECK_TIMEOUT(backend->numberOfTransfers == 2, 10000);
+    BOOST_TEST(backend->lastBar == 0);
+    BOOST_TEST(backend->lastAddress == 0);
+
+    // We only explicitly connect the three registers in the app, but the connection code will also connect the other
+    // registers into the CS, hence we need to check for the full size
+    BOOST_TEST(backend->lastSizeInBytes == 32);
+
+    // check result
+    app.testModule.consumingPush.read();
+    app.testModule.consumingPush2.read();
+    app.testModule.consumingPush3.read();
+    BOOST_CHECK_EQUAL(app.testModule.consumingPush, 11);
+    BOOST_CHECK_EQUAL(app.testModule.consumingPush2, 22);
+    BOOST_CHECK_EQUAL(app.testModule.consumingPush3, 33);
+
+    // prepare a second transfer
+    dev.write("/REG1.DUMMY_WRITEABLE", 12);
+    dev.write("/REG2.DUMMY_WRITEABLE", 23);
+    dev.write("/REG3.DUMMY_WRITEABLE", 34);
+
+    // trigger the transfer
+    app.testModule.theTrigger.write();
+    CHECK_TIMEOUT(backend->numberOfTransfers == 3, 10000);
+    BOOST_TEST(backend->lastBar == 0);
+    BOOST_TEST(backend->lastAddress == 0);
+
+    // We only explicitly connect the three registers in the app, but the connection code will also connect the other
+    // registers into the CS, hence we need to check for the full size
+    BOOST_TEST(backend->lastSizeInBytes == 32);
+
+    // check result
+    app.testModule.consumingPush.read();
+    app.testModule.consumingPush2.read();
+    app.testModule.consumingPush3.read();
+    BOOST_CHECK_EQUAL(app.testModule.consumingPush, 12);
+    BOOST_CHECK_EQUAL(app.testModule.consumingPush2, 23);
+    BOOST_CHECK_EQUAL(app.testModule.consumingPush3, 34);
+
+    dev.close();
   }
 
-  std::atomic<size_t> numberOfTransfers{0};
-  std::atomic<uint64_t> lastBar{};
-  std::atomic<uint64_t> lastAddress{};
-  std::atomic<size_t> lastSizeInBytes{};
-};
-
-/*********************************************************************************************************************/
-/* the ApplicationModule for the test is a template of the user type */
-
-struct TestModule : public ctk::ApplicationModule {
-  TestModule(ctk::ModuleGroup* owner, const std::string& name, const std::string& description,
-      const std::unordered_set<std::string>& tags = {})
-  : ApplicationModule(owner, name, description, tags), mainLoopStarted(2) {}
-
-  ctk::ScalarPushInput<int> consumingPush{this, "/REG1", "MV/m", "Description"};
-  ctk::ScalarPushInput<int> consumingPush2{this, "/REG2", "MV/m", "Description"};
-  ctk::ScalarPushInput<int> consumingPush3{this, "/REG3", "MV/m", "Description"};
-
-  ctk::ScalarOutput<int> theTrigger{this, "theTrigger", "MV/m", "Description"};
-
-  // We do not use testable mode for this test, so we need this barrier to synchronise to the beginning of the
-  // mainLoop(). This is required since the mainLoopWrapper accesses the module variables before the start of the
-  // mainLoop.
-  // execute this right after the Application::run():
-  //   app.testModule.mainLoopStarted.wait(); // make sure the module's mainLoop() is entered
-  boost::barrier mainLoopStarted;
-
-  void prepare() override {
-    incrementDataFaultCounter(); // force data to be flagged as faulty
-    writeAll();
-    decrementDataFaultCounter(); // data validity depends on inputs
-  }
-
-  void mainLoop() override {
-    std::cout << "Start of main loop" << std::endl;
-    mainLoopStarted.wait();
-    std::cout << "End of main loop" << std::endl;
-  }
-};
-
-/*********************************************************************************************************************/
-/* dummy application */
-
-struct TestApplication : public ctk::Application {
-  TestApplication() : Application("testSuite") {
-    ChimeraTK::BackendFactory::getInstance().registerBackendType(
-        "TestTransferGroupDummy", &TestTransferGroupDummy::createInstance);
-    dev2 = {this, dummySdm.data(), "/testModule/theTrigger"};
-  }
-  ~TestApplication() override { shutdown(); }
-
-  TestModule testModule{this, "testModule", "The test module"};
-  ctk::DeviceModule dev2;
-};
-
-/*********************************************************************************************************************/
-/* test that multiple variables triggered by the same source are put into the
- * same TransferGroup */
-
-BOOST_AUTO_TEST_CASE(testTriggerTransferGroup) {
-  std::cout << "***************************************************************"
-               "******************************************************"
-            << std::endl;
-  std::cout << "==> testTriggerTransferGroup" << std::endl;
-
-  ChimeraTK::BackendFactory::getInstance().setDMapFilePath("test.dmap");
-
-  TestApplication app;
-  auto pvManagers = ctk::createPVManager();
-  app.setPVManager(pvManagers.second);
-
-  ChimeraTK::Device dev;
-  dev.open(dummySdm.data());
-  auto backend = boost::dynamic_pointer_cast<TestTransferGroupDummy>(
-      ChimeraTK::BackendFactory::getInstance().createBackend(dummySdm.data()));
-  BOOST_CHECK(backend != nullptr);
-
-  app.initialise();
-  app.run();
-  app.testModule.mainLoopStarted.wait(); // make sure the module's mainLoop() is entered
-
-  // initialise values
-  app.testModule.consumingPush = 0;
-  app.testModule.consumingPush2 = 0;
-  app.testModule.consumingPush3 = 0;
-  dev.write("/REG1.DUMMY_WRITEABLE", 11);
-  dev.write("/REG2.DUMMY_WRITEABLE", 22);
-  dev.write("/REG3.DUMMY_WRITEABLE", 33);
-
-  // from the initial value transfer
-  CHECK_TIMEOUT(backend->numberOfTransfers == 1, 10000);
-
-  // trigger the transfer
-  app.testModule.theTrigger.write();
-  CHECK_TIMEOUT(backend->numberOfTransfers == 2, 10000);
-  BOOST_TEST(backend->lastBar == 0);
-  BOOST_TEST(backend->lastAddress == 0);
-
-  // We only explicitly connect the three registers in the app, but the connection code will also connect the other
-  // registers into the CS, hence we need to check for the full size
-  BOOST_TEST(backend->lastSizeInBytes == 32);
-
-  // check result
-  app.testModule.consumingPush.read();
-  app.testModule.consumingPush2.read();
-  app.testModule.consumingPush3.read();
-  BOOST_CHECK_EQUAL(app.testModule.consumingPush, 11);
-  BOOST_CHECK_EQUAL(app.testModule.consumingPush2, 22);
-  BOOST_CHECK_EQUAL(app.testModule.consumingPush3, 33);
-
-  // prepare a second transfer
-  dev.write("/REG1.DUMMY_WRITEABLE", 12);
-  dev.write("/REG2.DUMMY_WRITEABLE", 23);
-  dev.write("/REG3.DUMMY_WRITEABLE", 34);
-
-  // trigger the transfer
-  app.testModule.theTrigger.write();
-  CHECK_TIMEOUT(backend->numberOfTransfers == 3, 10000);
-  BOOST_TEST(backend->lastBar == 0);
-  BOOST_TEST(backend->lastAddress == 0);
-
-  // We only explicitly connect the three registers in the app, but the connection code will also connect the other
-  // registers into the CS, hence we need to check for the full size
-  BOOST_TEST(backend->lastSizeInBytes == 32);
-
-  // check result
-  app.testModule.consumingPush.read();
-  app.testModule.consumingPush2.read();
-  app.testModule.consumingPush3.read();
-  BOOST_CHECK_EQUAL(app.testModule.consumingPush, 12);
-  BOOST_CHECK_EQUAL(app.testModule.consumingPush2, 23);
-  BOOST_CHECK_EQUAL(app.testModule.consumingPush3, 34);
-
-  dev.close();
-}
+} // namespace Tests::testTrigger

--- a/tests/executables_src/testUserInputValidator.cc
+++ b/tests/executables_src/testUserInputValidator.cc
@@ -12,644 +12,648 @@
 #include <boost/mpl/list.hpp>
 #include <boost/test/included/unit_test.hpp>
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testUserInputValidator {
 
-/*********************************************************************************************************************/
-/* Test module with a single validated input, used stand alone or as a downstream module *****************************/
-/*********************************************************************************************************************/
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
-struct ModuleA : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
+  /*********************************************************************************************************************/
+  /* Test module with a single validated input, used stand alone or as a downstream module *****************************/
+  /*********************************************************************************************************************/
 
-  ctk::ScalarPushInputWB<int> in1{this, "in1", "", "First validated input"};
+  struct ModuleA : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  ctk::UserInputValidator validator;
+    ctk::ScalarPushInputWB<int> in1{this, "in1", "", "First validated input"};
 
-  std::string in1ErrorMessage;
+    ctk::UserInputValidator validator;
 
-  void prepare() override {
-    in1ErrorMessage = "(" + getName() + ") in1 needs to be smaller than 10";
-    validator.add(
-        in1ErrorMessage, [&] { return in1 < 10; }, in1);
-  }
+    std::string in1ErrorMessage;
 
-  void mainLoop() override {
-    auto group = readAnyGroup();
-    ctk::TransferElementID change;
-    while(true) {
-      validator.validate(change);
-
-      change = group.readAny();
-    }
-  }
-};
-
-/*********************************************************************************************************************/
-/* Variant of ModuleA with a second input ****************************************************************************/
-/*********************************************************************************************************************/
-
-struct ModuleAwithSecondInput : public ModuleA {
-  using ModuleA::ModuleA;
-
-  ctk::ScalarPushInputWB<int> in2{this, "in2", "", "Second validated input"};
-
-  std::string in2ErrorMessage;
-
-  void prepare() override {
-    ModuleA::prepare();
-    in2ErrorMessage = "(" + getName() + ") in2 needs to be bigger than 10";
-    validator.add(
-        in2ErrorMessage, [&] { return in2 > 10; }, in2);
-  }
-};
-
-/*********************************************************************************************************************/
-/* Test module with a single validated input and one output for connection to another validated input ****************/
-/*********************************************************************************************************************/
-
-struct UpstreamSingleOut : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  ctk::ScalarPushInputWB<int> in1{this, "in1", "", "First validated input"};
-  ctk::ScalarOutputPushRB<int> out1{this, "/Downstream/in1", "", "Output"};
-
-  ctk::UserInputValidator validator;
-
-  void prepare() override {
-    validator.add(
-        "(" + getName() + ") in1 needs to be smaller than 20", [&] { return in1 < 20; }, in1);
-  }
-
-  void mainLoop() override {
-    auto group = readAnyGroup();
-    ctk::TransferElementID change;
-    while(true) {
-      validator.validate(change);
-
-      out1.writeIfDifferent(in1 + 1);
-
-      change = group.readAny();
-    }
-  }
-};
-/*********************************************************************************************************************/
-/* Test module with a single validated input and two outputs for connection to another validated input ***************/
-/*********************************************************************************************************************/
-
-struct UpstreamTwinOut : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
-
-  ctk::ScalarPushInputWB<int> in1{this, "in1", "", "First validated input"};
-  ctk::ScalarOutputPushRB<int> out1{this, "/Downstream1/in1", "", "Output"};
-  ctk::ScalarOutputPushRB<int> out2{this, "/Downstream2/in1", "", "Output"};
-
-  ctk::UserInputValidator validator;
-
-  void prepare() override {
-    validator.add(
-        "(" + getName() + ") in1 needs to be smaller than 20", [&] { return in1 < 20; }, in1);
-  }
-
-  void mainLoop() override {
-    auto group = readAnyGroup();
-    ctk::TransferElementID change;
-    while(true) {
-      validator.validate(change);
-
-      out1.writeIfDifferent(in1 + 1);
-      out2.writeIfDifferent(in1 + 2);
-
-      change = group.readAny();
-    }
-  }
-};
-
-/*********************************************************************************************************************/
-/* Test cases ********************************************************************************************************/
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testSingleVariable) {
-  std::cout << "testSingleVariable" << std::endl;
-
-  struct TestApplication : public ctk::Application {
-    using ctk::Application::Application;
-    ~TestApplication() override { shutdown(); }
-    ModuleA moduleA{this, "ModuleA", ""};
-  };
-
-  TestApplication app("TestApp");
-  ctk::TestFacility test(app);
-
-  auto modAin1 = test.getScalar<int>("/ModuleA/in1");
-
-  test.runApplication();
-
-  modAin1.setAndWrite(8);
-  test.stepApplication();
-  BOOST_TEST(!modAin1.readLatest());
-  BOOST_TEST(app.moduleA.in1 == 8);
-
-  modAin1.setAndWrite(10);
-  test.stepApplication();
-  BOOST_TEST(modAin1.readLatest());
-  BOOST_TEST(modAin1 == 8);
-  BOOST_TEST(app.moduleA.in1 == 8);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testFallback) {
-  std::cout << "testFallback" << std::endl;
-
-  struct ModuleAmod : public ModuleA {
-    using ModuleA::ModuleA;
     void prepare() override {
-      ModuleA::prepare();
-      validator.setFallback(in1, 7);
+      in1ErrorMessage = "(" + getName() + ") in1 needs to be smaller than 10";
+      validator.add(
+          in1ErrorMessage, [&] { return in1 < 10; }, in1);
+    }
+
+    void mainLoop() override {
+      auto group = readAnyGroup();
+      ctk::TransferElementID change;
+      while(true) {
+        validator.validate(change);
+
+        change = group.readAny();
+      }
     }
   };
 
-  struct TestApplication : public ctk::Application {
-    using ctk::Application::Application;
-    ~TestApplication() override { shutdown(); }
-    ModuleAmod moduleA{this, "ModuleA", ""};
-  };
+  /*********************************************************************************************************************/
+  /* Variant of ModuleA with a second input ****************************************************************************/
+  /*********************************************************************************************************************/
 
-  TestApplication app("TestApp");
-  ctk::TestFacility test(app);
-
-  auto modAin1 = test.getScalar<int>("/ModuleA/in1");
-
-  test.setScalarDefault<int>("/ModuleA/in1", 12);
-
-  test.runApplication();
-
-  BOOST_TEST(!modAin1.readLatest());
-  BOOST_TEST(app.moduleA.in1 == 7);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testMultipleVariablesDifferentChecks) {
-  std::cout << "testMultipleVariablesDifferentChecks" << std::endl;
-  // add another input which is validated with another UserInputValidator::add() call
-
-  struct TestApplication : public ctk::Application {
-    using ctk::Application::Application;
-    ~TestApplication() override { shutdown(); }
-    ModuleAwithSecondInput moduleA{this, "ModuleA", ""};
-  };
-
-  TestApplication app("TestApp");
-  ctk::TestFacility test(app);
-
-  auto in1 = test.getScalar<int>("/ModuleA/in1");
-  auto in2 = test.getScalar<int>("/ModuleA/in2");
-
-  test.setScalarDefault<int>("/ModuleA/in1", 3);
-  test.setScalarDefault<int>("/ModuleA/in2", 12);
-
-  test.runApplication();
-
-  BOOST_TEST(!in1.readLatest());
-  BOOST_TEST(!in2.readLatest());
-
-  in1.setAndWrite(15);
-  test.stepApplication();
-  BOOST_TEST(in1.readLatest());
-  BOOST_TEST(in1 == 3);
-  BOOST_TEST(app.moduleA.in1 == 3);
-  BOOST_TEST(app.moduleA.in2 == 12);
-
-  in1.setAndWrite(9);
-  test.stepApplication();
-  BOOST_TEST(!in1.readLatest());
-  BOOST_TEST(app.moduleA.in1 == 9);
-  BOOST_TEST(app.moduleA.in2 == 12);
-
-  BOOST_TEST(!in2.readLatest());
-
-  in2.setAndWrite(7);
-  test.stepApplication();
-  BOOST_TEST(in2.readLatest());
-  BOOST_TEST(in2 == 12);
-  BOOST_TEST(app.moduleA.in1 == 9);
-  BOOST_TEST(app.moduleA.in2 == 12);
-
-  in2.setAndWrite(13);
-  test.stepApplication();
-  BOOST_TEST(!in2.readLatest());
-  BOOST_TEST(app.moduleA.in1 == 9);
-  BOOST_TEST(app.moduleA.in2 == 13);
-
-  BOOST_TEST(!in1.readLatest());
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testMultipleVariablesSameCheck) {
-  std::cout << "testMultipleVariablesSameCheck" << std::endl;
-  // add another input which is validated in the same UserInputValidator::add() call as the existing input, replacing
-  // the existing add() call
-
-  struct ModuleAmod : public ModuleA {
+  struct ModuleAwithSecondInput : public ModuleA {
     using ModuleA::ModuleA;
 
     ctk::ScalarPushInputWB<int> in2{this, "in2", "", "Second validated input"};
 
-    void prepare() override {
-      // Do not call ModuleA::prepare() here, we do not want the original check!
-      validator.add(
-          "in1 needs to be smaller than 10 and in2 needs to be bigger than 10", [&] { return in1 < 10 && in2 > 10; },
-          in1, in2);
-    }
-  };
-
-  struct TestApplication : public ctk::Application {
-    using ctk::Application::Application;
-    ~TestApplication() override { shutdown(); }
-    ModuleAmod moduleA{this, "ModuleA", ""};
-  };
-
-  // Implementation note about the test: Except for the setting (one single add() call combining both checks instead of
-  // two separate add() calls) this test can be identical to testMultipleVariablesDifferentChecks. The only difference
-  // in behaviour is the different message, which is defined in the add() call (and hence outside the code under test).
-
-  TestApplication app("TestApp");
-  ctk::TestFacility test(app);
-
-  auto in1 = test.getScalar<int>("/ModuleA/in1");
-  auto in2 = test.getScalar<int>("/ModuleA/in2");
-
-  test.setScalarDefault<int>("/ModuleA/in1", 3);
-  test.setScalarDefault<int>("/ModuleA/in2", 12);
-
-  test.runApplication();
-
-  BOOST_TEST(!in1.readLatest());
-  BOOST_TEST(!in2.readLatest());
-
-  in1.setAndWrite(15);
-  test.stepApplication();
-  BOOST_TEST(in1.readLatest());
-  BOOST_TEST(in1 == 3);
-  BOOST_TEST(app.moduleA.in1 == 3);
-  BOOST_TEST(app.moduleA.in2 == 12);
-
-  in1.setAndWrite(9);
-  test.stepApplication();
-  BOOST_TEST(!in1.readLatest());
-  BOOST_TEST(app.moduleA.in1 == 9);
-  BOOST_TEST(app.moduleA.in2 == 12);
-
-  BOOST_TEST(!in2.readLatest());
-
-  in2.setAndWrite(7);
-  test.stepApplication();
-  BOOST_TEST(in2.readLatest());
-  BOOST_TEST(in2 == 12);
-  BOOST_TEST(app.moduleA.in1 == 9);
-  BOOST_TEST(app.moduleA.in2 == 12);
-
-  in2.setAndWrite(13);
-  test.stepApplication();
-  BOOST_TEST(!in2.readLatest());
-  BOOST_TEST(app.moduleA.in1 == 9);
-  BOOST_TEST(app.moduleA.in2 == 13);
-
-  BOOST_TEST(!in1.readLatest());
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testMultipleChecksSameVariable) {
-  std::cout << "testMultipleChecksSameVariable" << std::endl;
-  // add multiple UserInputValidator::add() calls all checking the same variable i1
-
-  struct ModuleAmod : public ModuleA {
-    using ModuleA::ModuleA;
+    std::string in2ErrorMessage;
 
     void prepare() override {
-      ModuleA::prepare(); // defines check for in1 < 10
+      ModuleA::prepare();
+      in2ErrorMessage = "(" + getName() + ") in2 needs to be bigger than 10";
       validator.add(
-          "in1 needs to be greater than -5", [&] { return in1 > -5; }, in1);
+          in2ErrorMessage, [&] { return in2 > 10; }, in2);
     }
   };
 
-  struct TestApplication : public ctk::Application {
-    using ctk::Application::Application;
-    ~TestApplication() override { shutdown(); }
-    ModuleAmod moduleA{this, "ModuleA", ""};
-  };
+  /*********************************************************************************************************************/
+  /* Test module with a single validated input and one output for connection to another validated input ****************/
+  /*********************************************************************************************************************/
 
-  TestApplication app("TestApp");
-  ctk::TestFacility test(app);
+  struct UpstreamSingleOut : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
 
-  auto in1 = test.getScalar<int>("/ModuleA/in1");
+    ctk::ScalarPushInputWB<int> in1{this, "in1", "", "First validated input"};
+    ctk::ScalarOutputPushRB<int> out1{this, "/Downstream/in1", "", "Output"};
 
-  test.setScalarDefault<int>("/ModuleA/in1", 3);
+    ctk::UserInputValidator validator;
 
-  test.runApplication();
-
-  BOOST_TEST(!in1.readLatest());
-
-  in1.setAndWrite(15);
-  test.stepApplication();
-  BOOST_TEST(in1.readLatest());
-  BOOST_TEST(in1 == 3);
-  BOOST_TEST(app.moduleA.in1 == 3);
-
-  in1.setAndWrite(9);
-  test.stepApplication();
-  BOOST_TEST(!in1.readLatest());
-  BOOST_TEST(app.moduleA.in1 == 9);
-
-  in1.setAndWrite(-7);
-  test.stepApplication();
-  BOOST_TEST(in1.readLatest());
-  BOOST_TEST(in1 == 9);
-  BOOST_TEST(app.moduleA.in1 == 9);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testSetErrorFunction) {
-  std::cout << "testSetErrorFunction" << std::endl;
-  // check that setErrorFunction is called with the right message (need multiple checks with different messages)
-
-  struct TestApplication : public ctk::Application {
-    using ctk::Application::Application;
-    ~TestApplication() override { shutdown(); }
-    ModuleAwithSecondInput moduleA{this, "ModuleA", ""};
-  };
-
-  TestApplication app("TestApp");
-  ctk::TestFacility test(app);
-
-  std::string errorMessage;
-
-  app.moduleA.validator.setErrorFunction([&](const std::string& msg) { errorMessage = msg; });
-
-  auto modAin1 = test.getScalar<int>("/ModuleA/in1");
-  auto modAin2 = test.getScalar<int>("/ModuleA/in2");
-
-  test.setScalarDefault<int>("/ModuleA/in2", 20);
-
-  test.runApplication();
-
-  modAin1.setAndWrite(8);
-  test.stepApplication();
-  BOOST_TEST(!modAin1.readLatest());
-  BOOST_TEST(app.moduleA.in1 == 8);
-  BOOST_TEST(errorMessage.empty());
-
-  modAin1.setAndWrite(10);
-  test.stepApplication();
-  BOOST_TEST(modAin1.readLatest());
-  BOOST_TEST(modAin1 == 8);
-  BOOST_TEST(app.moduleA.in1 == 8);
-  BOOST_TEST(errorMessage == app.moduleA.in1ErrorMessage);
-
-  modAin2.setAndWrite(1);
-  test.stepApplication();
-  BOOST_TEST(modAin2.readLatest());
-  BOOST_TEST(modAin2 == 20);
-  BOOST_TEST(app.moduleA.in2 == 20);
-  BOOST_TEST(errorMessage == app.moduleA.in2ErrorMessage);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testBackwardsPropagationSingleDownstream) {
-  std::cout << "testBackwardsPropagationSingleDownstream" << std::endl;
-  // check that two modules with each one validator connected to each other propagate rejections from the downstream
-  // module to the upstream and the control system eventually
-  // Note: This is new functionality implemeted as part of #11558
-
-  struct TestApplication : public ctk::Application {
-    using ctk::Application::Application;
-    ~TestApplication() override { shutdown(); }
-    UpstreamSingleOut upstream{this, "Upstream", ""};
-    ModuleA downstream{this, "Downstream", ""};
-  };
-
-  TestApplication app("TestApp");
-  ctk::TestFacility test(app);
-
-  auto upstrIn = test.getScalar<int>("/Upstream/in1");
-  auto downstrIn = test.getScalar<int>("/Downstream/in1");
-
-  test.setScalarDefault<int>("/Upstream/in1", 5);
-
-  test.runApplication();
-
-  // discard initial values
-  downstrIn.readLatest();
-  BOOST_TEST(downstrIn == 6);
-
-  upstrIn.setAndWrite(30);
-  test.stepApplication();
-  BOOST_TEST(upstrIn.readNonBlocking());
-  BOOST_TEST(upstrIn == 5);
-  BOOST_TEST(!downstrIn.readNonBlocking()); // validation happens in upstream, not really part of this test case
-
-  upstrIn.setAndWrite(12);
-  test.stepApplication();
-  BOOST_TEST(upstrIn.readNonBlocking());
-  BOOST_TEST(upstrIn == 5);
-  BOOST_TEST(downstrIn.readLatest());
-  BOOST_TEST(downstrIn == 6);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testBackwardsPropagationTwoDownstream) {
-  std::cout << "testBackwardsPropagationTwoDownstream" << std::endl;
-  // Same as testBackwardsPropagationSingleDownstream but with two downstream modules (different PVs)
-  // Note: This is new functionality implemeted as part of #11558
-
-  struct TestApplication : public ctk::Application {
-    using ctk::Application::Application;
-    ~TestApplication() override { shutdown(); }
-    UpstreamTwinOut upstream{this, "Upstream", ""};
-    ModuleA downstream1{this, "Downstream1", ""};
-    ModuleA downstream2{this, "Downstream2", ""};
-  };
-
-  TestApplication app("TestApp");
-  ctk::TestFacility test(app);
-
-  auto upstrIn = test.getScalar<int>("/Upstream/in1");
-  auto downstr1In = test.getScalar<int>("/Downstream1/in1");
-  auto downstr2In = test.getScalar<int>("/Downstream2/in1");
-
-  test.setScalarDefault<int>("/Upstream/in1", 5);
-
-  test.runApplication();
-
-  // discard initial values
-  downstr1In.readLatest();
-  BOOST_TEST(downstr1In == 6);
-  downstr2In.readLatest();
-  BOOST_TEST(downstr2In == 7);
-
-  upstrIn.setAndWrite(30);
-  test.stepApplication();
-  BOOST_TEST(upstrIn.readNonBlocking());
-  BOOST_TEST(upstrIn == 5);
-  BOOST_TEST(!downstr1In.readNonBlocking()); // validation happens in upstream, not really part of this test case
-  BOOST_TEST(!downstr2In.readNonBlocking());
-
-  upstrIn.setAndWrite(12);
-  test.stepApplication();
-  BOOST_TEST(upstrIn.readNonBlocking());
-  BOOST_TEST(upstrIn == 5);
-  BOOST_TEST(downstr1In.readLatest());
-  BOOST_TEST(downstr1In == 6);
-  BOOST_TEST(downstr2In.readLatest());
-  BOOST_TEST(downstr2In == 7);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testFunnel) {
-  std::cout << "testFunnel" << std::endl;
-  // Two modules both having the same PV as an input (with return channel) which is validated
-  // Note: This is new functionality implemeted as part of #11558
-
-  struct TestApplication : public ctk::Application {
-    using ctk::Application::Application;
-    ~TestApplication() override { shutdown(); }
-    ModuleA module1{this, "Module", ""};
-    ModuleA module2{this, "Module", ""};
-  };
-
-  TestApplication app("TestApp");
-  ctk::TestFacility test(app);
-
-  auto in1 = test.getScalar<int>("/Module/in1");
-
-  test.setScalarDefault<int>("/Module/in1", 5);
-
-  test.runApplication();
-
-  in1.setAndWrite(30);
-  test.stepApplication();
-  BOOST_TEST(in1.readNonBlocking());
-  BOOST_TEST(in1 == 5);
-  BOOST_TEST(app.module1.in1 == 5);
-  BOOST_TEST(app.module2.in1 == 5);
-}
-
-/*********************************************************************************************************************/
-
-BOOST_AUTO_TEST_CASE(testDeepBackwardsPropagation) {
-  std::cout << "testDeepBackwardsPropagation" << std::endl;
-  // Like testBackwardsPropagationSingleDownstream, but with deeper validation chain and new input values arriving at
-  // the upstream module before rejections from downstream.
-
-  struct TestApplication : public ctk::Application {
-    using ctk::Application::Application;
-    ~TestApplication() override { shutdown(); }
-    UpstreamSingleOut upstream{this, "Upstream", ""};
-    UpstreamSingleOut midstream{this, "Midstream", ""};
-    ModuleA downstream{this, "Downstream", ""};
-  };
-
-  TestApplication app("TestApp");
-  app.upstream.out1 = {&app.upstream, "/Midstream/in1", "", "First validated input"};
-
-  ctk::TestFacility test(app);
-
-  auto upstrIn = test.getScalar<int>("/Upstream/in1");
-  auto midstreamIn = test.getScalar<int>("/Midstream/in1");
-  auto downstrIn = test.getScalar<int>("/Downstream/in1");
-
-  test.setScalarDefault<int>("/Upstream/in1", 5);
-
-  test.runApplication();
-
-  // discard initial values
-  midstreamIn.readLatest();
-  downstrIn.readLatest();
-  BOOST_TEST(midstreamIn == 6);
-  BOOST_TEST(downstrIn == 7);
-  // test a single value being discarded at the lowest level (Downstream)
-  upstrIn.setAndWrite(12);
-  test.stepApplication();
-  BOOST_TEST(midstreamIn.readNonBlocking());
-  BOOST_TEST(midstreamIn == 13); // first value is coming from Upstream
-  BOOST_TEST(downstrIn.readNonBlocking());
-  BOOST_TEST(downstrIn == 14); // first value is passed through by Midstream
-  BOOST_TEST(downstrIn.readNonBlocking());
-  BOOST_TEST(downstrIn == 7); // correction value coming back from Downstream
-  BOOST_TEST(!downstrIn.readNonBlocking());
-  BOOST_TEST(midstreamIn.readNonBlocking());
-  BOOST_TEST(midstreamIn == 6); // correction value coming back from Midstream
-  BOOST_TEST(!midstreamIn.readNonBlocking());
-  BOOST_TEST(upstrIn.readNonBlocking());
-  BOOST_TEST(upstrIn == 5); // correction value coming back from Upstream
-  BOOST_TEST(!upstrIn.readNonBlocking());
-
-  // test two consecutive values both being discarded at the lowest level
-  // Note: Writing two values into the upstrIn queue will make Upstream process the second value before the correction
-  // for the first value coming from Downstream, because readAny() will process updates in sequences of arrival
-  // (on notification queue). Apart from this it is not well defined (aka subject to race condition) where the second
-  // value from Upstream and the correction of the first value from Downstream cross.
-  upstrIn.setAndWrite(12);
-  upstrIn.setAndWrite(13);
-  test.stepApplication();
-  BOOST_TEST(midstreamIn.readNonBlocking());
-  BOOST_TEST(midstreamIn == 13); // first value is coming from upstream
-  BOOST_TEST(downstrIn.readNonBlocking());
-  BOOST_TEST(downstrIn == 14); // first value is coming from upstream/midstream
-
-  BOOST_TEST(downstrIn.readLatest()); // just observe final state, because intermediate states might be subject
-  BOOST_TEST(downstrIn == 7);         // to race conditions
-  BOOST_TEST(midstreamIn.readLatest());
-  BOOST_TEST(midstreamIn == 6);
-  BOOST_TEST(upstrIn.readLatest());
-  BOOST_TEST(upstrIn == 5);
-
-  // test two consecutive values, only the first being discarded at the lowest level and the second is accepted
-  size_t retry = 0;
-repeat:
-  upstrIn.setAndWrite(12);
-  upstrIn.setAndWrite(3);
-
-  test.stepApplication();
-
-  // There are two acceptable outcomes of this test:
-  //
-  // 1) Likely: The first value was rejected and the second was accepted
-  //
-  // 2) Unlikely: Both values are rejected. This can happen because the UserInputValidator of midstream needs to use a
-  //    fresh VersionNumber to propagate the rejection of the first value from downstream (otherwise the scenario in
-  //    testBackwardsPropagationTwoDownstream would break). Since that fresh VersionNumber is bigger then the one of the
-  //    second, valid value, it can overwrite the second value and hence that gets effectively rejected.
-  //
-  // Currently, we accept both scenarios but require that the likely scenario is observed (by retrying a couple of times
-  // if we see the second scenario). This problem can be solved by extending the VersionNumber with a sub-version, so we
-  // can both distinguish the corrected from the rejected values as well as find out to which original VersionNumber
-  // the corrected value belongs. Due to the fact that this problem only occurs when writing inputs faster than the
-  // values get rejected and the UserInputValidator being designed for inputs by users, this problem does not seem to
-  // play a big role in real scenarios.
-
-  BOOST_TEST(downstrIn.readLatest()); // just observe final state, to avoid intermediate races
-  BOOST_TEST(midstreamIn.readLatest());
-  if(downstrIn == 7) {
-    BOOST_TEST(upstrIn.readLatest());
-    BOOST_TEST(midstreamIn == 6);
-    BOOST_TEST(upstrIn == 5);
-    if(++retry < 10) {
-      goto repeat;
+    void prepare() override {
+      validator.add(
+          "(" + getName() + ") in1 needs to be smaller than 20", [&] { return in1 < 20; }, in1);
     }
+
+    void mainLoop() override {
+      auto group = readAnyGroup();
+      ctk::TransferElementID change;
+      while(true) {
+        validator.validate(change);
+
+        out1.writeIfDifferent(in1 + 1);
+
+        change = group.readAny();
+      }
+    }
+  };
+  /*********************************************************************************************************************/
+  /* Test module with a single validated input and two outputs for connection to another validated input ***************/
+  /*********************************************************************************************************************/
+
+  struct UpstreamTwinOut : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+
+    ctk::ScalarPushInputWB<int> in1{this, "in1", "", "First validated input"};
+    ctk::ScalarOutputPushRB<int> out1{this, "/Downstream1/in1", "", "Output"};
+    ctk::ScalarOutputPushRB<int> out2{this, "/Downstream2/in1", "", "Output"};
+
+    ctk::UserInputValidator validator;
+
+    void prepare() override {
+      validator.add(
+          "(" + getName() + ") in1 needs to be smaller than 20", [&] { return in1 < 20; }, in1);
+    }
+
+    void mainLoop() override {
+      auto group = readAnyGroup();
+      ctk::TransferElementID change;
+      while(true) {
+        validator.validate(change);
+
+        out1.writeIfDifferent(in1 + 1);
+        out2.writeIfDifferent(in1 + 2);
+
+        change = group.readAny();
+      }
+    }
+  };
+
+  /*********************************************************************************************************************/
+  /* Test cases ********************************************************************************************************/
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testSingleVariable) {
+    std::cout << "testSingleVariable" << std::endl;
+
+    struct TestApplication : public ctk::Application {
+      using ctk::Application::Application;
+      ~TestApplication() override { shutdown(); }
+      ModuleA moduleA{this, "ModuleA", ""};
+    };
+
+    TestApplication app("TestApp");
+    ctk::TestFacility test(app);
+
+    auto modAin1 = test.getScalar<int>("/ModuleA/in1");
+
+    test.runApplication();
+
+    modAin1.setAndWrite(8);
+    test.stepApplication();
+    BOOST_TEST(!modAin1.readLatest());
+    BOOST_TEST(app.moduleA.in1 == 8);
+
+    modAin1.setAndWrite(10);
+    test.stepApplication();
+    BOOST_TEST(modAin1.readLatest());
+    BOOST_TEST(modAin1 == 8);
+    BOOST_TEST(app.moduleA.in1 == 8);
   }
-  BOOST_TEST(!upstrIn.readLatest());
-  BOOST_TEST(downstrIn == 5);
-  BOOST_TEST(midstreamIn == 4);
-  BOOST_TEST(upstrIn == 3);
-}
 
-/*********************************************************************************************************************/
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testFallback) {
+    std::cout << "testFallback" << std::endl;
+
+    struct ModuleAmod : public ModuleA {
+      using ModuleA::ModuleA;
+      void prepare() override {
+        ModuleA::prepare();
+        validator.setFallback(in1, 7);
+      }
+    };
+
+    struct TestApplication : public ctk::Application {
+      using ctk::Application::Application;
+      ~TestApplication() override { shutdown(); }
+      ModuleAmod moduleA{this, "ModuleA", ""};
+    };
+
+    TestApplication app("TestApp");
+    ctk::TestFacility test(app);
+
+    auto modAin1 = test.getScalar<int>("/ModuleA/in1");
+
+    test.setScalarDefault<int>("/ModuleA/in1", 12);
+
+    test.runApplication();
+
+    BOOST_TEST(!modAin1.readLatest());
+    BOOST_TEST(app.moduleA.in1 == 7);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testMultipleVariablesDifferentChecks) {
+    std::cout << "testMultipleVariablesDifferentChecks" << std::endl;
+    // add another input which is validated with another UserInputValidator::add() call
+
+    struct TestApplication : public ctk::Application {
+      using ctk::Application::Application;
+      ~TestApplication() override { shutdown(); }
+      ModuleAwithSecondInput moduleA{this, "ModuleA", ""};
+    };
+
+    TestApplication app("TestApp");
+    ctk::TestFacility test(app);
+
+    auto in1 = test.getScalar<int>("/ModuleA/in1");
+    auto in2 = test.getScalar<int>("/ModuleA/in2");
+
+    test.setScalarDefault<int>("/ModuleA/in1", 3);
+    test.setScalarDefault<int>("/ModuleA/in2", 12);
+
+    test.runApplication();
+
+    BOOST_TEST(!in1.readLatest());
+    BOOST_TEST(!in2.readLatest());
+
+    in1.setAndWrite(15);
+    test.stepApplication();
+    BOOST_TEST(in1.readLatest());
+    BOOST_TEST(in1 == 3);
+    BOOST_TEST(app.moduleA.in1 == 3);
+    BOOST_TEST(app.moduleA.in2 == 12);
+
+    in1.setAndWrite(9);
+    test.stepApplication();
+    BOOST_TEST(!in1.readLatest());
+    BOOST_TEST(app.moduleA.in1 == 9);
+    BOOST_TEST(app.moduleA.in2 == 12);
+
+    BOOST_TEST(!in2.readLatest());
+
+    in2.setAndWrite(7);
+    test.stepApplication();
+    BOOST_TEST(in2.readLatest());
+    BOOST_TEST(in2 == 12);
+    BOOST_TEST(app.moduleA.in1 == 9);
+    BOOST_TEST(app.moduleA.in2 == 12);
+
+    in2.setAndWrite(13);
+    test.stepApplication();
+    BOOST_TEST(!in2.readLatest());
+    BOOST_TEST(app.moduleA.in1 == 9);
+    BOOST_TEST(app.moduleA.in2 == 13);
+
+    BOOST_TEST(!in1.readLatest());
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testMultipleVariablesSameCheck) {
+    std::cout << "testMultipleVariablesSameCheck" << std::endl;
+    // add another input which is validated in the same UserInputValidator::add() call as the existing input, replacing
+    // the existing add() call
+
+    struct ModuleAmod : public ModuleA {
+      using ModuleA::ModuleA;
+
+      ctk::ScalarPushInputWB<int> in2{this, "in2", "", "Second validated input"};
+
+      void prepare() override {
+        // Do not call ModuleA::prepare() here, we do not want the original check!
+        validator.add(
+            "in1 needs to be smaller than 10 and in2 needs to be bigger than 10", [&] { return in1 < 10 && in2 > 10; },
+            in1, in2);
+      }
+    };
+
+    struct TestApplication : public ctk::Application {
+      using ctk::Application::Application;
+      ~TestApplication() override { shutdown(); }
+      ModuleAmod moduleA{this, "ModuleA", ""};
+    };
+
+    // Implementation note about the test: Except for the setting (one single add() call combining both checks instead of
+    // two separate add() calls) this test can be identical to testMultipleVariablesDifferentChecks. The only difference
+    // in behaviour is the different message, which is defined in the add() call (and hence outside the code under test).
+
+    TestApplication app("TestApp");
+    ctk::TestFacility test(app);
+
+    auto in1 = test.getScalar<int>("/ModuleA/in1");
+    auto in2 = test.getScalar<int>("/ModuleA/in2");
+
+    test.setScalarDefault<int>("/ModuleA/in1", 3);
+    test.setScalarDefault<int>("/ModuleA/in2", 12);
+
+    test.runApplication();
+
+    BOOST_TEST(!in1.readLatest());
+    BOOST_TEST(!in2.readLatest());
+
+    in1.setAndWrite(15);
+    test.stepApplication();
+    BOOST_TEST(in1.readLatest());
+    BOOST_TEST(in1 == 3);
+    BOOST_TEST(app.moduleA.in1 == 3);
+    BOOST_TEST(app.moduleA.in2 == 12);
+
+    in1.setAndWrite(9);
+    test.stepApplication();
+    BOOST_TEST(!in1.readLatest());
+    BOOST_TEST(app.moduleA.in1 == 9);
+    BOOST_TEST(app.moduleA.in2 == 12);
+
+    BOOST_TEST(!in2.readLatest());
+
+    in2.setAndWrite(7);
+    test.stepApplication();
+    BOOST_TEST(in2.readLatest());
+    BOOST_TEST(in2 == 12);
+    BOOST_TEST(app.moduleA.in1 == 9);
+    BOOST_TEST(app.moduleA.in2 == 12);
+
+    in2.setAndWrite(13);
+    test.stepApplication();
+    BOOST_TEST(!in2.readLatest());
+    BOOST_TEST(app.moduleA.in1 == 9);
+    BOOST_TEST(app.moduleA.in2 == 13);
+
+    BOOST_TEST(!in1.readLatest());
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testMultipleChecksSameVariable) {
+    std::cout << "testMultipleChecksSameVariable" << std::endl;
+    // add multiple UserInputValidator::add() calls all checking the same variable i1
+
+    struct ModuleAmod : public ModuleA {
+      using ModuleA::ModuleA;
+
+      void prepare() override {
+        ModuleA::prepare(); // defines check for in1 < 10
+        validator.add(
+            "in1 needs to be greater than -5", [&] { return in1 > -5; }, in1);
+      }
+    };
+
+    struct TestApplication : public ctk::Application {
+      using ctk::Application::Application;
+      ~TestApplication() override { shutdown(); }
+      ModuleAmod moduleA{this, "ModuleA", ""};
+    };
+
+    TestApplication app("TestApp");
+    ctk::TestFacility test(app);
+
+    auto in1 = test.getScalar<int>("/ModuleA/in1");
+
+    test.setScalarDefault<int>("/ModuleA/in1", 3);
+
+    test.runApplication();
+
+    BOOST_TEST(!in1.readLatest());
+
+    in1.setAndWrite(15);
+    test.stepApplication();
+    BOOST_TEST(in1.readLatest());
+    BOOST_TEST(in1 == 3);
+    BOOST_TEST(app.moduleA.in1 == 3);
+
+    in1.setAndWrite(9);
+    test.stepApplication();
+    BOOST_TEST(!in1.readLatest());
+    BOOST_TEST(app.moduleA.in1 == 9);
+
+    in1.setAndWrite(-7);
+    test.stepApplication();
+    BOOST_TEST(in1.readLatest());
+    BOOST_TEST(in1 == 9);
+    BOOST_TEST(app.moduleA.in1 == 9);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testSetErrorFunction) {
+    std::cout << "testSetErrorFunction" << std::endl;
+    // check that setErrorFunction is called with the right message (need multiple checks with different messages)
+
+    struct TestApplication : public ctk::Application {
+      using ctk::Application::Application;
+      ~TestApplication() override { shutdown(); }
+      ModuleAwithSecondInput moduleA{this, "ModuleA", ""};
+    };
+
+    TestApplication app("TestApp");
+    ctk::TestFacility test(app);
+
+    std::string errorMessage;
+
+    app.moduleA.validator.setErrorFunction([&](const std::string& msg) { errorMessage = msg; });
+
+    auto modAin1 = test.getScalar<int>("/ModuleA/in1");
+    auto modAin2 = test.getScalar<int>("/ModuleA/in2");
+
+    test.setScalarDefault<int>("/ModuleA/in2", 20);
+
+    test.runApplication();
+
+    modAin1.setAndWrite(8);
+    test.stepApplication();
+    BOOST_TEST(!modAin1.readLatest());
+    BOOST_TEST(app.moduleA.in1 == 8);
+    BOOST_TEST(errorMessage.empty());
+
+    modAin1.setAndWrite(10);
+    test.stepApplication();
+    BOOST_TEST(modAin1.readLatest());
+    BOOST_TEST(modAin1 == 8);
+    BOOST_TEST(app.moduleA.in1 == 8);
+    BOOST_TEST(errorMessage == app.moduleA.in1ErrorMessage);
+
+    modAin2.setAndWrite(1);
+    test.stepApplication();
+    BOOST_TEST(modAin2.readLatest());
+    BOOST_TEST(modAin2 == 20);
+    BOOST_TEST(app.moduleA.in2 == 20);
+    BOOST_TEST(errorMessage == app.moduleA.in2ErrorMessage);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testBackwardsPropagationSingleDownstream) {
+    std::cout << "testBackwardsPropagationSingleDownstream" << std::endl;
+    // check that two modules with each one validator connected to each other propagate rejections from the downstream
+    // module to the upstream and the control system eventually
+    // Note: This is new functionality implemeted as part of #11558
+
+    struct TestApplication : public ctk::Application {
+      using ctk::Application::Application;
+      ~TestApplication() override { shutdown(); }
+      UpstreamSingleOut upstream{this, "Upstream", ""};
+      ModuleA downstream{this, "Downstream", ""};
+    };
+
+    TestApplication app("TestApp");
+    ctk::TestFacility test(app);
+
+    auto upstrIn = test.getScalar<int>("/Upstream/in1");
+    auto downstrIn = test.getScalar<int>("/Downstream/in1");
+
+    test.setScalarDefault<int>("/Upstream/in1", 5);
+
+    test.runApplication();
+
+    // discard initial values
+    downstrIn.readLatest();
+    BOOST_TEST(downstrIn == 6);
+
+    upstrIn.setAndWrite(30);
+    test.stepApplication();
+    BOOST_TEST(upstrIn.readNonBlocking());
+    BOOST_TEST(upstrIn == 5);
+    BOOST_TEST(!downstrIn.readNonBlocking()); // validation happens in upstream, not really part of this test case
+
+    upstrIn.setAndWrite(12);
+    test.stepApplication();
+    BOOST_TEST(upstrIn.readNonBlocking());
+    BOOST_TEST(upstrIn == 5);
+    BOOST_TEST(downstrIn.readLatest());
+    BOOST_TEST(downstrIn == 6);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testBackwardsPropagationTwoDownstream) {
+    std::cout << "testBackwardsPropagationTwoDownstream" << std::endl;
+    // Same as testBackwardsPropagationSingleDownstream but with two downstream modules (different PVs)
+    // Note: This is new functionality implemeted as part of #11558
+
+    struct TestApplication : public ctk::Application {
+      using ctk::Application::Application;
+      ~TestApplication() override { shutdown(); }
+      UpstreamTwinOut upstream{this, "Upstream", ""};
+      ModuleA downstream1{this, "Downstream1", ""};
+      ModuleA downstream2{this, "Downstream2", ""};
+    };
+
+    TestApplication app("TestApp");
+    ctk::TestFacility test(app);
+
+    auto upstrIn = test.getScalar<int>("/Upstream/in1");
+    auto downstr1In = test.getScalar<int>("/Downstream1/in1");
+    auto downstr2In = test.getScalar<int>("/Downstream2/in1");
+
+    test.setScalarDefault<int>("/Upstream/in1", 5);
+
+    test.runApplication();
+
+    // discard initial values
+    downstr1In.readLatest();
+    BOOST_TEST(downstr1In == 6);
+    downstr2In.readLatest();
+    BOOST_TEST(downstr2In == 7);
+
+    upstrIn.setAndWrite(30);
+    test.stepApplication();
+    BOOST_TEST(upstrIn.readNonBlocking());
+    BOOST_TEST(upstrIn == 5);
+    BOOST_TEST(!downstr1In.readNonBlocking()); // validation happens in upstream, not really part of this test case
+    BOOST_TEST(!downstr2In.readNonBlocking());
+
+    upstrIn.setAndWrite(12);
+    test.stepApplication();
+    BOOST_TEST(upstrIn.readNonBlocking());
+    BOOST_TEST(upstrIn == 5);
+    BOOST_TEST(downstr1In.readLatest());
+    BOOST_TEST(downstr1In == 6);
+    BOOST_TEST(downstr2In.readLatest());
+    BOOST_TEST(downstr2In == 7);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testFunnel) {
+    std::cout << "testFunnel" << std::endl;
+    // Two modules both having the same PV as an input (with return channel) which is validated
+    // Note: This is new functionality implemeted as part of #11558
+
+    struct TestApplication : public ctk::Application {
+      using ctk::Application::Application;
+      ~TestApplication() override { shutdown(); }
+      ModuleA module1{this, "Module", ""};
+      ModuleA module2{this, "Module", ""};
+    };
+
+    TestApplication app("TestApp");
+    ctk::TestFacility test(app);
+
+    auto in1 = test.getScalar<int>("/Module/in1");
+
+    test.setScalarDefault<int>("/Module/in1", 5);
+
+    test.runApplication();
+
+    in1.setAndWrite(30);
+    test.stepApplication();
+    BOOST_TEST(in1.readNonBlocking());
+    BOOST_TEST(in1 == 5);
+    BOOST_TEST(app.module1.in1 == 5);
+    BOOST_TEST(app.module2.in1 == 5);
+  }
+
+  /*********************************************************************************************************************/
+
+  BOOST_AUTO_TEST_CASE(testDeepBackwardsPropagation) {
+    std::cout << "testDeepBackwardsPropagation" << std::endl;
+    // Like testBackwardsPropagationSingleDownstream, but with deeper validation chain and new input values arriving at
+    // the upstream module before rejections from downstream.
+
+    struct TestApplication : public ctk::Application {
+      using ctk::Application::Application;
+      ~TestApplication() override { shutdown(); }
+      UpstreamSingleOut upstream{this, "Upstream", ""};
+      UpstreamSingleOut midstream{this, "Midstream", ""};
+      ModuleA downstream{this, "Downstream", ""};
+    };
+
+    TestApplication app("TestApp");
+    app.upstream.out1 = {&app.upstream, "/Midstream/in1", "", "First validated input"};
+
+    ctk::TestFacility test(app);
+
+    auto upstrIn = test.getScalar<int>("/Upstream/in1");
+    auto midstreamIn = test.getScalar<int>("/Midstream/in1");
+    auto downstrIn = test.getScalar<int>("/Downstream/in1");
+
+    test.setScalarDefault<int>("/Upstream/in1", 5);
+
+    test.runApplication();
+
+    // discard initial values
+    midstreamIn.readLatest();
+    downstrIn.readLatest();
+    BOOST_TEST(midstreamIn == 6);
+    BOOST_TEST(downstrIn == 7);
+    // test a single value being discarded at the lowest level (Downstream)
+    upstrIn.setAndWrite(12);
+    test.stepApplication();
+    BOOST_TEST(midstreamIn.readNonBlocking());
+    BOOST_TEST(midstreamIn == 13); // first value is coming from Upstream
+    BOOST_TEST(downstrIn.readNonBlocking());
+    BOOST_TEST(downstrIn == 14); // first value is passed through by Midstream
+    BOOST_TEST(downstrIn.readNonBlocking());
+    BOOST_TEST(downstrIn == 7); // correction value coming back from Downstream
+    BOOST_TEST(!downstrIn.readNonBlocking());
+    BOOST_TEST(midstreamIn.readNonBlocking());
+    BOOST_TEST(midstreamIn == 6); // correction value coming back from Midstream
+    BOOST_TEST(!midstreamIn.readNonBlocking());
+    BOOST_TEST(upstrIn.readNonBlocking());
+    BOOST_TEST(upstrIn == 5); // correction value coming back from Upstream
+    BOOST_TEST(!upstrIn.readNonBlocking());
+
+    // test two consecutive values both being discarded at the lowest level
+    // Note: Writing two values into the upstrIn queue will make Upstream process the second value before the correction
+    // for the first value coming from Downstream, because readAny() will process updates in sequences of arrival
+    // (on notification queue). Apart from this it is not well defined (aka subject to race condition) where the second
+    // value from Upstream and the correction of the first value from Downstream cross.
+    upstrIn.setAndWrite(12);
+    upstrIn.setAndWrite(13);
+    test.stepApplication();
+    BOOST_TEST(midstreamIn.readNonBlocking());
+    BOOST_TEST(midstreamIn == 13); // first value is coming from upstream
+    BOOST_TEST(downstrIn.readNonBlocking());
+    BOOST_TEST(downstrIn == 14); // first value is coming from upstream/midstream
+
+    BOOST_TEST(downstrIn.readLatest()); // just observe final state, because intermediate states might be subject
+    BOOST_TEST(downstrIn == 7);         // to race conditions
+    BOOST_TEST(midstreamIn.readLatest());
+    BOOST_TEST(midstreamIn == 6);
+    BOOST_TEST(upstrIn.readLatest());
+    BOOST_TEST(upstrIn == 5);
+
+    // test two consecutive values, only the first being discarded at the lowest level and the second is accepted
+    size_t retry = 0;
+  repeat:
+    upstrIn.setAndWrite(12);
+    upstrIn.setAndWrite(3);
+
+    test.stepApplication();
+
+    // There are two acceptable outcomes of this test:
+    //
+    // 1) Likely: The first value was rejected and the second was accepted
+    //
+    // 2) Unlikely: Both values are rejected. This can happen because the UserInputValidator of midstream needs to use a
+    //    fresh VersionNumber to propagate the rejection of the first value from downstream (otherwise the scenario in
+    //    testBackwardsPropagationTwoDownstream would break). Since that fresh VersionNumber is bigger then the one of
+    //    the second, valid value, it can overwrite the second value and hence that gets effectively rejected.
+    //
+    // Currently, we accept both scenarios but require that the likely scenario is observed (by retrying a couple of
+    // times if we see the second scenario). This problem can be solved by extending the VersionNumber with a
+    // sub-version, so we can both distinguish the corrected from the rejected values as well as find out to which
+    // original VersionNumber the corrected value belongs. Due to the fact that this problem only occurs when writing
+    // inputs faster than the values get rejected and the UserInputValidator being designed for inputs by users, this
+    // problem does not seem to play a big role in real scenarios.
+
+    BOOST_TEST(downstrIn.readLatest()); // just observe final state, to avoid intermediate races
+    BOOST_TEST(midstreamIn.readLatest());
+    if(downstrIn == 7) {
+      BOOST_TEST(upstrIn.readLatest());
+      BOOST_TEST(midstreamIn == 6);
+      BOOST_TEST(upstrIn == 5);
+      if(++retry < 10) {
+        goto repeat;
+      }
+    }
+    BOOST_TEST(!upstrIn.readLatest());
+    BOOST_TEST(downstrIn == 5);
+    BOOST_TEST(midstreamIn == 4);
+    BOOST_TEST(upstrIn == 3);
+  }
+
+  /*********************************************************************************************************************/
+
+} // namespace Tests::testUserInputValidator

--- a/tests/executables_src/testVariableGroup.cc
+++ b/tests/executables_src/testVariableGroup.cc
@@ -16,263 +16,267 @@
 #include <boost/test/included/unit_test.hpp>
 #include <boost/thread.hpp>
 
-using namespace boost::unit_test_framework;
-namespace ctk = ChimeraTK;
+namespace Tests::testVariableGroup {
 
-/*********************************************************************************************************************/
-/* the ApplicationModule for the test is a template of the user type */
+  using namespace boost::unit_test_framework;
+  namespace ctk = ChimeraTK;
 
-struct TestModule : public ctk::ApplicationModule {
-  using ctk::ApplicationModule::ApplicationModule;
+  /*********************************************************************************************************************/
+  /* the ApplicationModule for the test is a template of the user type */
 
-  struct MixedGroup : public ctk::VariableGroup {
-    using ctk::VariableGroup::VariableGroup;
-    ctk::ScalarPushInput<int> consumingPush{this, "feedingPush", "MV/m", "Descrption"};
-    ctk::ScalarPushInput<int> consumingPush2{this, "feedingPush2", "MV/m", "Descrption"};
-    ctk::ScalarPushInput<int> consumingPush3{this, "feedingPush3", "MV/m", "Descrption"};
-    ctk::ScalarPollInput<int> consumingPoll{this, "feedingPoll", "MV/m", "Descrption"};
-    ctk::ScalarPollInput<int> consumingPoll2{this, "feedingPoll2", "MV/m", "Descrption"};
-    ctk::ScalarPollInput<int> consumingPoll3{this, "feedingPoll3", "MV/m", "Descrption"};
+  struct TestModule : public ctk::ApplicationModule {
+    using ctk::ApplicationModule::ApplicationModule;
+
+    struct MixedGroup : public ctk::VariableGroup {
+      using ctk::VariableGroup::VariableGroup;
+      ctk::ScalarPushInput<int> consumingPush{this, "feedingPush", "MV/m", "Descrption"};
+      ctk::ScalarPushInput<int> consumingPush2{this, "feedingPush2", "MV/m", "Descrption"};
+      ctk::ScalarPushInput<int> consumingPush3{this, "feedingPush3", "MV/m", "Descrption"};
+      ctk::ScalarPollInput<int> consumingPoll{this, "feedingPoll", "MV/m", "Descrption"};
+      ctk::ScalarPollInput<int> consumingPoll2{this, "feedingPoll2", "MV/m", "Descrption"};
+      ctk::ScalarPollInput<int> consumingPoll3{this, "feedingPoll3", "MV/m", "Descrption"};
+    };
+    MixedGroup mixedGroup{this, ".", "A group with both push and poll inputs"};
+
+    ctk::ScalarOutput<int> feedingPush{this, "feedingPush", "MV/m", "Descrption"};
+    ctk::ScalarOutput<int> feedingPush2{this, "feedingPush2", "MV/m", "Descrption"};
+    ctk::ScalarOutput<int> feedingPush3{this, "feedingPush3", "MV/m", "Descrption"};
+    ctk::ScalarOutput<int> feedingPoll{this, "feedingPoll", "MV/m", "Descrption"};
+    ctk::ScalarOutput<int> feedingPoll2{this, "feedingPoll2", "MV/m", "Descrption"};
+    ctk::ScalarOutput<int> feedingPoll3{this, "feedingPoll3", "MV/m", "Descrption"};
+
+    void prepare() override {
+      incrementDataFaultCounter(); // foce all outputs to invalid
+      writeAll();
+      decrementDataFaultCounter(); // validity according to input validity
+    }
+
+    void mainLoop() override {}
   };
-  MixedGroup mixedGroup{this, ".", "A group with both push and poll inputs"};
 
-  ctk::ScalarOutput<int> feedingPush{this, "feedingPush", "MV/m", "Descrption"};
-  ctk::ScalarOutput<int> feedingPush2{this, "feedingPush2", "MV/m", "Descrption"};
-  ctk::ScalarOutput<int> feedingPush3{this, "feedingPush3", "MV/m", "Descrption"};
-  ctk::ScalarOutput<int> feedingPoll{this, "feedingPoll", "MV/m", "Descrption"};
-  ctk::ScalarOutput<int> feedingPoll2{this, "feedingPoll2", "MV/m", "Descrption"};
-  ctk::ScalarOutput<int> feedingPoll3{this, "feedingPoll3", "MV/m", "Descrption"};
+  /*********************************************************************************************************************/
+  /* dummy application */
 
-  void prepare() override {
-    incrementDataFaultCounter(); // foce all outputs to invalid
-    writeAll();
-    decrementDataFaultCounter(); // validity according to input validity
+  struct TestApplication : public ctk::Application {
+    TestApplication() : Application("testSuite") {}
+    ~TestApplication() override { shutdown(); }
+
+    TestModule testModule{this, "testModule", "The test module"};
+  };
+
+  /*********************************************************************************************************************/
+  /* test module-wide read/write operations */
+
+  BOOST_AUTO_TEST_CASE(testModuleReadWrite) {
+    std::cout << "**************************************************************************************************\n";
+    std::cout << "*** testModuleReadWrite" << std::endl;
+
+    TestApplication app;
+    ctk::TestFacility test(app);
+
+    test.runApplication();
+
+    // single theaded test
+    app.testModule.mixedGroup.consumingPush = 666;
+    app.testModule.mixedGroup.consumingPush2 = 666;
+    app.testModule.mixedGroup.consumingPush3 = 666;
+    app.testModule.mixedGroup.consumingPoll = 666;
+    app.testModule.mixedGroup.consumingPoll2 = 666;
+    app.testModule.mixedGroup.consumingPoll3 = 666;
+    app.testModule.feedingPush = 18;
+    app.testModule.feedingPush2 = 20;
+    app.testModule.feedingPush3 = 22;
+    app.testModule.feedingPoll = 23;
+    app.testModule.feedingPoll2 = 24;
+    app.testModule.feedingPoll3 = 27;
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 666);
+    app.testModule.writeAll();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 666);
+    app.testModule.readAll();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 20);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 24);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
+
+    app.testModule.readAllNonBlocking();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 20);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 24);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
+
+    app.testModule.feedingPush2 = 30;
+    app.testModule.feedingPoll2 = 33;
+    app.testModule.writeAll();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 20);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 24);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
+    app.testModule.readAllNonBlocking();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
+    app.testModule.readAllNonBlocking();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
+
+    app.testModule.feedingPush = 35;
+    app.testModule.feedingPoll3 = 40;
+    app.testModule.writeAll();
+    app.testModule.feedingPush = 36;
+    app.testModule.feedingPoll3 = 44;
+    app.testModule.writeAll();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
+    app.testModule.readAllNonBlocking();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 35);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
+    app.testModule.readAllNonBlocking();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 36);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
+    app.testModule.readAllNonBlocking();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 36);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
+
+    app.testModule.feedingPush = 45;
+    app.testModule.writeAll();
+    app.testModule.feedingPush = 46;
+    app.testModule.writeAll();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 36);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
+    app.testModule.readAllLatest();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 46);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
+    app.testModule.readAllLatest();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 46);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
   }
 
-  void mainLoop() override {}
-};
+  /*********************************************************************************************************************/
+  /* test trigger by app variable when connecting a polled device register to an app variable */
 
-/*********************************************************************************************************************/
-/* dummy application */
+  BOOST_AUTO_TEST_CASE(testReadAny) {
+    std::cout << "**************************************************************************************************\n";
+    std::cout << "==> testReadAny" << std::endl;
 
-struct TestApplication : public ctk::Application {
-  TestApplication() : Application("testSuite") {}
-  ~TestApplication() override { shutdown(); }
+    TestApplication app;
+    ctk::TestFacility test(app);
 
-  TestModule testModule{this, "testModule", "The test module"};
-};
+    test.runApplication();
 
-/*********************************************************************************************************************/
-/* test module-wide read/write operations */
+    auto group = app.testModule.mixedGroup.readAnyGroup();
 
-BOOST_AUTO_TEST_CASE(testModuleReadWrite) {
-  std::cout << "**************************************************************************************************\n";
-  std::cout << "*** testModuleReadWrite" << std::endl;
+    // single theaded test
+    app.testModule.feedingPush = 0;
+    app.testModule.feedingPush2 = 42;
+    app.testModule.feedingPush3 = 120;
+    app.testModule.feedingPoll = 10;
+    app.testModule.feedingPoll2 = 11;
+    app.testModule.feedingPoll3 = 12;
+    app.testModule.feedingPoll.write();
+    app.testModule.feedingPoll2.write();
+    app.testModule.feedingPoll3.write();
 
-  TestApplication app;
-  ctk::TestFacility test(app);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 0);
 
-  test.runApplication();
+    // test a single write
+    app.testModule.feedingPush2.write();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 0);
+    auto id = group.readAny();
+    BOOST_CHECK(id == app.testModule.mixedGroup.consumingPush2.getId());
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 42);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 10);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 11);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 12);
 
-  // single theaded test
-  app.testModule.mixedGroup.consumingPush = 666;
-  app.testModule.mixedGroup.consumingPush2 = 666;
-  app.testModule.mixedGroup.consumingPush3 = 666;
-  app.testModule.mixedGroup.consumingPoll = 666;
-  app.testModule.mixedGroup.consumingPoll2 = 666;
-  app.testModule.mixedGroup.consumingPoll3 = 666;
-  app.testModule.feedingPush = 18;
-  app.testModule.feedingPush2 = 20;
-  app.testModule.feedingPush3 = 22;
-  app.testModule.feedingPoll = 23;
-  app.testModule.feedingPoll2 = 24;
-  app.testModule.feedingPoll3 = 27;
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 666);
-  app.testModule.writeAll();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 666);
-  app.testModule.readAll();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 20);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 24);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
+    // two more writes
+    app.testModule.feedingPush2 = 666;
+    app.testModule.feedingPush2.write();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 42);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 10);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 11);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 12);
+    id = group.readAny();
+    BOOST_CHECK(id == app.testModule.mixedGroup.consumingPush2.getId());
+    app.testModule.feedingPush3.write();
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 10);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 11);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 12);
+    id = group.readAny();
+    BOOST_CHECK(id == app.testModule.mixedGroup.consumingPush3.getId());
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 666);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 120);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 10);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 11);
+    BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 12);
+  }
 
-  app.testModule.readAllNonBlocking();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 20);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 24);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
-
-  app.testModule.feedingPush2 = 30;
-  app.testModule.feedingPoll2 = 33;
-  app.testModule.writeAll();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 20);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 24);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
-  app.testModule.readAllNonBlocking();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
-  app.testModule.readAllNonBlocking();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
-
-  app.testModule.feedingPush = 35;
-  app.testModule.feedingPoll3 = 40;
-  app.testModule.writeAll();
-  app.testModule.feedingPush = 36;
-  app.testModule.feedingPoll3 = 44;
-  app.testModule.writeAll();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 18);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 27);
-  app.testModule.readAllNonBlocking();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 35);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
-  app.testModule.readAllNonBlocking();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 36);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
-  app.testModule.readAllNonBlocking();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 36);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
-
-  app.testModule.feedingPush = 45;
-  app.testModule.writeAll();
-  app.testModule.feedingPush = 46;
-  app.testModule.writeAll();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 36);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
-  app.testModule.readAllLatest();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 46);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
-  app.testModule.readAllLatest();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 46);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 30);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 22);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 23);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 33);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 44);
-}
-
-/*********************************************************************************************************************/
-/* test trigger by app variable when connecting a polled device register to an app variable */
-
-BOOST_AUTO_TEST_CASE(testReadAny) {
-  std::cout << "**************************************************************************************************\n";
-  std::cout << "==> testReadAny" << std::endl;
-
-  TestApplication app;
-  ctk::TestFacility test(app);
-
-  test.runApplication();
-
-  auto group = app.testModule.mixedGroup.readAnyGroup();
-
-  // single theaded test
-  app.testModule.feedingPush = 0;
-  app.testModule.feedingPush2 = 42;
-  app.testModule.feedingPush3 = 120;
-  app.testModule.feedingPoll = 10;
-  app.testModule.feedingPoll2 = 11;
-  app.testModule.feedingPoll3 = 12;
-  app.testModule.feedingPoll.write();
-  app.testModule.feedingPoll2.write();
-  app.testModule.feedingPoll3.write();
-
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 0);
-
-  // test a single write
-  app.testModule.feedingPush2.write();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 0);
-  auto id = group.readAny();
-  BOOST_CHECK(id == app.testModule.mixedGroup.consumingPush2.getId());
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 42);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 10);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 11);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 12);
-
-  // two more writes
-  app.testModule.feedingPush2 = 666;
-  app.testModule.feedingPush2.write();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 42);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 10);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 11);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 12);
-  id = group.readAny();
-  BOOST_CHECK(id == app.testModule.mixedGroup.consumingPush2.getId());
-  app.testModule.feedingPush3.write();
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 10);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 11);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 12);
-  id = group.readAny();
-  BOOST_CHECK(id == app.testModule.mixedGroup.consumingPush3.getId());
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush == 0);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush2 == 666);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPush3 == 120);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll == 10);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll2 == 11);
-  BOOST_CHECK(app.testModule.mixedGroup.consumingPoll3 == 12);
-}
+} // namespace Tests::testVariableGroup

--- a/tests/executables_src/testVersionPropagation.cc
+++ b/tests/executables_src/testVersionPropagation.cc
@@ -14,192 +14,196 @@
 
 #include <future>
 
-namespace ctk = ChimeraTK;
-using Fixture = FixtureWithPollAndPushInput<false>;
+namespace Tests::testVersionpropagation {
 
-BOOST_FIXTURE_TEST_SUITE(versionPropagation, Fixture)
+  namespace ctk = ChimeraTK;
+  using Fixture = FixtureWithPollAndPushInput<false>;
 
-/*********************************************************************************************************************/
+  BOOST_FIXTURE_TEST_SUITE(versionPropagation, Fixture)
 
-BOOST_AUTO_TEST_CASE(versionPropagation_testPolledRead) {
-  std::cout << "versionPropagation_testPolledRead" << std::endl;
-  auto moduleVersion = application.group1.pollModule.getCurrentVersionNumber();
-  [[maybe_unused]] auto pollVariableVersion = pollVariable2.getVersionNumber();
+  /*********************************************************************************************************************/
 
-  application.group1.outputModule.setCurrentVersionNumber({});
-  outputVariable2.write();
-  pollVariable2.read();
+  BOOST_AUTO_TEST_CASE(versionPropagation_testPolledRead) {
+    std::cout << "versionPropagation_testPolledRead" << std::endl;
+    auto moduleVersion = application.group1.pollModule.getCurrentVersionNumber();
+    [[maybe_unused]] auto pollVariableVersion = pollVariable2.getVersionNumber();
 
-  assert(pollVariable2.getVersionNumber() > pollVariableVersion);
-  BOOST_CHECK(moduleVersion == application.group1.pollModule.getCurrentVersionNumber());
-}
+    application.group1.outputModule.setCurrentVersionNumber({});
+    outputVariable2.write();
+    pollVariable2.read();
 
-/*********************************************************************************************************************/
+    assert(pollVariable2.getVersionNumber() > pollVariableVersion);
+    BOOST_CHECK(moduleVersion == application.group1.pollModule.getCurrentVersionNumber());
+  }
 
-BOOST_AUTO_TEST_CASE(versionPropagation_testPolledReadNonBlocking) {
-  std::cout << "versionPropagation_testPolledReadNonBlocking" << std::endl;
-  auto moduleVersion = application.group1.pollModule.getCurrentVersionNumber();
-  [[maybe_unused]] auto pollVariableVersion = pollVariable2.getVersionNumber();
+  /*********************************************************************************************************************/
 
-  application.group1.outputModule.setCurrentVersionNumber({});
-  outputVariable2.write();
-  pollVariable2.readNonBlocking();
+  BOOST_AUTO_TEST_CASE(versionPropagation_testPolledReadNonBlocking) {
+    std::cout << "versionPropagation_testPolledReadNonBlocking" << std::endl;
+    auto moduleVersion = application.group1.pollModule.getCurrentVersionNumber();
+    [[maybe_unused]] auto pollVariableVersion = pollVariable2.getVersionNumber();
 
-  assert(pollVariable2.getVersionNumber() > pollVariableVersion);
-  BOOST_CHECK(moduleVersion == application.group1.pollModule.getCurrentVersionNumber());
-}
+    application.group1.outputModule.setCurrentVersionNumber({});
+    outputVariable2.write();
+    pollVariable2.readNonBlocking();
 
-/*********************************************************************************************************************/
+    assert(pollVariable2.getVersionNumber() > pollVariableVersion);
+    BOOST_CHECK(moduleVersion == application.group1.pollModule.getCurrentVersionNumber());
+  }
 
-BOOST_AUTO_TEST_CASE(versionPropagation_testPolledReadLatest) {
-  std::cout << "versionPropagation_testPolledReadLatest" << std::endl;
-  auto moduleVersion = application.group1.pollModule.getCurrentVersionNumber();
-  [[maybe_unused]] auto pollVariableVersion = pollVariable2.getVersionNumber();
+  /*********************************************************************************************************************/
 
-  application.group1.outputModule.setCurrentVersionNumber({});
-  outputVariable2.write();
-  pollVariable2.readLatest();
+  BOOST_AUTO_TEST_CASE(versionPropagation_testPolledReadLatest) {
+    std::cout << "versionPropagation_testPolledReadLatest" << std::endl;
+    auto moduleVersion = application.group1.pollModule.getCurrentVersionNumber();
+    [[maybe_unused]] auto pollVariableVersion = pollVariable2.getVersionNumber();
 
-  assert(pollVariable2.getVersionNumber() > pollVariableVersion);
-  BOOST_CHECK(moduleVersion == application.group1.pollModule.getCurrentVersionNumber());
-}
+    application.group1.outputModule.setCurrentVersionNumber({});
+    outputVariable2.write();
+    pollVariable2.readLatest();
 
-/*********************************************************************************************************************/
+    assert(pollVariable2.getVersionNumber() > pollVariableVersion);
+    BOOST_CHECK(moduleVersion == application.group1.pollModule.getCurrentVersionNumber());
+  }
 
-BOOST_AUTO_TEST_CASE(versionPropagation_testPushTypeRead) {
-  std::cout << "versionPropagation_testPushTypeRead" << std::endl;
-  // Make sure we pop out any stray values in the pushInput before test start:
-  CHECK_TIMEOUT(pushVariable.readLatest() == false, 10000);
+  /*********************************************************************************************************************/
 
-  [[maybe_unused]] ctk::VersionNumber nextVersionNumber = {};
-  interrupt.write();
-  pushVariable.read();
-  assert(pushVariable.getVersionNumber() > nextVersionNumber);
-  BOOST_CHECK(application.group1.pushModule.getCurrentVersionNumber() == pushVariable.getVersionNumber());
-}
+  BOOST_AUTO_TEST_CASE(versionPropagation_testPushTypeRead) {
+    std::cout << "versionPropagation_testPushTypeRead" << std::endl;
+    // Make sure we pop out any stray values in the pushInput before test start:
+    CHECK_TIMEOUT(pushVariable.readLatest() == false, 10000);
 
-/*********************************************************************************************************************/
+    [[maybe_unused]] ctk::VersionNumber nextVersionNumber = {};
+    interrupt.write();
+    pushVariable.read();
+    assert(pushVariable.getVersionNumber() > nextVersionNumber);
+    BOOST_CHECK(application.group1.pushModule.getCurrentVersionNumber() == pushVariable.getVersionNumber());
+  }
 
-BOOST_AUTO_TEST_CASE(versionPropagation_testPushTypeReadNonBlocking) {
-  std::cout << "versionPropagation_testPushTypeReadNonBlocking" << std::endl;
-  CHECK_TIMEOUT(pushVariable.readLatest() == false, 10000);
+  /*********************************************************************************************************************/
 
-  auto pushInputVersionNumber = pushVariable.getVersionNumber();
+  BOOST_AUTO_TEST_CASE(versionPropagation_testPushTypeReadNonBlocking) {
+    std::cout << "versionPropagation_testPushTypeReadNonBlocking" << std::endl;
+    CHECK_TIMEOUT(pushVariable.readLatest() == false, 10000);
 
-  // no version change on readNonBlocking false
-  BOOST_CHECK_EQUAL(pushVariable.readNonBlocking(), false);
-  BOOST_CHECK(pushInputVersionNumber == pushVariable.getVersionNumber());
+    auto pushInputVersionNumber = pushVariable.getVersionNumber();
 
-  ctk::VersionNumber nextVersionNumber = {};
-  auto moduleVersion = application.group1.pushModule.getCurrentVersionNumber();
+    // no version change on readNonBlocking false
+    BOOST_CHECK_EQUAL(pushVariable.readNonBlocking(), false);
+    BOOST_CHECK(pushInputVersionNumber == pushVariable.getVersionNumber());
 
-  interrupt.write();
-  CHECK_TIMEOUT(pushVariable.readNonBlocking() == true, 10000);
-  BOOST_CHECK(pushVariable.getVersionNumber() > nextVersionNumber);
+    ctk::VersionNumber nextVersionNumber = {};
+    auto moduleVersion = application.group1.pushModule.getCurrentVersionNumber();
 
-  // readNonBlocking will not propagete the version to the module
-  BOOST_CHECK(application.group1.pushModule.getCurrentVersionNumber() == moduleVersion);
-}
+    interrupt.write();
+    CHECK_TIMEOUT(pushVariable.readNonBlocking() == true, 10000);
+    BOOST_CHECK(pushVariable.getVersionNumber() > nextVersionNumber);
 
-/*********************************************************************************************************************/
+    // readNonBlocking will not propagete the version to the module
+    BOOST_CHECK(application.group1.pushModule.getCurrentVersionNumber() == moduleVersion);
+  }
 
-BOOST_AUTO_TEST_CASE(versionPropagation_testPushTypeReadLatest) {
-  std::cout << "versionPropagation_testPushTypeReadLatest" << std::endl;
-  // Make sure we pop out any stray values in the pushInput before test start:
-  CHECK_TIMEOUT(pushVariable.readLatest() == false, 10000);
+  /*********************************************************************************************************************/
 
-  auto pushInputVersionNumber = pushVariable.getVersionNumber();
+  BOOST_AUTO_TEST_CASE(versionPropagation_testPushTypeReadLatest) {
+    std::cout << "versionPropagation_testPushTypeReadLatest" << std::endl;
+    // Make sure we pop out any stray values in the pushInput before test start:
+    CHECK_TIMEOUT(pushVariable.readLatest() == false, 10000);
 
-  // no version change on readNonBlocking false
-  BOOST_CHECK_EQUAL(pushVariable.readLatest(), false);
-  BOOST_CHECK(pushInputVersionNumber == pushVariable.getVersionNumber());
+    auto pushInputVersionNumber = pushVariable.getVersionNumber();
 
-  ctk::VersionNumber nextVersionNumber = {};
-  auto moduleVersion = application.group1.pushModule.getCurrentVersionNumber();
+    // no version change on readNonBlocking false
+    BOOST_CHECK_EQUAL(pushVariable.readLatest(), false);
+    BOOST_CHECK(pushInputVersionNumber == pushVariable.getVersionNumber());
 
-  interrupt.write();
-  CHECK_TIMEOUT(pushVariable.readLatest() == true, 10000);
-  BOOST_CHECK(pushVariable.getVersionNumber() > nextVersionNumber);
+    ctk::VersionNumber nextVersionNumber = {};
+    auto moduleVersion = application.group1.pushModule.getCurrentVersionNumber();
 
-  // readLatest will not propagete the version to the module
-  BOOST_CHECK(application.group1.pushModule.getCurrentVersionNumber() == moduleVersion);
-}
+    interrupt.write();
+    CHECK_TIMEOUT(pushVariable.readLatest() == true, 10000);
+    BOOST_CHECK(pushVariable.getVersionNumber() > nextVersionNumber);
 
-BOOST_AUTO_TEST_SUITE_END()
+    // readLatest will not propagete the version to the module
+    BOOST_CHECK(application.group1.pushModule.getCurrentVersionNumber() == moduleVersion);
+  }
 
-/*********************************************************************************************************************/
-/*********************************************************************************************************************/
+  BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE()
+  /*********************************************************************************************************************/
+  /*********************************************************************************************************************/
 
-struct ThePushModule : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
+  BOOST_AUTO_TEST_SUITE()
 
-  ChimeraTK::ScalarPushInput<int> pushInput{this, "/theVariable", "", ""};
+  struct ThePushModule : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
 
-  std::promise<void> p;
-  void mainLoop() override { p.set_value(); }
-};
+    ChimeraTK::ScalarPushInput<int> pushInput{this, "/theVariable", "", ""};
 
-struct TheOutputModule : ChimeraTK::ApplicationModule {
-  using ChimeraTK::ApplicationModule::ApplicationModule;
+    std::promise<void> p;
+    void mainLoop() override { p.set_value(); }
+  };
 
-  ChimeraTK::ScalarOutput<int> output{this, "/theVariable", "", ""};
+  struct TheOutputModule : ChimeraTK::ApplicationModule {
+    using ChimeraTK::ApplicationModule::ApplicationModule;
 
-  void prepare() override { output.write(); }
+    ChimeraTK::ScalarOutput<int> output{this, "/theVariable", "", ""};
 
-  std::promise<void> p;
-  void mainLoop() override { p.set_value(); }
-};
+    void prepare() override { output.write(); }
 
-struct TheTestApplication : ChimeraTK::Application {
-  using ChimeraTK::Application::Application;
-  ~TheTestApplication() override { shutdown(); }
+    std::promise<void> p;
+    void mainLoop() override { p.set_value(); }
+  };
 
-  ThePushModule pm{this, "pm", ""};
-  TheOutputModule om{this, "om", ""};
-};
+  struct TheTestApplication : ChimeraTK::Application {
+    using ChimeraTK::Application::Application;
+    ~TheTestApplication() override { shutdown(); }
 
-/*********************************************************************************************************************/
+    ThePushModule pm{this, "pm", ""};
+    TheOutputModule om{this, "om", ""};
+  };
 
-BOOST_AUTO_TEST_CASE(versionPropagation_testSetAndWrite) {
-  std::cout << "versionPropagation_testSetAndWrite" << std::endl;
-  TheTestApplication app("app");
-  ChimeraTK::TestFacility test(app, false);
-  test.runApplication();
-  app.pm.p.get_future().wait();
-  app.om.p.get_future().wait();
+  /*********************************************************************************************************************/
 
-  ChimeraTK::VersionNumber theVersion;
-  app.om.setCurrentVersionNumber(theVersion);
-  app.om.output.setAndWrite(42);
+  BOOST_AUTO_TEST_CASE(versionPropagation_testSetAndWrite) {
+    std::cout << "versionPropagation_testSetAndWrite" << std::endl;
+    TheTestApplication app("app");
+    ChimeraTK::TestFacility test(app, false);
+    test.runApplication();
+    app.pm.p.get_future().wait();
+    app.om.p.get_future().wait();
 
-  app.pm.pushInput.read();
+    ChimeraTK::VersionNumber theVersion;
+    app.om.setCurrentVersionNumber(theVersion);
+    app.om.output.setAndWrite(42);
 
-  BOOST_CHECK(app.pm.getCurrentVersionNumber() == theVersion);
-}
+    app.pm.pushInput.read();
 
-/*********************************************************************************************************************/
+    BOOST_CHECK(app.pm.getCurrentVersionNumber() == theVersion);
+  }
 
-BOOST_AUTO_TEST_CASE(versionPropagation_testWriteIfDifferent) {
-  std::cout << "versionPropagation_testWriteIfDifferent" << std::endl;
-  TheTestApplication app("app");
-  ChimeraTK::TestFacility test(app, false);
-  test.runApplication();
-  app.pm.p.get_future().wait();
-  app.om.p.get_future().wait();
+  /*********************************************************************************************************************/
 
-  ChimeraTK::VersionNumber theVersion;
-  app.om.setCurrentVersionNumber(theVersion);
-  app.om.output.writeIfDifferent(42);
+  BOOST_AUTO_TEST_CASE(versionPropagation_testWriteIfDifferent) {
+    std::cout << "versionPropagation_testWriteIfDifferent" << std::endl;
+    TheTestApplication app("app");
+    ChimeraTK::TestFacility test(app, false);
+    test.runApplication();
+    app.pm.p.get_future().wait();
+    app.om.p.get_future().wait();
 
-  app.pm.pushInput.read();
+    ChimeraTK::VersionNumber theVersion;
+    app.om.setCurrentVersionNumber(theVersion);
+    app.om.output.writeIfDifferent(42);
 
-  BOOST_CHECK(app.pm.getCurrentVersionNumber() == theVersion);
-}
+    app.pm.pushInput.read();
 
-/*********************************************************************************************************************/
+    BOOST_CHECK(app.pm.getCurrentVersionNumber() == theVersion);
+  }
 
-BOOST_AUTO_TEST_SUITE_END()
+  /*********************************************************************************************************************/
 
-/*********************************************************************************************************************/
+  BOOST_AUTO_TEST_SUITE_END()
+
+  /*********************************************************************************************************************/
+
+} // namespace Tests::testVersionpropagation


### PR DESCRIPTION
This helps in two ways:
1. Doxygen is confused if there are multiple class defintions with the
   same name, which happens frequently in tests, e.g. "ModuleA"
2. Doxygen shows rather prominently all classes defined in the tests
   when viewing the Class List, while the important classes are "hidden"
   at first below the ChimeraTK namespace.