### PR TITLE
feat: control log level by env variable

### DIFF
--- a/Python/bindings/src/PyLogger.cc
+++ b/Python/bindings/src/PyLogger.cc
@@ -12,13 +12,30 @@ namespace ChimeraTK {
   void PyLogger::bind(py::module& mod) {
     // Logger::Severity
     py::class_<Logger> mPythonLogger(mod, "Logger", py::module_local());
-    py::enum_<Logger::Severity>(mPythonLogger, "Severity", py::module_local())
-        .value("trace", Logger::Severity::trace)
-        .value("debug", Logger::Severity::debug)
-        .value("info", Logger::Severity::info)
-        .value("warning", Logger::Severity::warning)
-        .value("error", Logger::Severity::error)
+    // Register the inner enum Value first, so Severity can reference it
+    py::enum_<Logger::Severity::Value>(mPythonLogger, "_SeverityValue", py::module_local(), py::arithmetic())
+        .value("trace", Logger::Severity::Value::trace)
+        .value("debug", Logger::Severity::Value::debug)
+        .value("info", Logger::Severity::Value::info)
+        .value("warning", Logger::Severity::Value::warning)
+        .value("error", Logger::Severity::Value::error)
         .export_values();
+
+    py::class_<Logger::Severity> mSeverity(mPythonLogger, "Severity", py::module_local());
+    mSeverity
+        .def_property_readonly_static(
+            "trace", [](py::object) { return Logger::Severity(Logger::Severity::Value::trace); })
+        .def_property_readonly_static(
+            "debug", [](py::object) { return Logger::Severity(Logger::Severity::Value::debug); })
+        .def_property_readonly_static(
+            "info", [](py::object) { return Logger::Severity(Logger::Severity::Value::info); })
+        .def_property_readonly_static(
+            "warning", [](py::object) { return Logger::Severity(Logger::Severity::Value::warning); })
+        .def_property_readonly_static(
+            "error", [](py::object) { return Logger::Severity(Logger::Severity::Value::error); })
+        .def("__repr__", [](const Logger::Severity& s) { return std::string(s.toString()); })
+        .def("__eq__", [](const Logger::Severity& a, const Logger::Severity& b) { return a == b; })
+        .def("__ne__", [](const Logger::Severity& a, const Logger::Severity& b) { return a != b; });
 
     /**
      * Logger::StreamProxy

--- a/include/Application.h
+++ b/include/Application.h
@@ -119,13 +119,6 @@ namespace ChimeraTK {
      */
     static void registerThread(const std::string& name);
 
-    /**
-     * Enable debug output for the ConnectionMaker. Note, the debug output will have the logger severity "trace" and
-     * hence will not be visible by default. Enable trace output as follows:
-     *   Logger::getInstance().setMinSeverity(Logger::Severity::trace);
-     */
-    void debugMakeConnections() { _enableDebugMakeConnections = true; }
-
     ModuleType getModuleType() const override { return ModuleType::ModuleGroup; }
 
     std::string getQualifiedName() const override { return "/" + _name; }
@@ -140,13 +133,6 @@ namespace ChimeraTK {
     void enableVariableDebugging(const VariableNetworkNode& node) {
       _debugMode_variableList.insert(node.getUniqueId());
     }
-
-    /**
-     * Enable debug output for lost data. This will print to stdout every time data is lost in internal queues as it is
-     * counted with the DataLossCounter module. Do not enable in production environments. Do not call after
-     * initialisation phase of application.
-     */
-    void enableDebugDataLoss() { _debugDataLoss = true; }
 
     /**
      * Increment counter for how many write() operations have overwritten unread data. This function is normally not
@@ -227,9 +213,6 @@ namespace ChimeraTK {
     /** Flag whether run() has been called already, to make sure it doesn't get called twice. */
     bool _runCalled{false};
 
-    /** Flag if debug output is enabled for creation of the variable connections */
-    bool _enableDebugMakeConnections{false};
-
     /** Map from ProcessArray uniqueId to the variable ID for control system
      * variables. This is required for the TestFacility. */
     std::map<size_t, size_t> _pvIdMap;
@@ -244,9 +227,6 @@ namespace ChimeraTK {
 
     /** Counter for how many write() operations have overwritten unread data */
     std::atomic<size_t> _dataLossCounter{0};
-
-    /** Flag whether to debug data loss (as counted with the data loss counter). */
-    bool _debugDataLoss{false};
 
     /** Life-cycle state of the application */
     std::atomic<LifeCycleState> _lifeCycleState{LifeCycleState::initialisation};

--- a/include/ConnectionMaker.h
+++ b/include/ConnectionMaker.h
@@ -18,8 +18,6 @@ namespace ChimeraTK {
    public:
     explicit NetworkVisitor(Application& app) : _app(app) {}
 
-    void setDebugConnections(bool enable) { _debugConnections = enable; }
-
     /**
      * @brief Helper predicate to put ProcessVariableProxies into std::set
      */
@@ -50,7 +48,6 @@ namespace ChimeraTK {
     };
     std::set<std::string> _triggerNetworks{};
     std::map<std::string, NetworkInformation> _networks{};
-    bool _debugConnections{false};
 
     NetworkInformation checkNetwork(Model::ProcessVariableProxy& proxy);
     void finaliseNetwork(NetworkInformation& net);

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -4,8 +4,10 @@
 
 #include <ChimeraTK/cppext/future_queue.hpp>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/thread.hpp>
 
+#include <expected>
 #include <sstream>
 
 namespace ChimeraTK {
@@ -24,7 +26,31 @@ namespace ChimeraTK {
      * if the application is terminated immediately after sending a message to the log. Fatal errors shall be printed
      * directly to std::cerr before terminating the application.
      */
-    enum class Severity { trace, debug, info, warning, error };
+    class Severity {
+     public:
+      enum Value { trace, debug, info, warning, error };
+
+      // NOLINTNEXTLINE(google-explicit-constructor)
+      constexpr Severity(const Value& value) : _value(value) {}
+
+      // NOLINTNEXTLINE(google-explicit-constructor)
+      [[nodiscard]] constexpr operator Value() { return _value; }
+
+      /// Convert Severity into string
+      [[nodiscard]] constexpr std::string_view toString() const;
+
+      [[nodiscard]] constexpr auto operator<=>(const Severity& other) const = default;
+      [[nodiscard]] constexpr auto operator<=>(const Severity::Value& other) const { return _value <=> other; }
+
+      /**
+       * Set Severity from string. If the string does not represent a Severity, an error string explaining which values
+       * are valid is returned (meant to be passed on to humans only).
+       **/
+      constexpr static std::expected<Logger::Severity, std::string> fromString(const std::string& string);
+
+     private:
+      Value _value;
+    };
 
     /**
      * Set the minimum severity level to be passed to the logger. By default, the minimum severity is set to
@@ -106,12 +132,18 @@ namespace ChimeraTK {
 
     // Minimum severity to be sent to the queue. This allows filtering lower severity messages at sender side, even
     // before the message text has been (fully) composed.
-    std::atomic<Severity> _minSeverity{Severity::info};
+    std::atomic<Severity> _minSeverity{defaultSeverityFromEnv()};
 
     // Thread executing mainLoop().
     // Note: The thread must be started only after all other data members have been initialised, so this line must
     // come last (or the thread must be only started in the constructor body).
     boost::thread _mainLoopThread{[this] { mainLoop(); }};
+
+    /**
+     * Return the default severity based on the CHIMERATK_LOG_LEVEL environment variable.
+     * If the env var is not set or invalid, returns Severity::info.
+     */
+    static Severity defaultSeverityFromEnv();
 
     friend class Application;
   };
@@ -126,7 +158,6 @@ namespace ChimeraTK {
   }
 
   /********************************************************************************************************************/
-  /********************************************************************************************************************/
 
   inline Logger& Logger::getInstance() {
     return *getSharedPtr();
@@ -137,6 +168,47 @@ namespace ChimeraTK {
   inline std::shared_ptr<Logger>& Logger::getSharedPtr() {
     static std::shared_ptr<Logger> instance(new Logger());
     return instance;
+  }
+
+  /********************************************************************************************************************/
+  /********************************************************************************************************************/
+
+  constexpr std::string_view Logger::Severity::toString() const {
+    switch(_value) {
+      case trace:
+        return "trace";
+      case debug:
+        return "debug";
+      case info:
+        return "info";
+      case warning:
+        return "warning";
+      case error:
+        return "error";
+    }
+    std::unreachable();
+  }
+
+  /********************************************************************************************************************/
+
+  constexpr std::expected<Logger::Severity, std::string> Logger::Severity::fromString(const std::string& string) {
+    auto stringLower = boost::algorithm::to_lower_copy(std::string(string));
+    if(stringLower == "trace") {
+      return trace;
+    }
+    if(stringLower == "debug") {
+      return debug;
+    }
+    if(stringLower == "info") {
+      return info;
+    }
+    if(stringLower == "warning") {
+      return warning;
+    }
+    if(stringLower == "error") {
+      return error;
+    }
+    return std::unexpected("Valid values are: trace, debug, info, warning, error.");
   }
 
   /********************************************************************************************************************/

--- a/include/TestableMode.h
+++ b/include/TestableMode.h
@@ -77,16 +77,6 @@ namespace ChimeraTK::detail {
     void enable();
 
     /**
-     * Enable noisy debugging output for testable mode
-     */
-    void setEnableDebug(bool enable = true) { _enableDebug = enable; }
-
-    /**
-     * Enable debugging output for decorating the accessor
-     */
-    void setEnableDebugDecorating(bool enable = true) { _debugDecorating = enable; }
-
-    /**
      * Check whether testable mode has been enabled
      */
     [[nodiscard]] bool isEnabled() const { return _enabled; }
@@ -170,11 +160,6 @@ namespace ChimeraTK::detail {
     friend class ChimeraTK::DeviceManager;
     friend class ChimeraTK::TriggerFanOut;
     friend class ChimeraTK::TestFacility;
-
-    /**
-     * Flag if noisy debug output is enabled for the testable mode
-     */
-    bool _enableDebug{false};
 
     /**
      * Semaphore counter used in testable mode to check if application code is finished executing. This value may only
@@ -318,7 +303,6 @@ namespace ChimeraTK::detail {
      */
     pid_t pthreadId(const boost::thread::id& threadId = boost::this_thread::get_id());
 
-    bool _debugDecorating{false};
     friend class ChimeraTK::ConnectionMaker;
   };
 
@@ -335,11 +319,9 @@ namespace ChimeraTK::detail {
       return other;
     }
 
-    if(_debugDecorating) {
-      logger(Logger::Severity::debug, "TestableMode")
-          << "      Decorating pair " << producer.getQualifiedName() << "[" << other.first->getId() << "] -> "
-          << consumer.getQualifiedName() << "[" << other.second->getId() << "]";
-    }
+    logger(Logger::Severity::info, "TestableMode")
+        << "      Decorating pair " << producer.getQualifiedName() << "[" << other.first->getId() << "] -> "
+        << consumer.getQualifiedName() << "[" << other.second->getId() << "]";
 
     // create variable IDs
     size_t varId = detail::TestableMode::getNextVariableId();
@@ -383,11 +365,9 @@ namespace ChimeraTK::detail {
       return other;
     }
 
-    if(_debugDecorating) {
-      logger(Logger::Severity::debug, "TestableMode")
-          << "      Decorating single " << (direction == DecoratorType::READ ? "consumer " : "feeder ") << name << "["
-          << other->getId() << "]";
-    }
+    logger(Logger::Severity::info, "TestableMode")
+        << "      Decorating single " << (direction == DecoratorType::READ ? "consumer " : "feeder ") << name << "["
+        << other->getId() << "]";
 
     if(varId == 0) {
       varId = detail::TestableMode::getNextVariableId();
@@ -499,21 +479,16 @@ namespace ChimeraTK::detail {
       assert(_testableMode._counter > 0);
       --_testableMode._counter;
       --variable.counter;
-      if(_testableMode._enableDebug) {
-        logger(Logger::Severity::debug, "TestableMode")
-            << "TestableModeAccessorDecorator[name='" << this->getName() << "', id=" << _variableIdRead
-            << "]: testableMode.counter decreased, now at value " << _testableMode._counter << " / "
-            << variable.counter;
-      }
+      logger(Logger::Severity::trace, "TestableMode")
+          << "TestableModeAccessorDecorator[name='" << this->getName() << "', id=" << _variableIdRead
+          << "]: testableMode.counter decreased, now at value " << _testableMode._counter << " / " << variable.counter;
     }
     else {
-      if(_testableMode._enableDebug) {
-        logger(Logger::Severity::debug, "TestableMode")
-            << "TestableModeAccessorDecorator[name='" << this->getName() << "', id=" << _variableIdRead
-            << "]: testableMode.counter NOT decreased, was already at value " << _testableMode._counter << " / "
-            << variable.counter << "\n"
-            << variable.name;
-      }
+      logger(Logger::Severity::trace, "TestableMode")
+          << "TestableModeAccessorDecorator[name='" << this->getName() << "', id=" << _variableIdRead
+          << "]: testableMode.counter NOT decreased, was already at value " << _testableMode._counter << " / "
+          << variable.counter << "\n"
+          << variable.name;
     }
   }
 
@@ -557,17 +532,15 @@ namespace ChimeraTK::detail {
       _testableMode._counter--;
     }
 
-    if(_testableMode._enableDebug) {
-      if(!dataLost) {
-        logger(Logger::Severity::debug, "TestableMode")
-            << "TestableModeAccessorDecorator::write[name='" << this->getName() << "', id=" << _variableIdWrite
-            << "]: testableMode.counter increased, now at value " << _testableMode._counter;
-      }
-      else {
-        logger(Logger::Severity::debug, "TestableMode")
-            << "TestableModeAccessorDecorator::write[name='" << this->getName() << "', id=" << _variableIdWrite
-            << "]: testableMode.counter not increased due to lost data";
-      }
+    if(!dataLost) {
+      logger(Logger::Severity::trace, "TestableMode")
+          << "TestableModeAccessorDecorator::write[name='" << this->getName() << "', id=" << _variableIdWrite
+          << "]: testableMode.counter increased, now at value " << _testableMode._counter;
+    }
+    else {
+      logger(Logger::Severity::trace, "TestableMode")
+          << "TestableModeAccessorDecorator::write[name='" << this->getName() << "', id=" << _variableIdWrite
+          << "]: testableMode.counter not increased due to lost data";
     }
     return dataLost;
   }

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -85,9 +85,7 @@ void Application::registerThread(const std::string& name) {
 /**********************************************************************************************************************/
 
 void Application::incrementDataLossCounter(const std::string& name) {
-  if(getInstance()._debugDataLoss) {
-    logger(Logger::Severity::debug, "DataLossCounter") << "Data loss in variable " << name;
-  }
+  logger(Logger::Severity::debug, "DataLossCounter") << "Data loss in variable " << name;
   getInstance()._dataLossCounter++;
 }
 
@@ -113,7 +111,6 @@ void Application::initialise() {
     module->postConstruct();
   }
 
-  _cm.setDebugConnections(_enableDebugMakeConnections);
   _cm.finalise();
 
   _initialiseCalled = true;

--- a/src/ConnectionMaker.cc
+++ b/src/ConnectionMaker.cc
@@ -295,10 +295,6 @@ namespace ChimeraTK {
 
   template<typename... Args>
   void NetworkVisitor::debug(Args&&... args) {
-    if(not _debugConnections) {
-      return;
-    }
-
     // Fold expression printer from https://en.cppreference.com/w/cpp/language/fold
     (logger(Logger::Severity::debug, "ConnectionMaker") << ... << args) << std::endl;
   }
@@ -387,8 +383,6 @@ namespace ChimeraTK {
   void ConnectionMaker::finalise() {
     debug("Calling finalise()...");
 
-    _app.getTestableMode()._debugDecorating = _debugConnections;
-
     debug("Preparing trigger networks");
     debug("Collecting triggers");
 
@@ -437,8 +431,6 @@ namespace ChimeraTK {
 
   void ConnectionMaker::connect() {
     debug("Calling connect()...");
-
-    _app.getTestableMode()._debugDecorating = _debugConnections;
 
     // Improve: Likely no need to distinguish trigger and normal networks here... Also just iterate _networks instead
     // of the model!

--- a/src/Logger.cc
+++ b/src/Logger.cc
@@ -2,9 +2,30 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "Logger.h"
 
+#include <cstdlib>
+#include <format>
 #include <iostream>
 
 namespace ChimeraTK {
+
+  /********************************************************************************************************************/
+
+  Logger::Severity Logger::defaultSeverityFromEnv() {
+    const auto* envValue = std::getenv("CHIMERATK_LOG_LEVEL");
+    if(envValue == nullptr) {
+      return Severity::info;
+    }
+
+    auto severity = Severity::fromString(envValue);
+
+    if(!severity.has_value()) {
+      std::cerr << std::format("Warning: CHIMERATK_LOG_LEVEL has invalid value '{}'. {}. Falling back to default.",
+                       envValue, severity.error())
+                << std::endl;
+    }
+
+    return severity.value_or(Severity::info);
+  }
 
   /********************************************************************************************************************/
 

--- a/src/TestableMode.cc
+++ b/src/TestableMode.cc
@@ -114,11 +114,8 @@ namespace ChimeraTK::detail {
     }
 
     // debug output if enabled (also prevent spamming the same message)
-    if(_enableDebug) {                                                  // LCOV_EXCL_LINE (only cout)
-      logger(Logger::Severity::debug, "TestableMode")                   // LCOV_EXCL_LINE (only cout)
-          << "Application::testableModeLock(): Thread " << threadName() // LCOV_EXCL_LINE (only cout)
-          << " tries to obtain lock for " << name;                      // LCOV_EXCL_LINE (only cout)
-    } // LCOV_EXCL_LINE (only cout)
+    logger(Logger::Severity::trace, "TestableMode")
+        << "Application::testableModeLock(): Thread " << threadName() << " tries to obtain lock for " << name;
 
     // obtain the lock
     boost::thread::id lastSeen_lastOwner = _lastMutexOwner;
@@ -144,11 +141,8 @@ namespace ChimeraTK::detail {
     _lastMutexOwner = boost::this_thread::get_id();
 
     // debug output if enabled
-    if(_enableDebug) {                                       // LCOV_EXCL_LINE (only cout)
-      logger(Logger::Severity::debug, "TestableMode")        // LCOV_EXCL_LINE (only cout)
-          << "TestableMode::lock(): Thread " << threadName() // LCOV_EXCL_LINE (only cout)
-          << " obtained lock successfully for " << name;     // LCOV_EXCL_LINE (only cout)
-    } // LCOV_EXCL_LINE (only cout)
+    logger(Logger::Severity::trace, "TestableMode")
+        << "TestableMode::lock(): Thread " << threadName() << " obtained lock successfully for " << name;
   }
 
   /********************************************************************************************************************/
@@ -157,11 +151,8 @@ namespace ChimeraTK::detail {
     if(not _enabled) {
       return;
     }
-    if(_enableDebug) {                                         // LCOV_EXCL_LINE (only cout)
-      logger(Logger::Severity::debug, "TestableMode")          // LCOV_EXCL_LINE (only cout)
-          << "TestableMode::unlock(): Thread " << threadName() // LCOV_EXCL_LINE (only cout)
-          << " releases lock for " << name;                    // LCOV_EXCL_LINE (only cout)
-    } // LCOV_EXCL_LINE (only cout)
+    logger(Logger::Severity::trace, "TestableMode")
+        << "TestableMode::unlock(): Thread " << threadName() << " releases lock for " << name;
     getLockObject().unlock();
   }
 
@@ -180,10 +171,10 @@ namespace ChimeraTK::detail {
     size_t oldCounter = 0;
     auto t0 = std::chrono::steady_clock::now();
     while(true) {
-      if(_enableDebug && (oldCounter != _counter)) { // LCOV_EXCL_LINE (only cout)
-        logger(Logger::Severity::debug, "TestableMode")
-            << "Application::stepApplication(): testableMode.counter = " << _counter; // LCOV_EXCL_LINE (only cout)
-        oldCounter = _counter;                                                        // LCOV_EXCL_LINE (only cout)
+      if((oldCounter != _counter)) { // LCOV_EXCL_LINE (only logging)
+        logger(Logger::Severity::trace, "TestableMode")
+            << "Application::stepApplication(): testableMode.counter = " << _counter; // LCOV_EXCL_LINE (only logging)
+        oldCounter = _counter;                                                        // LCOV_EXCL_LINE (only logging)
       }
       unlock("stepApplication");
       boost::this_thread::yield();

--- a/tests/executables_src/testAppModuleConnections.cc
+++ b/tests/executables_src/testAppModuleConnections.cc
@@ -441,7 +441,6 @@ namespace Tests::testAppModuleConnections {
     std::cout << "*** testSelfUnregisteringModule" << std::endl;
 
     TestAppSelfUnregisteringModule app;
-    app.debugMakeConnections();
 
     ctk::TestFacility tf{app};
 

--- a/tests/executables_src/testControlSystemAccessors.cc
+++ b/tests/executables_src/testControlSystemAccessors.cc
@@ -77,8 +77,6 @@ namespace Tests::testControlSystemAccessors {
   BOOST_AUTO_TEST_CASE_TEMPLATE(testFeedToCS, T, test_types) {
     TestApplication<T> app;
 
-    app.debugMakeConnections();
-
     auto pvManagers = ctk::createPVManager();
     app.setPVManager(pvManagers.second);
 

--- a/tests/executables_src/testDeviceExceptionFlagPropagation.cc
+++ b/tests/executables_src/testDeviceExceptionFlagPropagation.cc
@@ -145,8 +145,6 @@ namespace Tests::testDeviceExceptionFlagPropagation {
 
     app.getModel().writeGraphViz("testDirectConnectRead.dot");
 
-    app.debugMakeConnections();
-
     ctk::TestFacility test(app);
     test.runApplication();
 

--- a/tests/executables_src/testIllegalNetworks.cc
+++ b/tests/executables_src/testIllegalNetworks.cc
@@ -49,7 +49,6 @@ namespace Tests::testIllegalNetworks {
 
   BOOST_AUTO_TEST_CASE(testTwoScalarPollPushAccessors) {
     TestApplication1 app;
-    app.debugMakeConnections();
 
     BOOST_CHECK_THROW(
         {
@@ -64,7 +63,7 @@ namespace Tests::testIllegalNetworks {
 
   template<typename T>
   struct TestApplication3 : public ctk::Application {
-    TestApplication3() : Application("testSuite") { debugMakeConnections(); }
+    TestApplication3() : Application("testSuite") {}
     ~TestApplication3() override { shutdown(); }
 
     struct : ctk::ApplicationModule {
@@ -94,7 +93,7 @@ namespace Tests::testIllegalNetworks {
   /* test case for too many polling consumers */
 
   struct TestApplication4 : public ctk::Application {
-    TestApplication4() : Application("testSuite") { debugMakeConnections(); }
+    TestApplication4() : Application("testSuite") {}
     ~TestApplication4() override { shutdown(); }
 
     ctk::SetDMapFilePath dmap{"test.dmap"};
@@ -134,7 +133,7 @@ namespace Tests::testIllegalNetworks {
 
   template<typename T>
   struct TestApplication5 : public ctk::Application {
-    TestApplication5() : Application("testSuite") { debugMakeConnections(); }
+    TestApplication5() : Application("testSuite") {}
     ~TestApplication5() override { shutdown(); }
 
     struct : ctk::ApplicationModule {
@@ -164,7 +163,7 @@ namespace Tests::testIllegalNetworks {
 
   template<typename T>
   struct TestApplication6 : public ctk::Application {
-    TestApplication6() : Application("testSuite") { debugMakeConnections(); }
+    TestApplication6() : Application("testSuite") {}
     ~TestApplication6() override { shutdown(); }
 
     struct : ctk::ApplicationModule {

--- a/tests/executables_src/testLogger.cc
+++ b/tests/executables_src/testLogger.cc
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <cstdlib>
+
+#define BOOST_TEST_MODULE testLogger
+
+#include "Logger.h"
+
+#include <boost/test/included/unit_test.hpp>
+
+namespace ctk = ChimeraTK;
+
+/**********************************************************************************************************************/
+
+// Attention! This test must be run first, otherwise setting the environment variable will not have any effect!
+BOOST_AUTO_TEST_CASE(TestEnvVarSetsMinSeverity) {
+  std::cout << "testEnvVarSetsMinSeverity" << std::endl;
+
+  // Set environment variable before creating logger instance
+  setenv("CHIMERATK_LOG_LEVEL", "warning", 1);
+
+  auto& logger = ctk::Logger::getInstance();
+
+  // With CHIMERATK_LOG_LEVEL=warning, the default minimum severity should be warning,
+  // so streams for lower log levels should be bad
+  auto traceStream = logger.getStream(ctk::Logger::Severity::trace, "test");
+  auto debugStream = logger.getStream(ctk::Logger::Severity::debug, "test");
+  auto infoStream = logger.getStream(ctk::Logger::Severity::info, "test");
+  auto warningStream = logger.getStream(ctk::Logger::Severity::warning, "test");
+  auto errorStream = logger.getStream(ctk::Logger::Severity::error, "test");
+
+  BOOST_TEST(!traceStream.good());
+  BOOST_TEST(!debugStream.good());
+  BOOST_TEST(!infoStream.good());
+  BOOST_TEST(warningStream.good());
+  BOOST_TEST(errorStream.good());
+}
+
+/**********************************************************************************************************************/
+
+BOOST_AUTO_TEST_CASE(TestMinSeveritySetPublicly) {
+  std::cout << "testMinSeveritySetPublicly" << std::endl;
+
+  auto& logger = ctk::Logger::getInstance();
+
+  // Set minimum severity to trace, so all streams should be good
+  logger.setMinSeverity(ctk::Logger::Severity::trace);
+
+  auto traceStream = logger.getStream(ctk::Logger::Severity::trace, "test");
+  auto debugStream = logger.getStream(ctk::Logger::Severity::debug, "test");
+  auto infoStream = logger.getStream(ctk::Logger::Severity::info, "test");
+
+  BOOST_TEST(traceStream.good());
+  BOOST_TEST(debugStream.good());
+  BOOST_TEST(infoStream.good());
+
+  // Set minimum severity to error, so only error stream should be good
+  logger.setMinSeverity(ctk::Logger::Severity::error);
+
+  auto errorStream = logger.getStream(ctk::Logger::Severity::error, "test");
+  auto warningStream = logger.getStream(ctk::Logger::Severity::warning, "test");
+
+  BOOST_TEST(errorStream.good());
+  BOOST_TEST(!warningStream.good());
+
+  // Reset to env-default for other tests
+  logger.setMinSeverity(ctk::Logger::Severity::debug);
+}
+
+/**********************************************************************************************************************/
+
+BOOST_AUTO_TEST_CASE(TestStreamOutput) {
+  std::cout << "testStreamOutput" << std::endl;
+
+  auto& logger = ctk::Logger::getInstance();
+
+  // Ensure we can capture output from info-level logs
+  logger.setMinSeverity(ctk::Logger::Severity::info);
+
+  // Send a log message. We cannot easily capture the async output here,
+  // but we can verify the stream is in a good state, meaning the message
+  // will be queued for output.
+  {
+    auto stream = logger.getStream(ctk::Logger::Severity::info, "testContext");
+    BOOST_TEST(stream.good());
+    stream << "test message" << std::endl;
+  }
+
+  // Give the logging thread time to process
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Verify that a debug message is filtered out at sender side when
+  // minimum severity is set to info
+  {
+    auto stream = logger.getStream(ctk::Logger::Severity::debug, "testContext");
+    BOOST_TEST(!stream.good());
+  }
+
+  logger.setMinSeverity(ctk::Logger::Severity::debug);
+}
+
+/**********************************************************************************************************************/

--- a/tests/executables_src/testNoInitialValue.cc
+++ b/tests/executables_src/testNoInitialValue.cc
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(TestNoInitialValueTagChecks) {
   };
 
   struct TagCheckApp : ctk::Application {
-    TagCheckApp() : ctk::Application("tagCheckApp") { ctk::Application::debugMakeConnections(); }
+    TagCheckApp() : ctk::Application("tagCheckApp") {}
     ~TagCheckApp() override { shutdown(); }
     TestModule mod{this, "Module", ""};
   } app;
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(TestNoInitialValueModuleEntersMainLoop) {
   };
 
   struct NoInitApp : ctk::Application {
-    NoInitApp() : ctk::Application("noInitApp") { ctk::Application::debugMakeConnections(); }
+    NoInitApp() : ctk::Application("noInitApp") {}
     ~NoInitApp() override { shutdown(); }
     TestModule mod{this, "Module", ""};
   } app;
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(TestNoInitialValueOnlyEntersWithBrokenDevice) {
   };
 
   struct OnlyNoInitApp : ctk::Application {
-    OnlyNoInitApp() : ctk::Application("onlyNoInitApp") { ctk::Application::debugMakeConnections(); }
+    OnlyNoInitApp() : ctk::Application("onlyNoInitApp") {}
     ~OnlyNoInitApp() override { shutdown(); }
     ctk::DeviceModule devMod{this, "testDevice", "/fakeTrigger"};
     NoInitOnlyModule mod{this, "Module", ""};
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(TestWithOptimiseUnmappedVariables) {
   };
 
   struct OnlyNoInitApp : ctk::Application {
-    OnlyNoInitApp() : ctk::Application("onlyNoInitOptApp") { ctk::Application::debugMakeConnections(); }
+    OnlyNoInitApp() : ctk::Application("onlyNoInitOptApp") {}
     ~OnlyNoInitApp() override { shutdown(); }
     ctk::DeviceModule devMod{this, "testDevice", "/fakeTrigger"};
     NoInitOnlyModule mod{this, "Module", ""};

--- a/tests/executables_src/testPropagateDataFaultFlag.cc
+++ b/tests/executables_src/testPropagateDataFaultFlag.cc
@@ -107,7 +107,6 @@ namespace Tests::testPropagateDataFaultFlag {
   BOOST_AUTO_TEST_CASE(testDirectConnections) {
     std::cout << "testDirectConnections" << std::endl;
     TestApplication1 app;
-    app.debugMakeConnections();
     ctk::TestFacility test(app);
 
     auto i1 = test.getScalar<int>("/t1/i1");

--- a/tests/executables_src/testReverseRecovery.cc
+++ b/tests/executables_src/testReverseRecovery.cc
@@ -37,7 +37,7 @@ struct ExternalMainLoopModule : public ctk::ApplicationModule {
   void mainLoop() final { doMainLoop(); }
 };
 struct TestApplication : ctk::Application {
-  TestApplication() : ctk::Application("tagTestApplication") { debugMakeConnections(); }
+  TestApplication() : ctk::Application("tagTestApplication") {}
   ~TestApplication() override { shutdown(); }
 
   ExternalMainLoopModule mod{this, "Module", ""};

--- a/tests/executables_src/testTestFacilities.cc
+++ b/tests/executables_src/testTestFacilities.cc
@@ -738,8 +738,6 @@ namespace Tests::testTestFacilities {
     // ---------------------
     {
       TestPollingThroughFanOutsApplication app;
-      app.debugMakeConnections();
-      // app.getTestableMode().setEnableDebug();
 
       app.m2.poll1 = {&app.m2, "/m1/out1", "", ""};
       app.m2.poll2 = {&app.m2, "/m1/out1", "", ""};

--- a/tests/include/fixtures.h
+++ b/tests/include/fixtures.h
@@ -90,10 +90,7 @@ struct DummyApplication : ChimeraTK::Application {
   constexpr static const char* ExceptionDummyCDD2 = "(ExceptionDummy:2?map=test_with_push.map)";
   constexpr static const char* ExceptionDummyCDD3 = "(ExceptionDummy:3?map=test_with_push.map)";
 
-  DummyApplication() : Application("DummyApplication") {
-    // enable this for debugging:
-    // debugMakeConnections();
-  }
+  DummyApplication() : Application("DummyApplication") {}
   ~DummyApplication() override { shutdown(); }
 
   struct Group1 : ChimeraTK::ModuleGroup {


### PR DESCRIPTION
Also enable most debugging options always, but with a low log level so they remain silent by default. This allows us to enable debug logging without changing the source code.