### PR TITLE
fix: terminate application while still waitig for init values

### DIFF
--- a/Python/bindings/src/PyApplicationModule.cc
+++ b/Python/bindings/src/PyApplicationModule.cc
@@ -60,9 +60,7 @@ namespace ChimeraTK {
     while(_myThread.attr("is_alive")().cast<bool>()) {
       for(auto& var : getAccessorListRecursive()) {
         auto el{var.getAppAccessorNoType().getHighLevelImplElement()};
-        if(el->getAccessModeFlags().has(AccessMode::wait_for_new_data)) {
-          el->interrupt();
-        }
+        el->interrupt();
       }
 
       _myThread.attr("join")(0.01);

--- a/include/ConstantAccessor.h
+++ b/include/ConstantAccessor.h
@@ -51,7 +51,11 @@ namespace ChimeraTK {
 
     std::list<boost::shared_ptr<ChimeraTK::TransferElement>> getInternalElements() override { return {}; }
 
-    void interrupt() override { TransferElement::interrupt_impl(this->_readQueue); }
+    void interrupt() override {
+      if(TransferElement::_accessModeFlags.has(AccessMode::wait_for_new_data)) {
+        TransferElement::interrupt_impl(this->_readQueue);
+      }
+    }
 
    protected:
     std::vector<UserType> _value;

--- a/include/FanOut.h
+++ b/include/FanOut.h
@@ -113,14 +113,10 @@ namespace ChimeraTK {
   template<typename UserType>
   void FanOut<UserType>::interrupt() {
     if(_impl) {
-      if(_impl->getAccessModeFlags().has(AccessMode::wait_for_new_data)) {
-        _impl->interrupt();
-      }
+      _impl->interrupt();
     }
     for(auto& slave : _slaves) {
-      if(slave->getAccessModeFlags().has(AccessMode::wait_for_new_data)) {
-        slave->interrupt();
-      }
+      slave->interrupt();
     }
   }
 

--- a/src/ApplicationModule.cc
+++ b/src/ApplicationModule.cc
@@ -68,9 +68,7 @@ namespace ChimeraTK {
         // if thread is not yet joined, send interrupt() to all variables.
         for(auto& var : getAccessorListRecursive()) {
           auto el{var.getAppAccessorNoType().getHighLevelImplElement()};
-          if(el->getAccessModeFlags().has(AccessMode::wait_for_new_data)) {
-            el->interrupt();
-          }
+          el->interrupt();
         }
         // it may not suffice to send interrupt() once, as the exception might get
         // overwritten in the queue, thus we repeat this until the thread was

--- a/src/TriggerFanOut.cc
+++ b/src/TriggerFanOut.cc
@@ -40,9 +40,7 @@ namespace ChimeraTK {
     try {
       if(_thread.joinable()) {
         _thread.interrupt();
-        if(_externalTrigger->getAccessModeFlags().has(AccessMode::wait_for_new_data)) {
-          _externalTrigger->interrupt();
-        }
+        _externalTrigger->interrupt();
         _thread.join();
       }
       assert(!_thread.joinable());


### PR DESCRIPTION
When terminating the application while poll-type inputs are waiting for initial values from other ApplicationModules, we need to interrupt() those blocking initial-value reads.

This requires a corresponding change in DeviceAccess to allow calling interrupt() without wait_for_new_data.

Note: This requires https://github.com/ChimeraTK/DeviceAccess/pull/456