### PR TITLE
Mhier/fix-tsan-issue

### DIFF
--- a/src/ConnectionMaker.cc
+++ b/src/ConnectionMaker.cc
@@ -989,8 +989,8 @@ namespace ChimeraTK {
             return consumer.getType() == NodeType::Device &&
                 consumer.getTags().contains(ChimeraTK::SystemTags::reverseRecovery);
           });
-          network.consumers.remove(*reverseConsumer);
           network.feeder = *reverseConsumer;
+          network.consumers.remove(*reverseConsumer);
         }
         else {
           network.feeder = VariableNetworkNode(network.valueType, true, network.valueLength);


### PR DESCRIPTION
This is an actual issue reported by TSAN. `reverseConsumer` is an
iterator pointing to an element on the std::list, which was first
removed from the list and then copied to network.feeder. Removing the
element from the list invalidates the iterator and frees the element.