### PR TITLE
fix: Rework the ReverseRecoveryDecorator

### DIFF
--- a/include/ExceptionHandlingDecorator.h
+++ b/include/ExceptionHandlingDecorator.h
@@ -22,8 +22,8 @@ namespace ChimeraTK {
      * All information to get the DeviceModule and to create a recovery accessor are
      * taken from the VariableNetworkNode.
      */
-    ExceptionHandlingDecorator(
-        boost::shared_ptr<ChimeraTK::NDRegisterAccessor<UserType>> accessor, const VariableNetworkNode& networkNode);
+    ExceptionHandlingDecorator(boost::shared_ptr<ChimeraTK::NDRegisterAccessor<UserType>> accessor,
+        const VariableNetworkNode& networkNode, boost::shared_ptr<RecoveryHelper> recoveryHelper);
 
     void doPreWrite(TransferType type, VersionNumber versionNumber) override;
 

--- a/include/FanOut.h
+++ b/include/FanOut.h
@@ -115,6 +115,7 @@ namespace ChimeraTK {
     if(_impl) {
       _impl->interrupt();
     }
+
     for(auto& slave : _slaves) {
       slave->interrupt();
     }

--- a/include/RecoveryHelper.h
+++ b/include/RecoveryHelper.h
@@ -16,7 +16,7 @@ namespace ChimeraTK {
     enum class Direction { fromDevice, toDevice };
     boost::shared_ptr<TransferElement> accessor;
     VersionNumber versionNumber;
-    uint64_t writeOrder;
+    uint64_t writeOrder{0};
     bool wasWritten{false};
     cppext::future_queue<void> notificationQueue;
     Direction recoveryDirection{Direction::toDevice};
@@ -24,6 +24,8 @@ namespace ChimeraTK {
     explicit RecoveryHelper(boost::shared_ptr<TransferElement> a, VersionNumber v = VersionNumber(nullptr),
         uint64_t order = 0, Direction direction = Direction::toDevice)
     : accessor(std::move(a)), versionNumber(v), writeOrder(order), recoveryDirection(direction) {}
+
+    RecoveryHelper() = default;
   };
 
 } // end of namespace ChimeraTK

--- a/include/ReverseRecoveryDecorator.h
+++ b/include/ReverseRecoveryDecorator.h
@@ -2,25 +2,29 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include "ExceptionHandlingDecorator.h"
+#include "RecoveryHelper.h"
 
 #include <ChimeraTK/Exception.h>
+#include <ChimeraTK/NDRegisterAccessorDecorator.h>
 
 namespace ChimeraTK {
 
   template<typename UserType>
-  class ReverseRecoveryDecorator : public ChimeraTK::ExceptionHandlingDecorator<UserType> {
+  class ReverseRecoveryDecorator : public ChimeraTK::NDRegisterAccessorDecorator<UserType> {
    public:
-    ReverseRecoveryDecorator(
-        boost::shared_ptr<ChimeraTK::NDRegisterAccessor<UserType>> accessor, const VariableNetworkNode& networkNode);
+    ReverseRecoveryDecorator(boost::shared_ptr<ChimeraTK::NDRegisterAccessor<UserType>> accessor,
+        boost::shared_ptr<RecoveryHelper> recoveryHelper);
+
+    void doPreRead(TransferType) override;
+    void doPostRead(TransferType, bool updateBuffer) override;
 
     void interrupt() override;
 
     void setInReadAnyGroup(ReadAnyGroup* rag) override;
 
    protected:
-    using ExceptionHandlingDecorator<UserType>::_recoveryHelper;
-    using ExceptionHandlingDecorator<UserType>::_target;
+    boost::shared_ptr<RecoveryHelper> _recoveryHelper;
+    using ChimeraTK::NDRegisterAccessorDecorator<UserType>::_target;
   };
 
   DECLARE_TEMPLATE_FOR_CHIMERATK_USER_TYPES(ReverseRecoveryDecorator);

--- a/include/ThreadedFanOut.h
+++ b/include/ThreadedFanOut.h
@@ -96,8 +96,7 @@ namespace ChimeraTK {
       deactivate();
     }
     catch(ChimeraTK::logic_error& e) {
-      std::cerr << e.what() << std::endl;
-      std::exit(1);
+      std::terminate();
     }
   }
 

--- a/src/ConnectionMaker.cc
+++ b/src/ConnectionMaker.cc
@@ -716,11 +716,13 @@ namespace ChimeraTK {
       accessor = _app.getTestableMode().decorate(accessor, detail::TestableMode::DecoratorType::READ);
     }
 
+    auto recoveryHelper = boost::make_shared<RecoveryHelper>();
+
     if(node.getDirection().dir == VariableDirection::consuming && node.getDirection().withReturn) {
-      return boost::make_shared<ReverseRecoveryDecorator<UserType>>(accessor, node);
+      accessor = boost::make_shared<ReverseRecoveryDecorator<UserType>>(accessor, recoveryHelper);
     }
 
-    return boost::make_shared<ExceptionHandlingDecorator<UserType>>(accessor, node);
+    return boost::make_shared<ExceptionHandlingDecorator<UserType>>(accessor, node, recoveryHelper);
   }
 
   /********************************************************************************************************************/

--- a/src/ReverseRecoveryDecorator.cc
+++ b/src/ReverseRecoveryDecorator.cc
@@ -7,8 +7,9 @@ namespace ChimeraTK {
 
   template<typename UserType>
   ReverseRecoveryDecorator<UserType>::ReverseRecoveryDecorator(
-      boost::shared_ptr<ChimeraTK::NDRegisterAccessor<UserType>> accessor, const VariableNetworkNode& networkNode)
-  : ExceptionHandlingDecorator<UserType>(std::move(accessor), networkNode) {
+      boost::shared_ptr<ChimeraTK::NDRegisterAccessor<UserType>> accessor,
+      boost::shared_ptr<RecoveryHelper> recoveryHelper)
+  : ChimeraTK::NDRegisterAccessorDecorator<UserType>(std::move(accessor)), _recoveryHelper(std::move(recoveryHelper)) {
     // Check if we are wrapping a push-type variable and forbid that
     if(TransferElement::getAccessModeFlags().has(AccessMode::wait_for_new_data)) {
       throw ChimeraTK::logic_error("Cannot use reverse recovery on push-type input");
@@ -21,7 +22,6 @@ namespace ChimeraTK {
     _recoveryHelper->recoveryDirection = RecoveryHelper::Direction::fromDevice;
 
     // Set the read queue as continuation of the notification queue
-    // The continuation will just trigger a read on the target accessor
     this->_readQueue =
         _recoveryHelper->notificationQueue.template then<void>([&, this]() { _target->read(); }, std::launch::deferred);
   }
@@ -40,6 +40,33 @@ namespace ChimeraTK {
     // Skip flagging our target as being in a ReadAnyGroup (it isn't since we replace the readQueue with our own)
     // NOLINTNEXTLINE(bugprone-parent-virtual-call)
     NDRegisterAccessor<UserType>::setInReadAnyGroup(rag);
+  }
+
+  /********************************************************************************************************************/
+
+  template<typename UserType>
+  void ReverseRecoveryDecorator<UserType>::doPreRead(TransferType) {}
+
+  /********************************************************************************************************************/
+
+  template<typename UserType>
+  void ReverseRecoveryDecorator<UserType>::doPostRead(TransferType, bool updateBuffer) {
+    // Do the same as NDRegisterAccessorDecorator::doPostRead() but without delegating to the target. We must
+    // not delegate, because we did not call preRead() and the entire operation is executed inside the
+    // continuation of the readQueue (see constructor implementation).
+    _target->setActiveException(this->_activeException);
+
+    // Decorators have to copy meta data even if updateDataBuffer is false
+    this->_dataValidity = _target->dataValidity();
+    this->_versionNumber = _target->getVersionNumber();
+
+    if(!updateBuffer) {
+      return;
+    }
+
+    for(size_t i = 0; i < _target->getNumberOfChannels(); ++i) {
+      this->buffer_2D[i].swap(_target->accessChannel(i));
+    }
   }
 
   /********************************************************************************************************************/

--- a/tests/config/taggedBitRange.xlmap
+++ b/tests/config/taggedBitRange.xlmap
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<logicalNameMap>
+  <redirectedRegister name="bit0">
+    <targetDevice>baseDevice</targetDevice>
+    <targetRegister>readWrite</targetRegister>
+    <plugin name="bitRange">
+      <parameter name="shift">0</parameter>
+      <parameter name="numberOfBits">1</parameter>
+    </plugin>
+    <plugin name="tagModifier">
+      <parameter name="set">_ChimeraTK_DeviceRegister_reverseRecovery</parameter>
+    </plugin>
+    <plugin name="typeHintModifier">
+      <parameter name="type">Boolean</parameter>
+    </plugin>
+  </redirectedRegister>
+
+  <redirectedRegister name="bit1">
+    <targetDevice>baseDevice</targetDevice>
+    <targetRegister>readWrite</targetRegister>
+    <plugin name="bitRange">
+      <parameter name="shift">1</parameter>
+      <parameter name="numberOfBits">1</parameter>
+    </plugin>
+    <plugin name="tagModifier">
+      <parameter name="set">_ChimeraTK_DeviceRegister_reverseRecovery</parameter>
+    </plugin>
+    <plugin name="typeHintModifier">
+      <parameter name="type">Boolean</parameter>
+    </plugin>
+  </redirectedRegister>
+  <redirectedRegister name="bit2">
+    <targetDevice>baseDevice</targetDevice>
+    <targetRegister>readWrite</targetRegister>
+    <plugin name="bitRange">
+      <parameter name="shift">2</parameter>
+      <parameter name="numberOfBits">1</parameter>
+    </plugin>
+    <plugin name="tagModifier">
+      <parameter name="set">_ChimeraTK_DeviceRegister_reverseRecovery</parameter>
+    </plugin>
+    <plugin name="typeHintModifier">
+      <parameter name="type">Boolean</parameter>
+    </plugin>
+  </redirectedRegister>
+
+  <redirectedRegister name="bit3">
+    <targetDevice>baseDevice</targetDevice>
+    <targetRegister>readWrite</targetRegister>
+    <plugin name="bitRange">
+      <parameter name="shift">3</parameter>
+      <parameter name="numberOfBits">1</parameter>
+    </plugin>
+    <plugin name="tagModifier">
+      <parameter name="set">_ChimeraTK_DeviceRegister_reverseRecovery</parameter>
+    </plugin>
+    <plugin name="typeHintModifier">
+      <parameter name="type">Boolean</parameter>
+    </plugin>
+  </redirectedRegister>
+
+  <redirectedRegister name="bit4">
+    <targetDevice>baseDevice</targetDevice>
+    <targetRegister>readWrite</targetRegister>
+    <plugin name="bitRange">
+      <parameter name="shift">4</parameter>
+      <parameter name="numberOfBits">1</parameter>
+    </plugin>
+    <plugin name="tagModifier">
+      <parameter name="set">_ChimeraTK_DeviceRegister_reverseRecovery</parameter>
+    </plugin>
+    <plugin name="typeHintModifier">
+      <parameter name="type">Boolean</parameter>
+    </plugin>
+  </redirectedRegister>
+  <redirectedRegister name="bit5">
+    <targetDevice>baseDevice</targetDevice>
+    <targetRegister>readWrite</targetRegister>
+    <plugin name="bitRange">
+      <parameter name="shift">5</parameter>
+      <parameter name="numberOfBits">1</parameter>
+    </plugin>
+    <plugin name="tagModifier">
+      <parameter name="set">_ChimeraTK_DeviceRegister_reverseRecovery</parameter>
+    </plugin>
+    <plugin name="typeHintModifier">
+      <parameter name="type">Boolean</parameter>
+    </plugin>
+  </redirectedRegister>
+
+
+  <redirectedRegister name="bit6">
+    <targetDevice>baseDevice</targetDevice>
+    <targetRegister>readWrite</targetRegister>
+    <plugin name="bitRange">
+      <parameter name="shift">6</parameter>
+      <parameter name="numberOfBits">1</parameter>
+    </plugin>
+    <plugin name="tagModifier">
+      <parameter name="set">_ChimeraTK_DeviceRegister_reverseRecovery</parameter>
+    </plugin>
+    <plugin name="typeHintModifier">
+      <parameter name="type">Boolean</parameter>
+    </plugin>
+  </redirectedRegister>
+  <redirectedRegister name="bit7">
+    <targetDevice>baseDevice</targetDevice>
+    <targetRegister>readWrite</targetRegister>
+    <plugin name="bitRange">
+      <parameter name="shift">7</parameter>
+      <parameter name="numberOfBits">1</parameter>
+    </plugin>
+    <plugin name="tagModifier">
+      <parameter name="set">_ChimeraTK_DeviceRegister_reverseRecovery</parameter>
+    </plugin>
+    <plugin name="typeHintModifier">
+      <parameter name="type">Boolean</parameter>
+    </plugin>
+  </redirectedRegister>
+  <redirectedRegister name="bit8">
+    <targetDevice>baseDevice</targetDevice>
+    <targetRegister>readWrite</targetRegister>
+    <plugin name="bitRange">
+      <parameter name="shift">8</parameter>
+      <parameter name="numberOfBits">1</parameter>
+    </plugin>
+    <plugin name="tagModifier">
+      <parameter name="set">_ChimeraTK_DeviceRegister_reverseRecovery</parameter>
+    </plugin>
+    <plugin name="typeHintModifier">
+      <parameter name="type">Boolean</parameter>
+    </plugin>
+  </redirectedRegister>
+  <redirectedRegister name="bit9">
+    <targetDevice>baseDevice</targetDevice>
+    <targetRegister>readWrite</targetRegister>
+    <plugin name="bitRange">
+      <parameter name="shift">9</parameter>
+      <parameter name="numberOfBits">1</parameter>
+    </plugin>
+    <plugin name="tagModifier">
+      <parameter name="set">_ChimeraTK_DeviceRegister_reverseRecovery</parameter>
+    </plugin>
+    <plugin name="typeHintModifier">
+      <parameter name="type">Boolean</parameter>
+    </plugin>
+  </redirectedRegister>
+
+</logicalNameMap>

--- a/tests/config/testTagged.dmap
+++ b/tests/config/testTagged.dmap
@@ -1,2 +1,3 @@
 baseDevice (sharedMemoryDummy?map=baseDevice.map)
 taggedDevice (logicalNameMap?map=tagged.xlmap)
+bitMappedDevice (logicalNameMap?map=taggedBitRange.xlmap)


### PR DESCRIPTION
Fixes various deadlocks with the LNM BitRange accessor, due to calling
read() while already in a read transfer.

Only decorate the write direction (as direct pass-through). For the read
direction, implement a simple async read scheme that can be triggered
from the DeviceManager when required. Also split the
ReverseRecoveryDecorator from the ExceptionHandlingDecorator and just
put the latter on top of the former
