### PR TITLE
jgeorg/feat missing new accessors

### DIFF
--- a/Python/bindings/src/PyArrayAccessor.cc
+++ b/Python/bindings/src/PyArrayAccessor.cc
@@ -288,6 +288,18 @@ namespace ChimeraTK {
               AccessorTypeTag<ArrayOutputPushRB>{}, type, &owner, name, unit, nElements, description);
         },
         py::return_value_policy::reference, "");
+
+    /**
+     *  ArrayOutputReverseRecovery
+     */
+    m.def(
+        "ArrayOutputReverseRecovery",
+        [](ChimeraTK::DataType type, VariableGroup& owner, const std::string& name, const std::string& unit,
+            size_t nElements, const std::string& description) {
+          return dynamic_cast<PyOwningObject&>(owner).make_child<PyArrayAccessor>(
+              AccessorTypeTag<ArrayOutputReverseRecovery>{}, type, &owner, name, unit, nElements, description);
+        },
+        py::return_value_policy::reference, "");
   }
 
   /********************************************************************************************************************/

--- a/Python/bindings/src/PyScalarAccessor.cc
+++ b/Python/bindings/src/PyScalarAccessor.cc
@@ -268,6 +268,18 @@ namespace ChimeraTK {
               AccessorTypeTag<ScalarOutputPushRB>{}, type, &owner, name, unit, description);
         },
         py::return_value_policy::reference, "");
+
+    /**
+     * ScalarOutputReverseRecovery
+     */
+    m.def(
+        "ScalarOutputReverseRecovery",
+        [](ChimeraTK::DataType type, VariableGroup& owner, const std::string& name, const std::string& unit,
+            const std::string& description) {
+          return dynamic_cast<PyOwningObject&>(owner).make_child<PyScalarAccessor>(
+              AccessorTypeTag<ScalarOutputReverseRecovery>{}, type, &owner, name, unit, description);
+        },
+        py::return_value_policy::reference, "");
   }
 
   /********************************************************************************************************************/

--- a/include/ArrayAccessor.h
+++ b/include/ArrayAccessor.h
@@ -123,7 +123,7 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
-  /** Deprecated, do not use. Use ArrayOutpuPushRB instead (works identically). */
+  /** Deprecated, do not use. Use ArrayOutputPushRB instead (works identically). */
   template<typename UserType>
   struct ArrayOutputRB : public ArrayAccessor<UserType> {
     [[deprecated]] ArrayOutputRB(Module* owner, const std::string& name, std::string unit, size_t nElements,
@@ -136,8 +136,8 @@ namespace ChimeraTK {
 
   template<typename UserType>
   struct ArrayOutputReverseRecovery : public ArrayAccessor<UserType> {
-    [[deprecated]] ArrayOutputReverseRecovery(Module* owner, const std::string& name, std::string unit,
-        size_t nElements, const std::string& description, const std::unordered_set<std::string>& tags = {});
+    ArrayOutputReverseRecovery(Module* owner, const std::string& name, std::string unit, size_t nElements,
+        const std::string& description, const std::unordered_set<std::string>& tags = {});
     ArrayOutputReverseRecovery() = default;
     using ArrayAccessor<UserType>::operator=;
   };


### PR DESCRIPTION
Add the two new accessors to the python bindings

- **feat(Python): Bind new reverse recovery accessors**
- **fix: Remove wrong [[deprecated]] tag**
