### PR TITLE
fix: python paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,12 +145,12 @@ install(DIRECTORY ${${PROJECT_NAME}_INCLUDE_DIRS} DESTINATION include/ChimeraTK/
 if(${pybind11_FOUND})
   # install Python modules to correct platform-dependent directory (if installing to system prefix)
   if("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr" OR "${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local")
-    set(python_install_path "${Python_SITEARCH}/ChimeraTK/ApplicationCore${${PROJECT_NAME}_SOVERSION}")
+    set(python_install_path "${Python_SITEARCH}")
   else()
-    set(python_install_path "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/ChimeraTK/ApplicationCore${${PROJECT_NAME}_SOVERSION}")
+    set(python_install_path "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
   endif()
 
-  install(TARGETS PyApplicationCore LIBRARY DESTINATION ${python_install_path})
+  install(TARGETS PyApplicationCore LIBRARY DESTINATION "${python_install_path}/ChimeraTK/ApplicationCore${${PROJECT_NAME}_SOVERSION}")
 
   if((NOT ${CMAKE_BUILD_TYPE} STREQUAL "asan") AND(NOT ${CMAKE_BUILD_TYPE} STREQUAL "tsan"))
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PyApplicationCore.pyi DESTINATION ${python_install_path})

--- a/Python/manager/PythonModuleManager.cc
+++ b/Python/manager/PythonModuleManager.cc
@@ -54,8 +54,7 @@ namespace ChimeraTK {
         for p in sys.path:
           new_paths.append(os.path.join(p, 'ChimeraTK', 'ApplicationCore'+so_version))
 
-        sys.path.extend(new_paths)
-        print(sys.path)
+        sys.path = new_paths + sys.path # prepend so old system libraries are not found first
       )",
           py::globals(), locals);
     }


### PR DESCRIPTION
- PyApplicationCore.pyi must not be in versioned directory, so it is found by the IDE
- prepend the versioned directories so old PyApplicationBindings in the system are not found first
- remove debug output
