### PR TITLE
feat: Log the parse error

### DIFF
--- a/Modules/include/ConfigReader.h
+++ b/Modules/include/ConfigReader.h
@@ -149,7 +149,7 @@ namespace ChimeraTK {
     std::unique_ptr<ModuleTree> _moduleTree;
 
     /** throw a parsing error with more information */
-    void parsingError(const std::string& message);
+    void parsingError(const std::string& message) noexcept;
 
     /** Class holding the value and the accessor for one configuration variable */
     template<typename T>

--- a/Modules/src/ConfigReader.cc
+++ b/Modules/src/ConfigReader.cc
@@ -5,6 +5,8 @@
 #include "TestFacility.h"
 #include "VariableGroup.h"
 
+#include <ChimeraTK/Exception.h>
+
 #include <libxml++/libxml++.h>
 
 #include <filesystem>
@@ -392,8 +394,13 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
-  void ConfigReader::parsingError(const std::string& message) {
-    throw ChimeraTK::logic_error("ConfigReader: Error parsing the config file '" + _fileName + "': " + message);
+  void ConfigReader::parsingError(const std::string& message) noexcept {
+    try {
+      throw ChimeraTK::logic_error("ConfigReader: Error parsing the config file '" + _fileName + "': " + message);
+    }
+    catch(ChimeraTK::logic_error&) {
+      std::terminate();
+    }
   }
 
   /********************************************************************************************************************/


### PR DESCRIPTION
Otherwise we will be left with a message saying "There is a bug in the
application because it did not call shutdown" since the throw will
happen in the Application's constructor, without any means for learning
about the actual error. This is especially annoying with the generic
server.
