### PR TITLE
feat: allow turning off version propagation from input

### DIFF
--- a/include/MetaDataPropagatingRegisterDecorator.h
+++ b/include/MetaDataPropagatingRegisterDecorator.h
@@ -63,11 +63,13 @@ namespace ChimeraTK {
     [[nodiscard]] DataValidity getTargetValidity() const { return _target->dataValidity(); }
 
     void disableDataValidityPropagation() { _disableDataValidityPropagation = true; }
+    void disableVersionNumberPropagation() { _disableVersionNumberPropagation = true; }
 
    protected:
     EntityOwner* _owner;
     VariableDirection _direction;
     bool _disableDataValidityPropagation = false;
+    bool _disableVersionNumberPropagation = false;
 
     using TransferElement::_dataValidity;
     using NDRegisterAccessorDecorator<T>::_target;

--- a/include/VariableNetworkNode.h
+++ b/include/VariableNetworkNode.h
@@ -179,9 +179,13 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
-  /** Special tag to designate that a not should not automatically take over DataValidity of its owning module.
+  /** Special tag to designate that an output should not automatically take over DataValidity of its owning module.
    *  Use e.g. for a StatusOutput which should indicate errors. */
   constexpr auto explicitDataValidityTag = "_ChimeraTK_NodeHasExplicitDataValidity";
+
+  /** Special tag to designate that a push-input should not propagate VersionNumber updates to its owning module.
+   *  Use if a poll-input is not adequate. */
+  constexpr auto independentVersionTag = "_ChimeraTK_NodeHasIndependentVersion";
 
   /********************************************************************************************************************/
 
@@ -277,6 +281,9 @@ namespace ChimeraTK {
         boost::make_shared<MetaDataPropagatingRegisterDecorator<UserType>>(impl, getOwningModule(), getDirection());
     if(pdata->tags.find(explicitDataValidityTag) != pdata->tags.end()) {
       decorated->disableDataValidityPropagation();
+    }
+    if(pdata->tags.find(independentVersionTag) != pdata->tags.end()) {
+      decorated->disableVersionNumberPropagation();
     }
 
     getAppAccessor<UserType>().replace(decorated);

--- a/src/MetaDataPropagatingRegisterDecorator.cc
+++ b/src/MetaDataPropagatingRegisterDecorator.cc
@@ -14,7 +14,8 @@ namespace ChimeraTK {
     NDRegisterAccessorDecorator<T, T>::doPostRead(type, hasNewData);
 
     // update the version number
-    if(_target->getAccessModeFlags().has(AccessMode::wait_for_new_data) && type == TransferType::read) {
+    if(!_disableVersionNumberPropagation && _target->getAccessModeFlags().has(AccessMode::wait_for_new_data) &&
+        type == TransferType::read) {
       _owner->setCurrentVersionNumber(this->getVersionNumber());
     }
 


### PR DESCRIPTION
to module, via special tag.

Important use case is PushInputWB, since I cannot convert it into PollInput.